### PR TITLE
Use shell=True as a default in utils' run()

### DIFF
--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -130,11 +130,11 @@ class Common(object):
         if self.opt('debug'):
             echo(self._indent(key, value, color, shift))
 
-    def _run(self, command, cwd):
+    def _run(self, command, cwd, shell):
         """ Run command, capture the output """
         # Create the process
         process = subprocess.Popen(
-            command, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            command, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell)
         descriptors = [process.stdout.fileno(), process.stderr.fileno()]
         stdout = ''
         stderr = ''
@@ -170,10 +170,10 @@ class Common(object):
         # Handle the exit code, return output
         if process.returncode != 0:
             raise subprocess.CalledProcessError(
-                process.returncode, ' '.join(command))
+                process.returncode, ' '.join(command) if isinstance(command, list) else command)
         return stdout, stderr
 
-    def run(self, command, message=None, cwd=None, dry=False):
+    def run(self, command, message=None, cwd=None, dry=False, shell=True):
         """
         Run command, give message, handle errors
 
@@ -193,10 +193,8 @@ class Common(object):
             return None, None
 
         # Prepare command, run it, handle the exit code
-        if isinstance(command, str):
-            command = shlex.split(command)
         try:
-            return self._run(command, cwd=cwd or self.workdir)
+            return self._run(command, cwd=cwd or self.workdir, shell=shell)
         except (OSError, subprocess.CalledProcessError) as error:
             raise GeneralError(f"{message}\n{error}")
 


### PR DESCRIPTION
as the capability is needed for running scriplets (used by Prepare)
and vagrant facilitates this behaviour as it passes all commands via ssh.

_ _ _ _

This will result in same behaviour for all Providers.