### PR TITLE
Always add path to main.fmf in `tests import`

### DIFF
--- a/tests/test/import/test.sh
+++ b/tests/test/import/test.sh
@@ -10,6 +10,7 @@ rlJournalStart
     rlPhaseStartTest 'Import metadata'
         rlRun 'tmt test import --no-nitrate'
         rlAssertGrep 'summary: Simple smoke test' 'main.fmf'
+        rlAssertGrep 'path: /parent/child' 'main.fmf'
     rlPhaseEnd
 
     rlPhaseStartTest 'Check duplicates'

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -376,10 +376,9 @@ def import_(context, paths, makefile, nitrate, purpose, disabled, **kwargs):
         # Gather old metadata and store them as fmf
         common, individual = tmt.convert.read(
             path, makefile, nitrate, purpose, disabled)
-        # Add path to common metadata if there are virtual test cases
-        if individual:
-            root = fmf.Tree(path).root
-            common['path'] = os.path.join( '/', os.path.relpath(path, root))
+        # Add path to common metadata
+        root = fmf.Tree(path).root
+        common['path'] = os.path.join( '/', os.path.relpath(path, root))
         # Store common metadata
         common_path = os.path.join(path, 'main.fmf')
         tmt.convert.write(common_path, common)


### PR DESCRIPTION
This makes life easier if one starts with single beaker tests
and later adds more virtual cases

Hopefully interim workaround for one of issues/239 scenarios :)