### PR TITLE
Add --env option and support in podman provisioner

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -175,14 +175,25 @@ def main(context, root, **kwargs):
     '-i', '--id', 'id_', help='Run id (name or directory path).', metavar="ID")
 @click.option(
     '-a', '--all', 'all_', help='Run all steps, customize some.', is_flag=True)
+@click.option(
+    '-e', '--environment',
+    help='Set environment variable. Can be specified multiple times.',
+    metavar='KEY=VALUE',
+    multiple='True'
+)
 @verbose_debug_quiet
 @force_dry
-def run(context, all_, id_, **kwargs):
+def run(context, all_, id_, environment, **kwargs):
     """ Run test steps. """
     # Initialize
     tmt.Run._save_context(context)
     run = tmt.Run(id_, context.obj.tree)
     context.obj.run = run
+
+    for env in environment:
+        if '=' not in env:
+            raise tmt.utils.GeneralError(
+                f"Invalid environment variable specification '{env}'.")
 
 main.add_command(run)
 

--- a/tmt/steps/provision/base.py
+++ b/tmt/steps/provision/base.py
@@ -17,10 +17,6 @@ class ProvisionBase(tmt.utils.Common):
         self.provision_dir = os.path.join(step.workdir, self.instance_name)
         os.mkdir(self.provision_dir)
 
-    def execute(self, command):
-        """ executes one command in a guest """
-        pass
-
     def sync_workdir_to_guest(self):
         """ sync self.plan.workdir from host to guests """
         pass

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -1,6 +1,5 @@
 import os
 
-from click import echo
 from tmt.steps.provision.base import ProvisionBase
 from tmt.utils import GeneralError, SpecificationError
 
@@ -24,8 +23,14 @@ class ProvisionPodman(ProvisionBase):
         self.container_name = None
         self.container_id = None
 
+        # Environment variables compatible with commands used
+        self.podman_env = [f'-e {env}' for env in self.opt('environment')]
+        self.shell_env = ' '.join(self.opt('environment'))
+
     def podman(self, command, **kwargs):
-        return self.run(f'podman {command}', **kwargs)[0].rstrip()
+        """ Run given command via podman """
+        return self.run(
+            ['podman'] + command, shell=False, **kwargs)[0].rstrip()
 
     def option(self, key):
         """ Return option specified on command line """
@@ -43,43 +48,47 @@ class ProvisionPodman(ProvisionBase):
             self.image, ' (force pull)' if self.pull else ''), 'green')
 
         # Check if the image is available
-        self.image_id = self.podman(
-            f'images -q {self.image}',
+        image_id = self.podman(
+            ['images', '-q', self.image],
             message=f'check for image {self.image}')
 
         # Pull image if not available or pull forced
-        if not self.image_id or self.pull:
-            self.image_id = self.podman(
-                f'pull -q {self.image}',
-                message=f'pull image {self.image}')
+        if not image_id or self.pull:
+            self.podman(
+                ['pull', '-q', self.image], message=f'pull image {self.image}')
 
         # Deduce container name from run id, as it can be a path,
         # make it podman container name friendly
         tmt_workdir = self.step.plan.workdir
         self.container_name = 'tmt' + tmt_workdir.replace('/', '-')
 
-        # Run the container
-        self.container_id = self.podman(
-            f'run --name {self.container_name} '
-            f'-v {tmt_workdir}:{tmt_workdir}:Z -itd {self.image}',
-            message=f'running container {self.image}')
+        # Run the container, add environment variables
+        self.container_id = self.podman(['run'] + self.podman_env + [
+            '--name', self.container_name,
+            '-v', f'{tmt_workdir}:{tmt_workdir}:Z', '-itd', self.image
+        ], message=f'running container {self.image}')
 
     def execute(self, *args, **kwargs):
+        """ Execute given commands in podman via shell """
         if not self.container_name:
             raise GeneralError(
                 'Could not execute without provisioned container')
 
-        self.info('args', self.join(args), 'red')
-        self.podman(f'exec {self.container_name} {self.join(args)}')
+        # Note that we MUST run commands via bash, so variables
+        # work as expected
+        self.podman(['exec'] + self.podman_env + [
+            self.container_name, 'sh', '-c', self.join(args)
+        ], **kwargs)
 
     def _prepare_ansible(self, what):
         """ Prepare using ansible """
         # Playbook paths should be relative to the metadata tree root
         playbook = os.path.join(self.step.plan.run.tree.root, what)
+
         # Run ansible playbook against localhost, in verbose mode
-        # Set collumns to 80 characters
+        # Set columns to 80 characters so it looks the same as with vagrant
         self.run(
-            f'stty cols 80; podman unshare ansible-playbook '
+            f'stty cols 80; {self.shell_env} podman unshare ansible-playbook '
             f'-v -c podman -i {self.container_name}, {playbook}')
 
     def _prepare_shell(self, what):
@@ -92,7 +101,7 @@ class ProvisionPodman(ProvisionBase):
         """ Run prepare phase """
         try:
             self._prepare_map[how](what)
-        except AttributeError as e:
+        except AttributeError:
             raise SpecificationError(
                 f"Prepare method '{how}' is not supported.")
 


### PR DESCRIPTION
This is the first patch which introduces specifying environment
variables on command line which get forwarded to tmt's plugins.

Patches to other provisioners will come later.

What is this good for?
It makes it possible to write generic plan definitions with variables:

```
provision:
    how: continer
    image: fedora:latest
discover:
    how: shell
    tests:
        - name: install
          test: echo install test for $TASK_ID
        - name: upgrade
          test: echo upgrade test for $TASK_ID
        - name: downgrade
          test: echo downgrade test for $TASK_ID
        - name: remove
          test: echo remove tet for $TASK_ID
execute:
    how: shell
```

You can test with:

```
tmt run -e TASK_ID=111111
```

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>