### PR TITLE
Add environment specification

### DIFF
--- a/spec/plans/environment.fmf
+++ b/spec/plans/environment.fmf
@@ -12,4 +12,4 @@ example: |
             RELEASE: f33
         execute:
             script:
-                - echo "Testing $KOJI_TASK_ID on relase $RELEASE"
+                - echo "Testing $KOJI_TASK_ID on release $RELEASE"

--- a/spec/plans/environment.fmf
+++ b/spec/plans/environment.fmf
@@ -1,0 +1,15 @@
+summary: Environment variables
+
+description:
+    Specifies environment variables available in all steps. Plugins
+    need to include these environment variables while running
+    commands or other programs.
+
+example: |
+    /plan:
+        environment:
+            KOJI_TASK_ID: 42890031
+            RELEASE: f33
+        execute:
+            script:
+                - echo "Testing $KOJI_TASK_ID on relase $RELEASE"


### PR DESCRIPTION
I believe it would be best if we could specify the environment on the
top level of the plan, next to summary and steps.

Environment then would be then available in all steps ...

Resolves #85

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>