### PR TITLE
tests/unit/test_cli.py: use localhost provisioner

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -84,7 +84,9 @@ def test_step():
     for step in tmt.steps.STEPS:
         if step == 'provision':
             continue
-        result = runner.invoke(tmt.cli.main, ['--root', MINI, 'run', step])
+        result = runner.invoke(tmt.cli.main, [
+            '--root', MINI, 'run', '--all', 'provision', '--how=local', step
+        ])
         assert result.exit_code == 0
         assert step in result.output
         assert 'Provision' not in result.output


### PR DESCRIPTION
Fix the tests to use localhost provisioner. By default
we now have vagrant which already provides prepare step
and fails (obviously) if run just with prepare step.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>