### PR TITLE
Support multiple verbose/debug levels [fix #191]

### DIFF
--- a/tests/unit/steps/test_provision.py
+++ b/tests/unit/steps/test_provision.py
@@ -63,7 +63,7 @@ def test_localhost_prepare_ansible():
         playbook = os.path.join(plan.run.tree.root, 'playbook.yml')
         run.assert_called_once_with(
             f'sudo sh -c "stty cols 80; '
-            f'ansible-playbook -v -c local -i localhost, {playbook}"')
+            f'ansible-playbook -c local -i localhost, {playbook}"')
 
 
 def test_localhost_prepare_shell():

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -8,11 +8,11 @@ import click
 # Verbose, debug and quiet output
 verbose_debug_quiet = [
     click.option(
-        '-v', '--verbose', is_flag=True,
-        help='I want to see more details. Please, be verbose.'),
+        '-v', '--verbose', is_flag=True, multiple=True,
+        help='Show more details. Use multiple times to raise verbosity.'),
     click.option(
-        '-d', '--debug', is_flag=True,
-        help='Provide as much debugging details as possible.'),
+        '-d', '--debug', is_flag=True, multiple=True,
+        help='Provide debugging information. Repeat to see more details.'),
     click.option(
         '-q', '--quiet', is_flag=True,
         help='Be quiet. Exit code is just enough for me.'),

--- a/tmt/steps/provision/localhost.py
+++ b/tmt/steps/provision/localhost.py
@@ -22,8 +22,11 @@ class ProvisionLocalhost(ProvisionBase):
         """ Run ansible on localhost """
         # Playbook paths should be relative to the metadata tree root
         playbook = os.path.join(self.step.plan.run.tree.root, what)
+        # Prepare verbose level based on the --debug option count
+        verbose = ' -' + self.opt('debug') * 'v' if self.opt('debug') else ''
         # Run ansible playbook against localhost, in verbose mode
-        ansible = f'ansible-playbook -v -c local -i localhost, {playbook}'
+        ansible = (
+            f'ansible-playbook{verbose} -c local -i localhost, {playbook}')
         # Force column width to 80 chars, to mitigate issues with too long
         # lines due to indent. Column width is the same as with libvirt plugin.
         columns = 'stty cols 80'

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -86,12 +86,13 @@ class ProvisionPodman(ProvisionBase):
         """ Prepare using ansible """
         # Playbook paths should be relative to the metadata tree root
         playbook = os.path.join(self.step.plan.run.tree.root, what)
-
-        # Run ansible playbook against localhost, in verbose mode
+        # Prepare verbose level based on the --debug option count
+        verbose = ' -' + self.opt('debug') * 'v' if self.opt('debug') else ''
+        # Run ansible playbook against localhost
         # Set columns to 80 characters so it looks the same as with vagrant
         self.run(
-            f'stty cols 80; {self.shell_env} podman unshare ansible-playbook '
-            f'-v -c podman -i {self.container_name}, {playbook}')
+            f'stty cols 80; {self.shell_env} podman unshare ansible-playbook'
+            f'{verbose} -c podman -i {self.container_name}, {playbook}')
 
     def _prepare_shell(self, what):
         """ Prepare using shell """

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -310,12 +310,14 @@ class ProvisionTestcloud(ProvisionBase):
         """ Prepare using ansible """
         # Playbook paths should be relative to the metadata tree root
         playbook = os.path.join(self.step.plan.run.tree.root, what)
+        # Prepare verbose level based on the --debug option count
+        verbose = ' -' + self.opt('debug') * 'v' if self.opt('debug') else ''
         # Set collumns to 80 characters while running ansible
         self.run(
             f'stty cols 80; ansible-playbook '
             f'--ssh-common-args="{self.ssh_args_shell}" '
-            f'-e ansible_python_interpreter=auto '
-            f'-v -i {self.user}@{self.ip}, {playbook}')
+            f'-e ansible_python_interpreter=auto'
+            f'{verbose} -i {self.user}@{self.ip}, {playbook}')
 
     def _prepare_shell(self, what):
         """ Prepare using shell """

--- a/tmt/steps/provision/vagrant.py
+++ b/tmt/steps/provision/vagrant.py
@@ -123,11 +123,14 @@ class ProvisionVagrant(ProvisionBase):
         if how == 'ansible':
             name = how
 
+            # Prepare verbose level based on the --debug option count
+            verbose = self.opt('debug') * 'v' if self.opt('debug') else 'false'
             self.add_config_block(cmd,
                 name,
                 f'become = true',
                 self.kve('become_user', self.data['user']),
-                self.kve('playbook', what))
+                self.kve('playbook', what),
+                self.kve('verbose', verbose))
                 # I'm not sure whether this is needed:
                 # run: 'never'
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -103,9 +103,16 @@ class Common(object):
         parent = None
         if self.parent:
             parent = self.parent.opt(option)
-        # Special handling for flags (parent's yes wins)
-        if isinstance(parent, bool):
-            return parent if parent else local
+        # Special handling for special flags (parent's yes always wins)
+        if option in ['verbose', 'debug', 'quiet', 'force', 'dry']:
+            winner = parent if parent else local
+            # Convert tuple of booleans into debug/verbose level (int)
+            if option in ['verbose', 'debug']:
+                if isinstance(winner, tuple):
+                    winner = len(winner)
+                if winner is None:
+                    winner = 0
+            return winner
         return parent if parent is not None else local
 
     def _level(self):


### PR DESCRIPTION
For now enable extra verbose level for ansible preparation.
We should get rid of the duplication during plugin cleanup.