### PR TITLE
Vagrant Provider output and provider handling enhancements

### DIFF
--- a/tmt/steps/provision/vagrant.py
+++ b/tmt/steps/provision/vagrant.py
@@ -39,7 +39,8 @@ class ProvisionVagrant(ProvisionBase):
     ## Default API ##
     def __init__(self, data, step):
         """ Initialize the Vagrant provision step """
-        super(ProvisionVagrant, self).__init__(data, step)
+        self.super = super(ProvisionVagrant, self)
+        self.super.__init__(data, step)
         self.vagrantfile = os.path.join(self.provision_dir, 'Vagrantfile')
         self.vf_data = ''
 
@@ -67,18 +68,18 @@ class ProvisionVagrant(ProvisionBase):
         """ Load ProvisionVagrant step """
         #TODO: ensure this loads self.data[*]
         # instancename and regenerates provision_dir and vagrantfile
-        super(ProvisionVagrant, self).load()
+        self.super.load()
 
     def save(self):
         """ Save ProvisionVagrant step """
         #TODO: ensure this saves self.data[*]
         # instancename
-        super(ProvisionVagrant, self).save()
+        self.super.save()
         #TypeError: save() takes 1 positional argument but 2 were given
 
 #    def wake(self):
 #        """ Prepare the Vagrantfile """
-#        super(ProvisionVagrant, self).wake(self)
+#        self.super.wake(self)
 #        # capabilities? providers?
 
     def go(self):
@@ -93,8 +94,8 @@ class ProvisionVagrant(ProvisionBase):
 
     def show(self):
         """ Show execute details """
-        super(ProvisionVagrant, self).show(keys=['how', 'box', 'image'])
-        self.debug('Vagrantfile', self.vf_read())
+        self.super.show(keys=['how', 'box', 'image'])
+        self.info('Vagrantfile', self.vf_read())
 
     def sync_workdir_to_guest(self):
         """ sync on demand """

--- a/tmt/steps/provision/vagrant.py
+++ b/tmt/steps/provision/vagrant.py
@@ -298,20 +298,20 @@ class ProvisionVagrant(ProvisionBase):
             right before last 'end'.
             Prepends with `config_prefix`.
         """
-        vfdata = self.vf_read()
+        vf_tmp = self.vf_read()
 
         # Lookup last 'end' in Vagrantfile
         i = 0
-        for line in reversed(vfdata):
+        for line in reversed(vf_tmp):
             i -= 1
             if (line.find('end') != -1):
                 break
 
-        vfdata = vfdata[:i] \
+        vf_tmp = vf_tmp[:i] \
             + [self.config_prefix + config] \
-            + vfdata[i:]
+            + vf_tmp[i:]
 
-        return self.vf_write(vfdata)
+        return self.vf_write(vf_tmp)
 
     def vf_read(self):
         """ read Vagrantfile
@@ -319,14 +319,18 @@ class ProvisionVagrant(ProvisionBase):
         """
         return open(self.vagrantfile).read().splitlines()
 
-    def vf_write(self, vfdata):
-        if type(vfdata) is list:
-            vfdata = self.eol.join(vfdata)
+    def vf_write(self, vf_tmp):
+        """ write into Vagrantfile
+            str or list
+            runs validate()
+        """
+        if type(vf_tmp) is list:
+            vf_tmp = self.eol.join(vf_tmp)
 
         with open(self.vagrantfile, 'w', newline=self.eol) as f:
-            f.write(vfdata)
+            f.write(vf_tmp)
 
-        self.debug('Vagrantfile', vfdata)
+        self.debug('Vagrantfile', vf_tmp)
         return self.validate()
 
     def vf_backup(self):

--- a/tmt/steps/provision/vagrant.py
+++ b/tmt/steps/provision/vagrant.py
@@ -150,7 +150,7 @@ class ProvisionVagrant(ProvisionBase):
         #csp = self.run_vagrant('status')
         #return self.hr(csp.stdout)
 
-    def cleanup(self):
+    def clean(self):
         """ remove box and base box """
         self.run_vagrant('box', 'remove', '-f', self.data['box'])
         # TODO: libvirt storage removal?

--- a/tmt/steps/provision/vagrant.py
+++ b/tmt/steps/provision/vagrant.py
@@ -194,9 +194,9 @@ class ProvisionVagrant(ProvisionBase):
     def add_how(self):
         target = f"how_{self.data['how']}"
         self.debug(f"Relaying to: {target}")
-        getattr(self, \
-            target, \
-            lambda: 'generic', \
+        getattr(self,
+            target,
+            lambda: 'generic',
             )()
 
     def how_virtual(self):
@@ -380,14 +380,14 @@ class ProvisionVagrant(ProvisionBase):
             emsg = lambda: RuntimeError(f"Message type unknown: {mtype}")
 
             if val:
-                getattr(self.super, \
-                    mtype, \
-                    emsg, \
+                getattr(self.super,
+                    mtype,
+                    emsg,
                     )(key, val, color)
             else:
-                getattr(self.super, \
-                    mtype, \
-                    emsg, \
+                getattr(self.super,
+                    mtype,
+                    emsg,
                     )(key)
 
     def hr(self, val):

--- a/tmt/steps/provision/vagrant.py
+++ b/tmt/steps/provision/vagrant.py
@@ -97,7 +97,23 @@ class ProvisionVagrant(ProvisionBase):
 
     def sync_workdir_from_guest(self):
         """ sync from guest to host """
-        raise SpecificationError('NYI: cannot currently sync from guest.')
+        raise ConvertError('NYI: cannot currently sync from guest.')
+
+    def copy_from_guest(self, target):
+        """ copy file/folder from guest to host's copy dir """
+        beg = f"[[ -d '{target}' ]]"
+        end = 'set -xe; exit 0; '
+
+        isdir = f"{beg} || {end}"
+        isntdir = f"{beg} && {end}"
+
+        target_dir = f'{self.provision_dir}/copy/{target}'
+        self.execute(isdir + self.cmd_mkcp(target_dir, f'{target}/.'))
+
+        target_dir = f'$(dirname "{self.provision_dir}/copy/{target}")'
+        self.execute(isntdir + self.cmd_mkcp(target_dir, target))
+
+        self.sync_workdir_from_guest()
 
     def destroy(self):
         """ remove instance """
@@ -105,7 +121,7 @@ class ProvisionVagrant(ProvisionBase):
 
     def prepare(self, name, path):
         """ add single 'preparator' and run it """
-        raise SpecificationError('NYI: cannot currently add preparators.')
+        raise ConvertError('NYI: cannot currently add preparators.')
         self.add_config('provision', name, 'path')
 
 
@@ -129,7 +145,7 @@ class ProvisionVagrant(ProvisionBase):
 
     def status(self):
         """ Get vagrant's status """
-        raise SpecificationError('NYI: cannot currently return status.')
+        raise ConvertError('NYI: cannot currently return status.')
         # TODO: how to get stdout from self.run?
         #csp = self.run_vagrant('status')
         #return self.hr(csp.stdout)
@@ -219,7 +235,7 @@ class ProvisionVagrant(ProvisionBase):
 
     def how_openstack(self):
         self.debug(f"generating: openstack")
-        raise SpecificationError('NYI: cannot run on openstack.')
+        raise SpecificationError('NYI: cannot currently run on openstack.')
 
     def how_docker(self):
         self.how_container()
@@ -229,7 +245,7 @@ class ProvisionVagrant(ProvisionBase):
 
     def how_container(self):
         self.debug(f"generating: container")
-        raise SpecificationError('NYI: cannot run containers.')
+        raise SpecificationError('NYI: cannot currently run containers.')
 
 
     ## END of API ##
@@ -428,6 +444,11 @@ class ProvisionVagrant(ProvisionBase):
             return thing + (string ,)
         else:
             return thing + ' ' + string
+
+    def cmd_mkcp(self, target_dir, target):
+        target_dir = self.quote(target_dir)
+        target = self.quote(target)
+        return f'mkdir -p {target_dir}; cp -vafr {target} {target_dir}'
 
     def quote(self, string):
         return f'"{string}"'

--- a/tmt/steps/provision/vagrant.py
+++ b/tmt/steps/provision/vagrant.py
@@ -52,8 +52,8 @@ class ProvisionVagrant(ProvisionBase):
         # Check for working Vagrant
         self.run_vagrant('version')
 
-        # Let's check what's actually needed
-        self.how()
+        # Let's check what's needed
+        self.check_how()
 
         # Create a Vagrantfile
         self.create()
@@ -61,8 +61,8 @@ class ProvisionVagrant(ProvisionBase):
         # Add default entries to Vagrantfile
         self.add_defaults()
 
-        # Let's check what's actually needed
-        #self.add_knowhow()
+        # Let's add what's needed
+        self.add_how()
 
     def load(self):
         """ Load ProvisionVagrant step """
@@ -142,12 +142,10 @@ class ProvisionVagrant(ProvisionBase):
 
 
     ## Knowhow ##
-    def how(self):
+    def check_how(self):
         """ Decide what to do when HOW is ...
             does not add anything into Vagrantfile yet
         """
-        self.debug()
-
         self.set_default('how', 'virtual')
         self.set_default('image', self.default_image)
 
@@ -184,8 +182,9 @@ class ProvisionVagrant(ProvisionBase):
         for x in ('how','box','image'):
             self.info(x, self.data[x])
 
+    def add_how(self):
+        pass
         # TODO: Dynamic call [switch] to specific how_*
-        return True
 
     def how_virtual(self):
         pass
@@ -225,8 +224,6 @@ class ProvisionVagrant(ProvisionBase):
             self.add_raw_config("provider 'libvirt' do |libvirt| libvirt.qemu_use_session = true ; end")
         except:
             self.vf_restore()
-
-        return True
 
     def run_vagrant(self, *args):
         """ Run vagrant command and raise an error if it fails


### PR DESCRIPTION
* Better output handling: use `run()`, `debug()` and `info()` from utils.

* Support arbitrary `provider` = 'how' (generic, not tested).

* Use Switching methods for various providers.

& Other cosmetic changes.