### PR TITLE
Destroy container in finish only if there is any

### DIFF
--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -98,4 +98,5 @@ class ProvisionPodman(ProvisionBase):
 
     def destroy(self):
         """ Remove the container """
-        self.podman(f'container rm -f {self.container_name}')
+        if self.container_name:
+            self.podman(f'container rm -f {self.container_name}')


### PR DESCRIPTION
Otherwise the `finally` clause under `Plan.go()` hides exceptions
which happen before the container is created.