### PR TITLE
Add podman provisioner

### DIFF
--- a/plans/container.fmf
+++ b/plans/container.fmf
@@ -1,0 +1,14 @@
+summary:
+    Simple test for container provisioner
+artifact:
+    - build
+    - update
+provision:
+    how: container
+    image: fedora:latest
+prepare:
+    how: ansible
+    playbooks:
+        - ansible/packages.yml
+execute:
+    script: tmt --help

--- a/tmt.spec
+++ b/tmt.spec
@@ -60,8 +60,8 @@ Requires: tmt == %{version}-%{release}
 Requires: ansible podman
 
 %description container
-All dependencies of the Test Management Tool required to run tests in a
-container environment.
+All dependencies of the Test Management Tool required to run tests
+in a container environment.
 
 %package all
 Summary: Extra dependencies for the Test Management Tool
@@ -119,6 +119,10 @@ export LANG=en_US.utf-8
 %files -n python%{python3_pkgversion}-%{name}
 %{python3_sitelib}/%{name}/
 %{python3_sitelib}/%{name}-*.egg-info/
+%license LICENSE
+
+
+%files container
 %license LICENSE
 
 

--- a/tmt.spec
+++ b/tmt.spec
@@ -54,6 +54,14 @@ The tmt Python module and command line tool implement the test
 metadata specification (L1 and L2) and allows easy test execution.
 This package contains the Python 3 module.
 
+%package container
+Summary: Container provisioner for the Test Management Tool
+Requires: tmt == %{version}-%{release}
+Requires: ansible podman
+
+%description container
+All dependencies of the Test Management Tool required to run tests in a
+container environment.
 
 %package all
 Summary: Extra dependencies for the Test Management Tool

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -205,7 +205,7 @@ def discover(context, **kwargs):
     help='Use specified method for provisioning.')
 @click.option(
     '-i', '--image', metavar='IMAGE',
-    help='Select virtual machine image to use (URI or Box name).')
+    help='Select image to use. Possible valued depdend on the method.')
 @click.option(
     '-b', '--box', metavar='BOX',
     help='Vagrant box name to use.')
@@ -226,7 +226,11 @@ def discover(context, **kwargs):
     help='Private key to use for login into guest system.')
 @click.option(
     '-g', '--guest', metavar='GUEST',
-    help='Select remote host to connect to (how: connect)')
+    help='Select remote host to connect to (how: connect).')
+@click.option(
+    '--pull', is_flag=True,
+    help='Force pulling container image (how: container).')
+
 @verbose_debug_quiet
 @force_dry
 def provision(context, **kwargs):

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -205,7 +205,7 @@ def discover(context, **kwargs):
     help='Use specified method for provisioning.')
 @click.option(
     '-i', '--image', metavar='IMAGE',
-    help='Select image to use. Possible valued depdend on the method.')
+    help='Select image to use. Possible values depend on the method.')
 @click.option(
     '-b', '--box', metavar='BOX',
     help='Vagrant box name to use.')
@@ -228,7 +228,7 @@ def discover(context, **kwargs):
     '-g', '--guest', metavar='GUEST',
     help='Select remote host to connect to (how: connect).')
 @click.option(
-    '--pull', is_flag=True,
+    '--container-pull', is_flag=True,
     help='Force pulling container image (how: container).')
 
 @verbose_debug_quiet

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -8,7 +8,7 @@ import os
 from click import echo
 
 from tmt.utils import SpecificationError
-from tmt.steps.provision import vagrant, localhost
+from tmt.steps.provision import vagrant, localhost, podman
 
 
 class Provision(tmt.steps.Step):
@@ -21,7 +21,9 @@ class Provision(tmt.steps.Step):
         'libvirt': vagrant.ProvisionVagrant,
         'virtual': vagrant.ProvisionVagrant,
         'local': localhost.ProvisionLocalhost,
-        'localhost': localhost.ProvisionLocalhost
+        'localhost': localhost.ProvisionLocalhost,
+        'container': podman.ProvisionPodman,
+        'podman': podman.ProvisionPodman,
     }
 
     # Default implementation for provision is a virtual machine

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -75,7 +75,7 @@ class ProvisionPodman(ProvisionBase):
         """ Run ansible on localhost """
         # Set current working directory to the test metadata root
         self.info('preparing shell')
-        self.podman(what, cwd=self.step.plan.run.tree.root)
+        self.execute(what, cwd=self.step.plan.run.tree.root)
 
     def prepare(self, how, what):
         """ Run prepare phase """

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -16,16 +16,16 @@ class ProvisionPodman(ProvisionBase):
             'shell': self._prepare_shell,
         }
 
-        # get image from provision options
+        # Get image from provision options
         self.image = self.option('image')
-        self.pull = self.option('pull')
+        self.pull = self.option('container_pull')
 
         self.image_id = self.podman(
             f'images -q {self.image}',
             message=f'check for image {self.image}'
         )
 
-        # pull image if not available or pull forced
+        # Pull image if not available or pull forced
         if not self.image_id or self.pull:
             self.image_id = self.podman(
                 f'pull -q {self.image}',
@@ -36,8 +36,8 @@ class ProvisionPodman(ProvisionBase):
         return self.run(f'podman {command}', **kwargs)[0].rstrip()
 
     def option(self, key):
-        """ Return option specified on commandline """
-        # consider command line as priority
+        """ Return option specified on command line """
+        # Consider command line as priority
         if self.opt(key):
             return self.opt(key)
 
@@ -46,33 +46,37 @@ class ProvisionPodman(ProvisionBase):
     def go(self):
         super(ProvisionPodman, self).go()
 
-        # show which image we are using
-        self.info('image', '{}{}'.format(self.image, '(force pull)' if self.pull else ''), 'green')
+        # Show which image we are using
+        self.info('image', '{}{}'.format(
+            self.image, '(force pull)' if self.pull else ''), 'green')
 
-        # deduce container name from run id, as it can be a path, make it podman container name friendly
+        # Deduce container name from run id, as it can be a path,
+        # make it podman container name friendly
         tmt_workdir = self.step.plan.workdir
-        self.container_name = 'tft-' + tmt_workdir.replace('/', '-')
+        self.container_name = 'tmt-' + tmt_workdir.replace('/', '-')
 
-        # run the container
+        # Run the container
         self.container_id = self.podman(
-            f'run --name {self.container_name} -v {tmt_workdir}:{tmt_workdir}:Z -itd {self.image}',
-            message=f'running container {self.image}'
-        )
-        
+            f'run --name {self.container_name} '
+            f'-v {tmt_workdir}:{tmt_workdir}:Z -itd {self.image}',
+            message=f'running container {self.image}')
+
     def execute(self, *args, **kwargs):
         self.info('args', self.join(args), 'red')
         self.podman(f'exec {self.container_id} {self.join(args)}')
 
     def _prepare_ansible(self, what):
-        """ Run ansible on localhost """
+        """ Prepare using ansible """
         # Playbook paths should be relative to the metadata tree root
         playbook = os.path.join(self.step.plan.run.tree.root, what)
         # Run ansible playbook against localhost, in verbose mode
         # Set collumns to 80 characters
-        self.run(f'stty cols 80; podman unshare ansible-playbook -vvv -c podman -i {self.container_id}, {playbook}')
+        self.run(
+            f'stty cols 80; podman unshare ansible-playbook '
+            f'-v -c podman -i {self.container_id}, {playbook}')
 
     def _prepare_shell(self, what):
-        """ Run ansible on localhost """
+        """ Prepare using shell """
         # Set current working directory to the test metadata root
         self.info('preparing shell')
         self.execute(what, cwd=self.step.plan.run.tree.root)

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -1,0 +1,86 @@
+import os
+
+from click import echo
+from tmt.steps.provision.base import ProvisionBase
+from tmt.utils import SpecificationError
+
+
+class ProvisionPodman(ProvisionBase):
+    """ Podman Provisioner """
+
+    def __init__(self, data, step):
+        super(ProvisionPodman, self).__init__(data, step)
+
+        self._prepare_map = {
+            'ansible': self._prepare_ansible,
+            'shell': self._prepare_shell,
+        }
+
+        # get image from provision options
+        self.image = self.option('image')
+        self.pull = self.option('pull')
+
+        self.image_id = self.podman(
+            f'images -q {self.image}',
+            message=f'check for image {self.image}'
+        )
+
+        # pull image if not available or pull forced
+        if not self.image_id or self.pull:
+            self.image_id = self.podman(
+                f'pull -q {self.image}',
+                message=f'pull image {self.image}'
+            )
+
+    def podman(self, command, **kwargs):
+        return self.run(f'podman {command}', **kwargs)[0].rstrip()
+
+    def option(self, key):
+        """ Return option specified on commandline """
+        # consider command line as priority
+        if self.opt(key):
+            return self.opt(key)
+
+        return self.data.get(key, None)
+
+    def go(self):
+        super(ProvisionPodman, self).go()
+
+        # show which image we are using
+        self.info('image', '{}{}'.format(self.image, '(force pull)' if self.pull else ''), 'green')
+
+        # deduce container name from run id, as it can be a path, make it podman container name friendly
+        tmt_workdir = self.step.plan.workdir
+        self.container_name = 'tft-' + tmt_workdir.replace('/', '-')
+
+        # run the container
+        self.container_id = self.podman(
+            f'run --name {self.container_name} -v {tmt_workdir}:{tmt_workdir}:Z -itd {self.image}',
+            message=f'running container {self.image}'
+        )
+        
+    def execute(self, *args, **kwargs):
+        self.info('args', self.join(args), 'red')
+        self.podman(f'exec {self.container_id} {self.join(args)}')
+
+    def _prepare_ansible(self, what):
+        """ Run ansible on localhost """
+        # Playbook paths should be relative to the metadata tree root
+        playbook = os.path.join(self.step.plan.run.tree.root, what)
+        # Run ansible playbook against localhost, in verbose mode
+        # Set collumns to 80 characters
+        self.run(f'stty cols 80; podman unshare ansible-playbook -vvv -c podman -i {self.container_id}, {playbook}')
+
+    def _prepare_shell(self, what):
+        """ Run ansible on localhost """
+        # Set current working directory to the test metadata root
+        self.info('preparing shell')
+        self.podman(what, cwd=self.step.plan.run.tree.root)
+
+    def prepare(self, how, what):
+        """ Run prepare phase """
+        try:
+            self._prepare_map[how](what)
+        except AttributeError as e:
+            raise SpecificationError(
+                f"Prepare method '{how}' is not supported.")


### PR DESCRIPTION
This patch adds podman provisioner which for now also provides 'how: container'.

Along comes a test for it:

    tmt run plan --name container

Also add a new subpackage tmt-container to install this provisioner
dependencies.

TODO:
- [ ] discuss and fix container cleanup, now all containers stay up and running ....
- [ ] add test for shell executor

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>