### PR TITLE
packages.yml: add tmt with copr repo

### DIFF
--- a/plans/packages.yml
+++ b/plans/packages.yml
@@ -1,6 +1,6 @@
 - hosts: all
   tasks:
-  - name: Install tmt rpeository
+  - name: Install tmt repository
     yum_repository:
       name: tmt
       description: tmt repo

--- a/plans/packages.yml
+++ b/plans/packages.yml
@@ -1,6 +1,13 @@
 - hosts: all
   tasks:
+  - name: Install tmt rpeository
+    yum_repository:
+      name: tmt
+      description: tmt repo
+      baseurl: https://copr-be.cloud.fedoraproject.org/results/psss/tmt/fedora-$releasever-$basearch/
   - name: Install necessary dependencies
     dnf:
       state: present
-      name: fmf
+      name:
+       - fmf
+       - tmt


### PR DESCRIPTION
This change is needed to run tmt tests via libvirt.