### PR TITLE
Make it possible to pass script on cmdline

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -263,6 +263,9 @@ def prepare(context, **kwargs):
 @click.option(
     '-h', '--how', metavar='METHOD',
     help='Use specified method for test execution.')
+@click.option(
+    '-s', '--script', metavar='SCRIPT', multiple=True,
+    help='Script to execute.')
 @verbose_debug_quiet
 @force_dry
 def execute(context, **kwargs):

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -27,7 +27,8 @@ class Discover(tmt.steps.Step):
         """ Wake up the step (process workdir and command line) """
         super(Discover, self).wake()
         # Check execute step for possible shell scripts
-        scripts = self.plan.execute.data[0].get('script')
+        scripts = self.plan.execute.opt(
+            'script', self.plan.execute.data[0].get('script'))
         if scripts:
             if isinstance(scripts, str):
                 scripts = [scripts]


### PR DESCRIPTION
This is required for generic tests.

tmt run -a execute --script ... --script ...

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>