### PR TITLE
 Implement --env for testcloud provisioner

### DIFF
--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -365,7 +365,20 @@ def dictionary_to_yaml(data):
 
 
 def dict_to_shell(data):
-    """ Convert dictionary to list of key=value pairs """
+    """
+    Convert dictionary or list/tuple of key=value pairs to list of key=value
+    pairs where value is quoted with shlex.quote.
+    """
+    if isinstance(data, list) or isinstance(data, tuple):
+        converted_data = []
+        for item in data:
+            splitted_item = item.split('=')
+            key = splitted_item[0]
+            value = shlex.quote('='.join(splitted_item[1:]))
+            converted_data.append(f'{key}={value}')
+
+        return converted_data
+
     return [f"{key}={shlex.quote(str(value))}" for key, value in data.items()]
 
 


### PR DESCRIPTION
Along the way also:
    
* improve a bit how image is detected, so the user can just pass a path, and tmt adds testcloud  required prefix 'file://' by itself.
   
* make sure finish runs only if there is an instance provisioned

Note: also bundles #132, pls review only the commit with the same name as the description of the PR