### PR TITLE
Use cache 'unsafe' for testcloud

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -73,7 +73,7 @@ DOMAIN_TEMPLATE = """<domain type='kvm'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
     </disk>
     <disk type='file' device='disk'>
-      <driver name='qemu' type='raw'/>
+      <driver name='qemu' type='raw' cache='unsafe'/>
       <source file="{{ seed }}"/>
       <target dev='vdb' bus='virtio'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>


### PR DESCRIPTION
The key aspect of this “unsafe” mode, is that all flush commands
from the guests are ignored. Should significantly speedup dnf
for example.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>