### PR TITLE
Fix test discovery from the execute step scripts

### DIFF
--- a/tests/discover/main.fmf
+++ b/tests/discover/main.fmf
@@ -15,3 +15,7 @@ tier: 1
 /filtering:
     summary: Test selection by name and advanced filter
     test: ./filtering.sh
+
+/scripts:
+    summary: Check test discovery from the execute step
+    test: ./scripts.sh

--- a/tests/discover/references.sh
+++ b/tests/discover/references.sh
@@ -61,7 +61,6 @@ rlJournalStart
         rlRun 'tmt run -d discover plan --name $plan | tee output'
         rlAssertGrep 'Cloning into' output
         rlAssertGrep 'Checkout ref.*master' output
-        rlAssertGrep '3 tests selected' output
         rlAssertGrep /tests/docs output
         rlAssertGrep /tests/env output
         rlAssertGrep /tests/ls output

--- a/tests/discover/scripts.sh
+++ b/tests/discover/scripts.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun 'set -o pipefail'
+    rlPhaseEnd
+
+    plan='plan --name smoke'
+
+    rlPhaseStartTest 'All steps'
+        rlRun "tmt run $plan | tee output"
+        rlAssertGrep '1 test selected' 'output'
+    rlPhaseEnd
+
+    rlPhaseStartTest 'Selected steps'
+        rlRun "tmt run discover execute $plan | tee output"
+        rlAssertGrep '1 test selected' 'output'
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun 'rm -f output' 0 'Removing tmp file'
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -51,9 +51,10 @@ class Discover(tmt.steps.Step):
     def _discover_from_execute(self):
         """ Check the execute step for possible shell script tests """
 
-        # Check scripts, convert to list if needed
-        scripts = self.plan.execute.opt(
-            'script', self.plan.execute.data[0].get('script'))
+        # Check scripts for command line and data, convert to list if needed
+        scripts = self.plan.execute.opt('script')
+        if not scripts:
+            scripts = self.plan.execute.data[0].get('script')
         if not scripts:
             return
         if isinstance(scripts, str):


### PR DESCRIPTION
When the execute step is provided on the command line it would
give an empty list for the 'script' option, thus overriding the
default from execute step data. Simple smoke test included.