### PR TITLE
Support for `install:` in prepare

### DIFF
--- a/spec/steps/prepare.fmf
+++ b/spec/steps/prepare.fmf
@@ -27,6 +27,44 @@ description: |
         - /tmt/steps/provision/vagrant
         - /tmt/steps/provision/testcloud
 
+/install:
+    summary:
+        Install a package using dnf/yum.
+    description:
+        Installs a package(s) from specified source and verifies that it was
+        installed successfuly.
+    example: |
+        prepare:
+            how: install
+            package: ruby
+    implemented:
+        - /tmt/steps/prepare
+
+/install-copr:
+    summary:
+        Enable COPR repository using dnf and install package(s).
+    description:
+        Enable COPR repository and then run same as install.
+    example: |
+        prepare:
+            how: install
+            copr: pvalena/vagrant
+            package: vagrant
+    implemented:
+        - /tmt/steps/prepare
+
+/install-koji:
+    summary:
+        Download build package(s) and install them.
+    description:
+        Downloads build packages from koji (or brew) and install them using dnf/yum.
+    example: |
+        prepare:
+            how: install
+            url: https://koji.fedoraproject.org/koji/buildinfo?buildID=1465484
+    implemented:
+        - /tmt/steps/prepare
+
 /ansible:
     summary:
         Apply ansible playbook to get the desired final state.

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -243,7 +243,6 @@ def discover(context, **kwargs):
 @click.option(
     '--container-pull', is_flag=True,
     help='Force pulling container image (how: container).')
-
 @verbose_debug_quiet
 @force_dry
 def provision(context, **kwargs):
@@ -263,6 +262,15 @@ def provision(context, **kwargs):
 @click.option(
     '-p', '--playbook', metavar='PLAYBOOK',
     help='Path or URI to ansible playbook to run.')
+@click.option(
+    '-g', '--package', metavar='PACKAGE',
+    help='Package name to install.')
+@click.option(
+    '-c', '--copr', metavar='COPR',
+    help='Copr repository to enable.')
+@click.option(
+    '-u', '--url', metavar='URL',
+    help='Install from build URL.')
 @verbose_debug_quiet
 @force_dry
 def prepare(context, **kwargs):

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -15,8 +15,10 @@ from tmt.utils import GeneralError, SpecificationError
 
 class Prepare(tmt.steps.Step):
     name = 'prepare'
+    eol = '\n'
 
     valid_inputs = { 'shell': ['script'],
+                     'install': ['package', 'packages', 'url'],
                      'ansible': ['playbook', 'playbooks']
                    }
 
@@ -31,47 +33,50 @@ class Prepare(tmt.steps.Step):
         self.super.wake()
 
         for i in range(len(self.data)):
-            self.opts(i, 'how', 'script')
+            self.opts(i, 'how', 'input', 'copr')
+            how = self.data[i]['how']
 
-            for alt in ('playbook', 'playbooks'):
-                value = self.alias(i, 'script', alt)
-                how = self.data[i]['how']
+            # Aliases for 'input'; or the WHAT is to be applied
+            for key in self.valid_inputs:
+                for alt in self.valid_inputs[key]:
+                    value = self.alias(i, 'input', alt)
 
-                if value and how in self.valid_inputs:
-                    valid = self.valid_inputs[how]
-                    if not alt in valid:
+                    if value and key != how:
                         raise SpecificationError(f"You cannot specify {alt} for {how}.")
 
     def show(self):
         """ Show discover details """
-        self.super.show(keys = ['how', 'script'])
+        self.super.show(keys = ['how', 'input', 'copr'])
 
     def go(self):
         """ Prepare the test step """
         # TODO: not sure why
         self.super.go()
 
+        for dat in self.data:
+            self.run_how(dat)
+
         packages = []
         for step in self.plan.steps():
-            if getattr(step, 'requires', False):
+            if hasattr(step, 'requires'):
                 packages += step.requires()
 
         if packages:
             self.debug(f'Installing steps requires', ', '.join(packages))
             self.install(packages)
 
-        for dat in self.data:
-            self.run_how(dat)
-
 
     ## Knowhow ##
     def run_how(self, dat):
         """ Run specific HOW """
-        input = dat['script']
+        input = dat['input']
         if not input:
             self.debug('note', f"No data provided for prepare.", 'yellow')
             return
         self.debug('input', input, 'yellow')
+
+        if 'copr' in dat:
+            self.copr(dat['copr'])
 
         how = dat['how']
         getattr(self, f"how_{how}", self.how_generic)(how, input)
@@ -86,58 +91,131 @@ class Prepare(tmt.steps.Step):
 
         # Try guesssing the path (1)
         whatpath = os.path.join(self.plan.run.tree.root, what)
+        self.debug('Looking for prepare script in', self.plan.run.tree.root)
 
-        self.debug('Looking for prepare script in', whatpath)
         if os.path.exists(whatpath) and os.path.isfile(whatpath):
             what = whatpath
+
         else:
             # Try guesssing the path (2)
-            whatpath = os.path.join(self.plan.workdir,
+            base = os.path.join(self.plan.workdir,
                 'discover',
                 self.data[0]['name'],
-                'tests',
-                what)
+                'tests')
+            whatpath = os.path.join(base, what)
+            self.debug('Looking for prepare script in', base)
 
-            self.debug('Looking for prepare script', whatpath)
             if os.path.exists(whatpath) and os.path.isfile(whatpath):
                 what = whatpath
+
+            elif how == 'shell':
+                return self.command(what)
 
         try:
             self.plan.provision.prepare(how, what)
         except AttributeError as error:
             raise SpecificationError('NYI: cannot currently run this preparator.')
 
+    def how_install(self, how, what):
+        """ Install packages
+            handles various URIs or packages themselves
+        """
+        if not type(what) is list:
+            return self.install(what)
+
+        rest = []
+        for wha in what:
+            if self.is_uri(wha):
+                domain = self.get_uri(wha).netloc
+                if not re.search(r"^koji\.", domain) is None:
+                    self.how_koji('koji', how, what)
+                    continue
+                if not re.search(r"^brew\.", domain) is None:
+                    self.how_koji('brew', how, what)
+                    continue
+
+            rest += wha
+        self.install(rest)
+
+    def how_koji(self, com, how, what):
+        """ Download and install packages from koji URI """
+        what_uri = self.get_uri(what)
+
+        if what_uri:
+            query = self.get_query(what_uri)
+
+            if not 'buildID' in query:
+                raise SpecificationError(f"No buildID found in: {what}")
+
+            build = query['buildID']
+
+        else:
+            self.debug(f"Could not parse URI, assuming buildID was given.")
+            build = what
+
+        self.install(com)
+
+        install_dir = os.path.join(self.workdir, 'install')
+        self.command(f"{self.cmd_mkcd(install_dir)}; {com} download-build -a noarch -a x86_64 {build}; dnf install --skip-broken -y *.rpm; rm *.rpm")
+
 
     ## Additional API ##
+    def copr(self, copr):
+        """ Enable copr repository """
+        self.debug(f'Enabling copr repository', copr)
+        # Shouldn't be needed
+        # self.install('dnf-command(copr)')
+        return self.command(f"sudo dnf copr list --enabled | grep -qE '(^|\/){copr}$' || sudo dnf copr -y enable {copr}")
+
     def install(self, packages):
         """ Install specified package(s)
         """
         if type(packages) is list:
+            packages = [
+                self.quote(package) for package in packages
+            ]
             packages = ' '.join(packages)
+        else:
+            packages = self.quote(packages)
 
-        ## TODO: remove this after run(shell=True) is in provision.prepare()
-        try:
-            self.plan.provision.prepare('shell', f"rpm -V {packages}")
-        except GeneralError:
-            self.plan.provision.prepare('shell', f"dnf install -y {packages}")
-        return
-        ## <
+        return self.command(f"rpm -V {packages} || sudo dnf install -y {packages}")
 
+    def command(self, command, logfile=True):
         failed = False
         logf = os.path.join(self.workdir, 'prepare.log')
+
+        comf = os.path.join(self.workdir, 'command.sh')
+        comd = [
+              'set -x',
+              command,
+              'exit $?',
+              ''
+            ]
+        with open(comf, 'w', newline=self.eol) as f:
+            f.write(self.eol.join(comd))
+        os.chmod(comf, 0o700)
+
+        if type(logfile) is str and logfile:
+            logf = logfile
+
+        self.plan.provision.sync_workdir_to_guest()
         try:
-            self.plan.provision.prepare('shell', f"set -o pipefail; ( rpm -V {packages} || sudo dnf install -y {packages} ) 2>&1 | tee -a '{logf}'")
+            if logfile:
+                self.plan.provision.prepare('shell',
+                    f"set -o pipefail; bash '{comf}' 2>&1 | tee -a '{logf}'")
+            else:
+                self.plan.provision.prepare('shell', comf)
         except GeneralError:
             failed = True
 
         self.plan.provision.sync_workdir_from_guest()
 
-        output = open(logf).read()
-
         if failed:
-            raise GeneralError(f'Install failed:\n{output}')
-
-        self.debug(logf, output, 'yellow')
+            if logfile:
+                output = '\nlog:\n' + open(logf).read()
+            else:
+                output = command
+            raise GeneralError(f'Command failed: ' + output)
 
 
     ## END of API ##
@@ -215,4 +293,3 @@ class Prepare(tmt.steps.Step):
     def quote(self, string):
         """ returns string decorated with squot """
         return f"'{string}'"
-


### PR DESCRIPTION
also better script handling.

## TODO:
 - [x] docs about koji and brew handling, maybe reword.
 - [x] ~~commandline args for `koji` or `brew`~~ - covered by install
 - [x] input validator
 - [x] more examples for install