### PR TITLE
Implement wake up for Run, Step and Discover

### DIFF
--- a/tests/unit/steps/test_execute.py
+++ b/tests/unit/steps/test_execute.py
@@ -1,7 +1,13 @@
 import unittest
 
-from tmt.steps.execute import Execute, shell, beakerlib
+import tmt
+from tmt.steps.execute import shell, beakerlib
 from tmt.utils import SpecificationError
+
+# Ignore loading from workdir
+class Execute(tmt.steps.execute.Execute):
+    def load(self):
+        pass
 
 
 class TestExecute(unittest.TestCase):

--- a/tests/unit/steps/test_provision.py
+++ b/tests/unit/steps/test_provision.py
@@ -15,7 +15,7 @@ class PlanMock(MagicMock):
     run = MagicMock(tree=MagicMock(root=''))
 
     def opt(self, *args, **kwargs):
-        return {}
+        return None
 
     def _level(self):
         return 0

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -91,7 +91,7 @@ class Node(tmt.utils.Common):
         if format_ == 'dict':
             return data
         elif format_ == 'yaml':
-            return tmt.utils.dictionary_to_yaml(data)
+            return tmt.utils.dict_to_yaml(data)
         else:
             raise tmt.utils.GeneralError(
                 f"Invalid test export format '{format_}'.")
@@ -117,9 +117,31 @@ class Test(Node):
         'enabled',
         ]
 
-    def __init__(self, node):
-        """ Initialize the test """
+    def __init__(self, data, name=None):
+        """
+        Initialize test data from an fmf node or a dictionary
+
+        The following two methods are supported:
+
+            Test(node)
+            Test(dictionary, name)
+
+        Test name is required when initializing from a dictionary.
+        """
+
+        # Create a simple test node if dictionary given
+        if isinstance(data, dict):
+            if name is None:
+                raise GeneralError('Name required to initialize test.')
+            elif not name.startswith('/'):
+                raise SpecificationError("Test name should start with a '/'.")
+            else:
+                node = fmf.Tree(data)
+                node.name = name
+        else:
+            node = data
         super(Test, self).__init__(node)
+
         # Get all supported attributes
         for key in self._keys:
             setattr(self, key, self.node.get(key))
@@ -353,9 +375,12 @@ class Plan(Node):
         if self.summary:
             self.verbose('summary', self.summary, 'green')
         # Wake up all steps
+        self.debug('wake', color='cyan', shift=0)
         for step in self.steps(disabled=True):
+            self.debug(str(step), color='blue')
             step.wake()
         # Run enabled steps except 'finish'
+        self.debug('go', color='cyan', shift=0)
         try:
             for step in self.steps(skip=['finish']):
                 step.go()
@@ -589,6 +614,33 @@ class Run(tmt.utils.Common):
         self.debug(f"Using tree '{self.tree.root}'.")
         self._plans = None
 
+    def save(self):
+        """ Save list of selected plans and enabled steps """
+        data = dict(
+            plans = [plan.name for plan in self._plans],
+            steps = list(self._context.obj.steps),
+            )
+        self.write('run.yaml', tmt.utils.dict_to_yaml(data))
+
+    def load(self):
+        """ Load list of selected plans and enabled steps """
+        try:
+            data = tmt.utils.yaml_to_dict(self.read('run.yaml'))
+        except tmt.utils.FileError:
+            self.debug('Run data not found.')
+            return
+
+        # Filter plans by name unless specified on the command line
+        plan_options = ['names', 'filters', 'conditions']
+        if not any([Plan._opt(option) for option in plan_options]):
+            self._plans = [
+                plan for plan in self.tree.plans(run=self)
+                if plan.name in data['plans']]
+
+        # Initialize steps only if not specified on the command line
+        if not self.opt('all_') and not self._context.obj.steps:
+            self._context.obj.steps = set(data['steps'])
+
     @property
     def plans(self):
         """ Test plans for execution """
@@ -600,10 +652,14 @@ class Run(tmt.utils.Common):
         """ Go and do test steps for selected plans """
         # Show run id / workdir path
         self.info(self.workdir, color='magenta')
+        # Attempt to load run data
+        self.load()
         # Enable all steps if none selected or --all provided
         if self.opt('all_') or not self._context.obj.steps:
             self._context.obj.steps = set(tmt.steps.STEPS)
-        # Show summary and iterate over plans
+        # Show summary, store run data
         self.verbose('Found {0}.'.format(listed(self.plans, 'plan')))
+        self.save()
+        # Iterate over plans
         for plan in self.plans:
             plan.go()

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -3,6 +3,7 @@
 """ Discover Step Classes """
 
 import tmt
+from fmf.utils import listed
 
 class Discover(tmt.steps.Step):
     """ Gather and show information about test cases to be executed """
@@ -10,24 +11,46 @@ class Discover(tmt.steps.Step):
     def __init__(self, data, plan):
         """ Store supported attributes, check for sanity """
         super(Discover, self).__init__(data, plan)
-        self.steps = []
+        self.plugins = []
+
+        # List of Test() objects representing discovered tests
+        self._tests = []
 
     def load(self):
         """ Load step data from the workdir """
-        pass
+        super(Discover, self).load()
+        try:
+            tests = tmt.utils.yaml_to_dict(self.read('tests.yaml'))
+            self._tests = [
+                tmt.Test(data, name) for name, data in tests.items()]
+        except tmt.utils.GeneralError:
+            self.debug('Discovered tests not found.')
 
     def save(self):
         """ Save step data to the workdir """
         super(Discover, self).save()
-        # Create 'tests.yaml' with the list of tests for the executor
+
+        # Apply common plan environment to all tests
+        environment = self.plan.environment
+
+        # Create tests.yaml with the full test data
         tests = dict([
-            test.export(format_='execute', environment=self.plan.environment)
+            (test.name, test.export(format_='dict', environment=environment))
             for test in self.tests()])
-        self.write('tests.yaml', tmt.utils.dictionary_to_yaml(tests))
+        self.write('tests.yaml', tmt.utils.dict_to_yaml(tests))
+
+        # Create 'run.yaml' with the list of tests for the executor
+        if not self.tests():
+            return
+        tests = dict([
+            test.export(format_='execute', environment=environment)
+            for test in self.tests()])
+        self.write('run.yaml', tmt.utils.dict_to_yaml(tests))
 
     def wake(self):
         """ Wake up the step (process workdir and command line) """
         super(Discover, self).wake()
+
         # Check execute step for possible shell scripts
         scripts = self.plan.execute.opt(
             'script', self.plan.execute.data[0].get('script'))
@@ -45,41 +68,73 @@ class Discover(tmt.steps.Step):
             # Otherwise override current empty definition
             else:
                 self.data[0]['tests'] = tests
-        # Choose the plugin
+
+        # Choose the right plugin and wake it up
         for data in self.data:
             if data['how'] == 'fmf':
                 from tmt.steps.discover.fmf import DiscoverFmf
-                self.steps.append(DiscoverFmf(data, step=self))
+                plugin = DiscoverFmf(data, step=self)
             elif data['how'] == 'shell':
                 from tmt.steps.discover.shell import DiscoverShell
-                self.steps.append(DiscoverShell(data, step=self))
+                plugin = DiscoverShell(data, step=self)
             else:
                 raise tmt.utils.SpecificationError(
                     f"Unknown discover method '{data['how']}'.")
+            self.plugins.append(plugin)
+            plugin.wake()
+
+        # Nothing more to do if already done
+        if self.status() == 'done':
+            self.debug('Discover wake up complete (already done before).')
+        # Save status and step data (now we know what to do)
+        else:
+            self.status('todo')
+            self.save()
 
     def show(self):
         """ Show discover details """
         keys = ['how', 'repository', 'revision', 'filter']
         super(Discover, self).show(keys)
 
+    def summary(self):
+        """ Give a concise summary of the discovery """
+        # Summary of selected tests
+        text = listed(len(self.tests()), 'test') + ' selected'
+        self.info('tests', text, 'green', shift=1)
+        # Test list in verbose mode
+        for test in self.tests():
+            self.verbose(test.name, color='red', shift=2)
+
     def go(self):
         """ Execute all steps """
-        # Nothing to do if already done
-        if self.status() == 'done':
-            return
-        # Go!
-        self.status('going')
         super(Discover, self).go()
-        for step in self.steps:
-            step.go()
-        self.save()
+
+        # Nothing more to do if already done
+        if self.status() == 'done':
+            self.info('status', 'done', 'green', shift=1)
+            self.summary()
+            return
+
+        # Perform test discovery, gather discovered tests
+        for plugin in self.plugins:
+            # Go and discover tests
+            plugin.go()
+            # Prefix test name only if multiple plugins configured
+            prefix = f'/{plugin.name}' if len(self.plugins) > 1 else ''
+            # Check discovered tests, modify test name/path
+            for test in plugin.tests():
+                test.name = f"{prefix}{test.name}"
+                test.path = f"/{plugin.name}{test.path}"
+                self._tests.append(test)
+
+        # Give a summary, update status and save
+        self.summary()
         self.status('done')
+        self.save()
 
     def tests(self):
-        """ Return a list of all tests """
-        for step in self.steps:
-            for test in step.tests():
-                yield test
+        """ Return the list of all enabled tests """
+        return [test for test in self._tests if test.enabled]
 
 
 class DiscoverPlugin(tmt.steps.Plugin):

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -39,9 +39,9 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
                     f"Missing test script in '{self.step.plan.name}'.")
             # Prepare path to the test working directory (tree root by default)
             try:
-                data['path'] = f"/{self.name}/tests{data['path']}"
+                data['path'] = f"/tests{data['path']}"
             except KeyError:
-                data['path'] = f"/{self.name}/tests"
+                data['path'] = f"/tests"
 
             # Create a simple fmf node, adjust its name
             tests.child(name, data)
@@ -55,11 +55,6 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
 
         # Use a tmt.Tree to apply possible command line filters
         tests = tmt.Tree(tree=tests).tests()
-        # Summary of selected tests, test list in verbose mode
-        summary = fmf.utils.listed(len(tests), 'test') + ' selected'
-        self.info('tests', summary, 'green')
-        for test in tests:
-            self.verbose(test.name, color='red', shift=1)
         self._tests = tests
 
     def tests(self):

--- a/tmt/steps/execute/run.sh
+++ b/tmt/steps/execute/run.sh
@@ -28,7 +28,7 @@ tmt_VERBOSE=
 tmt_TYPE='shell'
 
 tmt_TESTS_D='discover'
-tmt_TESTS_F="${tmt_TESTS_D}/tests.yaml"
+tmt_TESTS_F="${tmt_TESTS_D}/run.yaml"
 
 tmt_LOG_D='execute'
 tmt_LOGOUT_F="out.log"

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -107,7 +107,7 @@ class Provision(tmt.steps.Step):
 
     def write(self, data):
         path = os.path.join(self.workdir, 'guests.yaml')
-        self.super.write(path, self.dictionary_to_yaml(data))
+        self.super.write(path, self.dict_to_yaml(data))
 
     def read(self, current):
         path = os.path.join(self.workdir, 'guests.yaml')

--- a/tmt/steps/provision/base.py
+++ b/tmt/steps/provision/base.py
@@ -78,7 +78,7 @@ class ProvisionBase(tmt.utils.Common):
         return ' '.join(args)
 
     def write(self, data):
-        self.super.write(self.path, self.dictionary_to_yaml(data))
+        self.super.write(self.path, self.dict_to_yaml(data))
 
     def read(self, current):
         if os.path.exists(self.path) and os.path.isfile(self.path):


### PR DESCRIPTION
Add wake up functionality including Discover example.
Implement load() and save() for Run, Step and Discover.
Move status() from Common to Step where it belongs.
New exception FileError for file-related problems.
Test class now supports initialization from dict.
Implement --force thanks to Common._workdir_cleanup().
Rename dictionary_to_yaml() to dict_to_yaml().