### PR TITLE
Add an argument to ProvisionBase.copy_from_guest

### DIFF
--- a/tmt/steps/provision/base.py
+++ b/tmt/steps/provision/base.py
@@ -25,7 +25,7 @@ class ProvisionBase(tmt.utils.Common):
         """ sync self.plan.workdir from guest to host """
         pass
 
-    def copy_from_guest(self):
+    def copy_from_guest(self, target):
         """ copy on guest to workdir and sync_workdir_from_guest
 
             arg: "/var/log/journal.log"


### PR DESCRIPTION
I've noticed that the docstring mentions an argument,
and a Vagrant backend also uses one.