### PR TITLE
Disable /plan/helps for running in cruncher

### DIFF
--- a/plans/helps.fmf
+++ b/plans/helps.fmf
@@ -17,3 +17,6 @@ prepare:
     script: dnf copr enable -y psss/tmt && dnf install -y tmt
 execute:
     how: shell
+artifact:
+    - build
+    - update


### PR DESCRIPTION
Let's try the new filtering capability of cruncher.