### PR TITLE
Add different summaries for sub-packages

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -37,7 +37,7 @@ This package contains the command line tool.
 
 
 %package -n     python%{python3_pkgversion}-%{name}
-Summary:        %{summary}
+Summary:        Python library for the %{summary}
 BuildRequires: python%{python3_pkgversion}-devel
 BuildRequires: python%{python3_pkgversion}-setuptools
 BuildRequires: python%{python3_pkgversion}-pytest
@@ -56,7 +56,7 @@ This package contains the Python 3 module.
 
 
 %package all
-Summary: %{summary}
+Summary: %{summary} extra dependencies
 Requires: tmt == %{version}-%{release}
 Requires: vagrant vagrant-libvirt python3-nitrate
 


### PR DESCRIPTION
The RPM sub-packages should use different, more descriptive summaries, otherwise it is not possible to tell from the RPM list, what sub-packages I need:

```
[root@hhorak-t470 mysql-container]# dnf search  tmt
Last metadata expiration check: 2:26:19 ago on Mon 03 Feb 2020 03:24:15 PM CET.
=============================== Name Exactly Matched: tmt ================================
tmt.noarch : Test Management Tool
tmt.src : Test Management Tool
=================================== Name Matched: tmt ====================================
tmt-all.noarch : Test Management Tool
python3-tmt.noarch : Test Management Tool
```