### PR TITLE
cli: add --how option to provision command

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -104,9 +104,11 @@ def discover():
 
 
 @run.command()
-def provision():
+@click.option('--how', help="Force 'how' attribute for all provisioning steps.")
+def provision(how):
     """ Provision an environment for testing (or use localhost) """
     tmt.steps.provision.Provision.enabled = True
+    tmt.steps.provision.Provision.how = how
     return 'provision'
 
 


### PR DESCRIPTION
Sets how as class attribute, forcing how method from command-line.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>