### PR TITLE
Remove copr build job from packit (not necessary)

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,12 +13,6 @@ actions:
   - make packit-path
 
 jobs:
-- job: copr_build
-  trigger: pull_request
-  metadata:
-    targets:
-      - fedora-all
-
 - job: tests
   trigger: pull_request
   metadata:


### PR DESCRIPTION
Make the test results review easier (less lines, same benefit).