### PR TITLE
Add login support to testcloud provisioner

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -242,6 +242,9 @@ def discover(context, **kwargs):
 @click.option(
     '--container-pull', is_flag=True,
     help='Force pulling container image (how: container).')
+@click.option(
+    '-l', '--login', is_flag=True,
+    help='Login to the machine after running.')
 
 @verbose_debug_quiet
 @force_dry

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1,4 +1,5 @@
 import re
+import subprocess
 import os
 import time
 
@@ -341,3 +342,9 @@ class ProvisionTestcloud(ProvisionBase):
         if self.instance:
             self.info('instance', 'stopping', 'green')
             self.instance.stop()
+        if self.option('login'):
+            self.info('instance', 'login', 'green')
+            p = subprocess.Popen(
+                ['ssh'] + self.ssh_args + [self.ssh_user_host])
+            p.communicate()
+        self.instance.stop()


### PR DESCRIPTION
Runs during finish step.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>