### PR TITLE
Sync more extra-* attributes when exporting

### DIFF
--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -57,6 +57,8 @@ The following attributes, if present, are exported as well:
 
 * extra-hardware — hardware in the structured field
 * extra-pepa — pepa in the structured field
+* extra-summary — Nitrate test case summary
+* extra-task — Nitrate test case script
 
 They have the ``extra`` prefix as they are not part of the L1
 Metadata Specification and are supposed to be synced temporarily

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -55,6 +55,16 @@ def export_to_nitrate(test, create):
         else:
             raise ConvertError("Nitrate test case id not found.")
 
+    # Summary
+    if test.node.get('extra-summary'):
+        nitrate_case.summary = test.node.get('extra-summary')
+        echo(style('summary: ', fg='green') + test.node.get('extra-summary'))
+
+    # Script
+    if test.node.get('extra-task'):
+        nitrate_case.script = test.node.get('extra-task')
+        echo(style('script: ', fg='green') + test.node.get('extra-task'))
+
     # Components
     # First remove any components that are already there
     nitrate_case.components.clear()

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -56,7 +56,7 @@ def export_to_nitrate(test, create):
             raise ConvertError("Nitrate test case id not found.")
 
     # Summary
-    if test.node.get('extra-summary'):
+    if test.node.get('extra-summary', test.summary):
         nitrate_case.summary = test.node.get('extra-summary')
         echo(style('summary: ', fg='green') + test.node.get('extra-summary'))
 

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -56,9 +56,12 @@ def export_to_nitrate(test, create):
             raise ConvertError("Nitrate test case id not found.")
 
     # Summary
-    if test.node.get('extra-summary', test.summary):
-        nitrate_case.summary = test.node.get('extra-summary')
-        echo(style('summary: ', fg='green') + test.node.get('extra-summary'))
+    summary = test.node.get('extra-summary', test.summary)
+    if summary:
+        nitrate_case.summary = summary
+        echo(style('summary: ', fg='green') + summary)
+    else:
+        raise ConvertError("Nitrate case summary could not be determined.")
 
     # Script
     if test.node.get('extra-task'):


### PR DESCRIPTION
'extra-summary' and 'extra-task' are now synced as well when exporting
to nitrate.
Docs updated.