### PR TITLE
provision/libvirt: debug messages need string

### DIFF
--- a/tmt/steps/provision/vagrant.py
+++ b/tmt/steps/provision/vagrant.py
@@ -225,7 +225,7 @@ class ProvisionVagrant(ProvisionBase):
         try:
             self.add_provider('libvirt', 'qemu_use_session = true')
         except GeneralError as error:
-            self.debug(error)
+            self.debug(str(error))
             self.vf_restore()
 
     def how_openstack(self):


### PR DESCRIPTION
Otherwise this would blow up in an exception on <F29.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>