### PR TITLE
Update the test case relevancy specification

### DIFF
--- a/spec/tests/relevancy.fmf
+++ b/spec/tests/relevancy.fmf
@@ -6,7 +6,7 @@ story:
     As a tester I want to skip execution of a particular test case
     in given test environment.
 
-description: >
+description: |
     Sometimes a test case is only relevant for specific
     environment.  Test Case Relevancy allows to filter irrelevant
     test cases out.
@@ -14,12 +14,21 @@ description: >
     Environment is defined by one or more environment dimensions
     such as product, distro, collection, variant, arch, component.
     Relevancy consists of a set of rules of the form ``condition:
-    decision``. Should be a ``list``.
+    decision``. The first matching rule wins. See the `Test Case
+    Relevancy`__ definition for details about the concept.
+
+    Should be a ``list`` of rules or a ``string`` with
+    one rule per line.
+
+    __ https://docs.fedoraproject.org/en-US/ci/test-case-relevancy/
 
 example: |
     relevancy:
-       - "distro < f-28: False"
+       - "distro < fedora-28: False"
        - "distro = rhel-7 & arch = ppc64: False"
+    relevancy: |
+       distro < fedora-28: False
+       distro = rhel-7 & arch = ppc64: False
 
 links:
     - https://docs.fedoraproject.org/en-US/ci/test-case-relevancy/


### PR DESCRIPTION
Explicitly mention that string with one rule per line is also
supported (this is what `tmt test convert` current does), plus
use a long name for fedora distro to make it more readable. We
could support both short and long names in the implementation.