### PR TITLE
Improve the workdir handling in the Common class

### DIFF
--- a/tests/unit/steps/test_provision.py
+++ b/tests/unit/steps/test_provision.py
@@ -21,12 +21,6 @@ class PlanMock(MagicMock):
         return 0
 
 
-def test_empty_plan():
-    provision = Provision({}, None)
-    with pytest.raises(GeneralError):
-        provision.wake()
-
-
 def test_defaults():
     provision = Provision({}, PlanMock())
     provision.wake()

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -650,13 +650,11 @@ class Tree(tmt.utils.Common):
 class Run(tmt.utils.Common):
     """ Test run, a container of plans """
 
-    def __init__(self, id_=None, tree=None):
+    def __init__(self, id_=None, tree=None, context=None):
         """ Initialize tree, workdir and plans """
-        super(Run, self).__init__()
+        super().__init__(workdir=id_ or True, context=context)
         # Save the tree
         self.tree = tree if tree else tmt.Tree('.')
-        # Prepare the workdir
-        self._workdir_init(id_)
         self.debug(f"Using tree '{self.tree.root}'.")
         self._plans = None
 

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -166,8 +166,7 @@ def main(context, root, **kwargs):
 def run(context, all_, id_, environment, **kwargs):
     """ Run test steps. """
     # Initialize
-    tmt.Run._save_context(context)
-    run = tmt.Run(id_, context.obj.tree)
+    run = tmt.Run(id_, context.obj.tree, context=context)
     context.obj.run = run
 
     # Check for sane environment variables


### PR DESCRIPTION
Update the Common class so that workdir is no more mandatory. This
allows to use read(), write(), run() and other methods without the
need to always initialize the workdir. It will be useful for other
subcommands such as 'tmt test export'. Also improved docs a bit.

The empty plan test has been removed as it depends on options
detection from plan and other stuff. I don't think it makes sense
to spend time with complicated mocking here.