### PR TITLE
Add environment support to the discover step

### DIFF
--- a/tests/env/main.fmf
+++ b/tests/env/main.fmf
@@ -1,0 +1,4 @@
+summary: Check environment variables handling
+tier: 2
+environment:
+    TESTING: WORKS

--- a/tests/env/test.sh
+++ b/tests/env/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+PACKAGE="tmt"
+
+rlJournalStart
+    rlPhaseStartTest
+        rlRun "echo $TESTING | grep WORKS"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -20,7 +20,9 @@ class Discover(tmt.steps.Step):
         """ Save step data to the workdir """
         super(Discover, self).save()
         # Create 'tests.yaml' with the list of tests for the executor
-        tests = dict([test.export(format_='execute') for test in self.tests()])
+        tests = dict([
+            test.export(format_='execute', environment=self.plan.environment)
+            for test in self.tests()])
         self.write('tests.yaml', tmt.utils.dictionary_to_yaml(tests))
 
     def wake(self):

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -438,6 +438,11 @@ def format(
         # Otherwise just place each item on a new line
         else:
             output += ('\n' + indent_string).join(value)
+    # Dictionary
+    elif isinstance(value, dict):
+        # Place each key value pair on a separate line
+        output += ('\n' + indent_string).join(
+            f'{item[0]}: {item[1]}' for item in value.items())
     # Text
     elif isinstance(value, str):
         # In 'auto' mode enable wrapping when long lines present


### PR DESCRIPTION
Combine L1 and L2 environment in Test.export().
Include a simple test with an environment variable.
Extend utils.format() to support dictionaries as well.