### PR TITLE
tmt/utils: add support for changing logging for run method

### DIFF
--- a/tests/unit/steps/test_provision.py
+++ b/tests/unit/steps/test_provision.py
@@ -68,7 +68,7 @@ def test_localhost_prepare_ansible():
         provision.prepare('ansible', 'playbook.yml')
         playbook = os.path.join(plan.run.tree.root, 'playbook.yml')
         run.assert_called_once_with(
-            f'ansible-playbook -vb -c local -i localhost, {playbook}')
+            f'ansible-playbook -vb -c local -i localhost, {playbook}', log=provision.guests[0].verbose)
 
 
 def test_localhost_prepare_shell():

--- a/tmt/steps/provision/localhost.py
+++ b/tmt/steps/provision/localhost.py
@@ -2,7 +2,7 @@ import os
 
 from click import echo
 from tmt.steps.provision.base import ProvisionBase
-from tmt.utils import SpecificationError
+from tmt.utils import GeneralError, SpecificationError
 
 
 class ProvisionLocalhost(ProvisionBase):
@@ -23,7 +23,7 @@ class ProvisionLocalhost(ProvisionBase):
         # Playbook paths should be relative to the metadata tree root
         playbook = os.path.join(self.step.plan.run.tree.root, what)
         # Run ansible against localhost, in verbose mode, enable --become
-        self.run(f'ansible-playbook -vb -c local -i localhost, {playbook}')
+        self.run(f'ansible-playbook -vb -c local -i localhost, {playbook}', log=self.verbose)
 
     def _prepare_shell(self, what):
         """ Run ansible on localhost """


### PR DESCRIPTION
Can come handy if you want to display run command output under different log level.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>