### PR TITLE
Fix Execute errors handling 

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -92,6 +92,20 @@ def test_step():
         assert step in result.output
         assert 'execute' not in result.output
 
+def test_step_execute():
+    """ Test execute step"""
+    step = 'execute'
+
+    result = runner.invoke(
+        tmt.cli.main, ['--root', example('local'), 'run', step])
+
+    # Test execute empty with discover output missing
+    assert result.exit_code == 1
+    assert 'Could not find TESTS file' in result.output
+
+    assert step in result.output
+    assert 'provision' not in result.output
+
 def test_systemd():
     """ Check systemd example """
     result = runner.invoke(

--- a/tmt/steps/execute/run.sh
+++ b/tmt/steps/execute/run.sh
@@ -269,6 +269,7 @@ shift
 
 cd "$tmt_WD" || tmt_ abort "Failed to cd: $tmt_WD"
 [[ -r "$tmt_TESTS_F" ]] || tmt_abort "Could not find TESTS file: $tmt_TESTS_F"
+[[ `wc -l "$tmt_TESTS_F" | cut -d' ' -f1` -gt 1 ]] || tmt_abort "Missing tests. (`cat "$tmt_TESTS_F"`)"
 
 tmt_TESTS_D="$(readlink -f "${tmt_WD}/${tmt_TESTS_D}")"
 [[ -d "$tmt_TESTS_D" ]] || tmt_abort "Could not find Discover dir: $tmt_TESTS_D"


### PR DESCRIPTION
Add dummy tests for discover and execute steps.
Fail in run.sh if there are Missing tests.

Fix log and fatal error handling in execute.
   - remove logs prior to writing into them
   - output logs and raise an error on fatal failure