### PR TITLE
Depend on git-core and not the full git package

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -26,7 +26,7 @@ Source0: https://github.com/psss/tmt/releases/download/%{version}/tmt-%{version}
 
 # Main tmt package requires the Python module
 Requires: python%{python3_pkgversion}-%{name} == %{version}-%{release}
-Requires: git
+Requires: git-core
 
 %description
 The tmt Python module and command line tool implement the test


### PR DESCRIPTION
The full `git` package seems to be an overkill for our usage. This shaves around ~100M of disk space usage from the target machine for me.