### PR TITLE
Implement Plugin.show() for a full dynamic support

### DIFF
--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -84,11 +84,7 @@ class Discover(tmt.steps.Step):
 
         # Choose the right plugin and wake it up
         for data in self.data:
-            plugin_class = DiscoverPlugin.delegate(data['how'])
-            self.debug(
-                f"Using '{plugin_class.__name__}' plugin "
-                f"for the '{data['how']}' method.")
-            plugin = plugin_class(self, data)
+            plugin = DiscoverPlugin.delegate(self, data)
             self.plugins.append(plugin)
             plugin.wake()
 
@@ -102,8 +98,8 @@ class Discover(tmt.steps.Step):
 
     def show(self):
         """ Show discover details """
-        keys = ['how', 'url', 'ref', 'path', 'test', 'filter']
-        super().show(keys)
+        for data in self.data:
+            DiscoverPlugin.delegate(self, data).show()
 
     def summary(self):
         """ Give a concise summary of the discovery """

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -67,6 +67,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         # No other defaults available
         return default
 
+    def show(self):
+        """ Show discover details """
+        super().show(['url', 'ref', 'path', 'test', 'filter'])
+
     def wake(self):
         """ Wake up the plugin (override data with command line) """
 

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -6,6 +6,7 @@ import os
 import fmf
 import tmt
 import copy
+import click
 import shutil
 import tmt.steps.discover
 
@@ -19,6 +20,14 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
             summary='Manual list of shell tests',
             order=50),
         ]
+
+    def show(self):
+        """ Show config details """
+        super().show([])
+        tests = self.get('tests')
+        if tests:
+            test_names = [test['name'] for test in tests]
+            click.echo(tmt.utils.format('tests', test_names))
 
     def wake(self):
         # Check provided tests, default to an empty list


### PR DESCRIPTION
Remove the last hard-coded part of the Discover step.
Simplify Plugin.delegate() to return plugin instance.
Fix the default implemenation of plugin defaults.