### PR TITLE
Put quotes in `pip install .[*]` in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,9 +218,9 @@ Install ``python3-virtualenvwrapper`` to easily create and enable
 virtual environments using ``mkvirtualenv`` and ``workon``. You
 can also easily install optional dependencies in this way::
 
-    pip install .[docs]
-    pip install .[tests]
-    pip install .[all]
+    pip install '.[docs]'
+    pip install '.[tests]'
+    pip install '.[all]'
 
 
 Links


### PR DESCRIPTION
as not having them results in interpretation for ZSH f.e..