### PR TITLE
Fail nicely if executed without provision

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -66,7 +66,7 @@ class Execute(tmt.steps.Step):
             self.executor.go(self.plan.workdir)
         except tmt.utils.GeneralError as error:
             self.get_logs(lognames)
-            raise tmt.utils.GeneralError("Test execution failed.")
+            raise tmt.utils.GeneralError(f'Test execution failed: {error}')
 
         output = self.get_logs(lognames)
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -2,7 +2,7 @@ import os
 
 from click import echo
 from tmt.steps.provision.base import ProvisionBase
-from tmt.utils import SpecificationError
+from tmt.utils import GeneralError, SpecificationError
 
 
 class ProvisionPodman(ProvisionBase):
@@ -19,6 +19,10 @@ class ProvisionPodman(ProvisionBase):
         # Get image from provision options
         self.image = self.option('image')
         self.pull = self.option('container_pull')
+
+        # Instances variables initialized later
+        self.container_name = None
+        self.container_id = None
 
     def podman(self, command, **kwargs):
         return self.run(f'podman {command}', **kwargs)[0].rstrip()
@@ -61,6 +65,10 @@ class ProvisionPodman(ProvisionBase):
             message=f'running container {self.image}')
 
     def execute(self, *args, **kwargs):
+        if not self.container_name:
+            raise GeneralError(
+                'Could not execute without provisioned container')
+
         self.info('args', self.join(args), 'red')
         self.podman(f'exec {self.container_name} {self.join(args)}')
 


### PR DESCRIPTION
$ tmt run execute plan --name /plans/container
ERROR  Test execution failed: Could not execute without provisioned container

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>