### PR TITLE
Implement executing the last run using --last

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -701,3 +701,9 @@ the test and cleaning up::
     tmt run -i <ID> execute              # ... until you're done
 
     tmt run -i <ID> report finish
+
+Instead of always specifying the whole run id you can also use
+``--last`` or ``-l`` as an abbreviation for the last run id::
+
+    tmt run -l execute
+    tmt run --last execute

--- a/stories/cli/run.fmf
+++ b/stories/cli/run.fmf
@@ -148,9 +148,8 @@ story: 'As a user I want to execute tests easily'
     example:
         - tmt run --all execute --how restraint
 
-/latest:
+/last:
     story: 'As a user I want to rerun tests easily'
-
     description: >
         Execute previous run without the need to specify the
         previous run id. The command is a shortcut for::
@@ -158,7 +157,9 @@ story: 'As a user I want to execute tests easily'
             tmt run --id PREVIOUS_RUN
 
         Note that ``tmt`` saves last run id on each new execution.
-
+    implemented: /tmt/base
+    documented: /docs/examples#debug-tests
     example:
         - tmt run -l
-        - tmt run --latest
+        - tmt run --last
+

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import re
+import tmt
 import unittest
 
 from tmt.utils import StructuredField, StructuredFieldError, public_git_url
@@ -37,6 +38,15 @@ def test_listify():
     assert listify('a b c', split=True) == ['a', 'b', 'c']
     assert listify(dict(a=1, b=2)) == dict(a=[1], b=[2])
     assert listify(dict(a=1, b=2), keys=['a']) == dict(a=[1], b=2)
+
+
+def test_config():
+    """ Config smoke test """
+    run = '/var/tmp/tmt/test'
+    config1 = tmt.utils.Config()
+    config1.last_run(run)
+    config2 = tmt.utils.Config()
+    assert config2.last_run() == run
 
 
 class test_structured_field(unittest.TestCase):

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -702,7 +702,16 @@ class Run(tmt.utils.Common):
 
     def __init__(self, id_=None, tree=None, context=None):
         """ Initialize tree, workdir and plans """
+        # Use the last run id if requested
+        config = tmt.utils.Config()
+        if context.params.get('last'):
+            id_ = config.last_run()
+            if id_ is None:
+                raise tmt.utils.GeneralError(
+                    "No last run id found. Have you executed any run?")
         super().__init__(workdir=id_ or True, context=context)
+        # Store workdir as the last run id
+        config.last_run(self.workdir)
         # Save the tree
         self.tree = tree if tree else tmt.Tree('.')
         self.debug(f"Using tree '{self.tree.root}'.")

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -157,6 +157,8 @@ def main(context, root, **kwargs):
 @click.option(
     '-i', '--id', 'id_', help='Run id (name or directory path).', metavar="ID")
 @click.option(
+    '-l', '--last', help='Execute the last run once again.', is_flag=True)
+@click.option(
     '-a', '--all', 'all_', help='Run all steps, customize some.', is_flag=True)
 @click.option(
     '-e', '--environment', metavar='KEY=VALUE', multiple='True',

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -38,6 +38,41 @@ DEFAULT_NAME = 'default'
 DEFAULT_PLUGIN_ORDER = 50
 DEFAULT_PLUGIN_ORDER_REQUIRES = 70
 
+# Config directory
+CONFIG_PATH = '~/.config/tmt'
+
+
+class Config(object):
+    """ User configuration """
+
+    def __init__(self):
+        """ Initialize config directory path """
+        self.path = os.path.expanduser(CONFIG_PATH)
+        if not os.path.exists(self.path):
+            try:
+                os.makedirs(self.path)
+            except OSError as error:
+                raise GeneralError(
+                    f"Failed to create config '{self.path}'.\n{error}")
+
+    def last_run(self, run_id=None):
+        """ Get and set last run id """
+        symlink = os.path.join(self.path, 'last-run')
+        if run_id:
+            try:
+                os.remove(symlink)
+            except OSError:
+                pass
+            try:
+                os.symlink(run_id, symlink)
+            except OSError as error:
+                raise GeneralError(
+                    f"Unable to save last run '{self.path}'.\n{error}")
+            return run_id
+        if os.path.islink(symlink):
+            return os.path.realpath(symlink)
+        return None
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Common


### PR DESCRIPTION
Covers story `/stories/cli/run/last` introduced in #136. I have renamed the option to `--last` as it sounds somehow more natural to me. @lukaszachy, @thrix, what do you think?