### PR TITLE
Add the 'requires' attribute into the L1 Metadata

### DIFF
--- a/spec/tests/require.fmf
+++ b/spec/tests/require.fmf
@@ -1,0 +1,29 @@
+summary: Packages required for the test execution
+
+story:
+    As a tester I want to specify packages which are required by
+    the test and need to be installed on the system so that the
+    test can be successfully executed.
+
+description: |
+    In order to execute the test, additional packages may need to
+    be installed on the system. For example `gcc` and `make` are
+    needed to compile tests written in C on the target machine. If
+    the package cannot be installed test execution should result
+    in an ``error``.
+
+    For tests shared across multiple components or product
+    versions where required packages have different names it is
+    recommended to use the ``prepare`` step configuration (L2
+    metadata) to specify required packages for each component or
+    product version individually.
+
+    Should be a ``list of strings`` using package specification
+    supported by ``dnf`` which takes care of the installation.
+
+example: |
+    require: [gcc, make]
+
+    require:
+        - gcc
+        - make


### PR DESCRIPTION
After several discussions it seems we will need the 'requires'
attribute available in the L1 Metadata as well. The proposal is to
use it for additional packages needed for test execution but not
for the system under test which should be covered by L2 Metadata.