### PR TITLE
Remove vagrant from requires until it's in epel8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ source: clean tmp
 	mkdir -p $(TMP)/SOURCES
 	mkdir -p $(TMP)/$(PACKAGE)
 	cp -a $(FILES) $(TMP)/$(PACKAGE)
+	rm $(TMP)/$(PACKAGE)/tmt/steps/provision/{base,vagrant}.py
 tarball: source man
 	cd $(TMP) && tar cfz SOURCES/$(PACKAGE).tar.gz $(PACKAGE)
 rpm: tarball

--- a/tests/unit/steps/test_provision.py
+++ b/tests/unit/steps/test_provision.py
@@ -6,7 +6,7 @@ import tempfile
 from mock import MagicMock, patch
 
 import tmt
-from tmt.steps.provision import Provision, local, vagrant
+from tmt.steps.provision import Provision, local
 from tmt.utils import GeneralError, SpecificationError
 
 

--- a/tmt.spec
+++ b/tmt.spec
@@ -79,7 +79,8 @@ Summary: Extra dependencies for the Test Management Tool
 Requires: tmt >= %{version}
 Requires: tmt-container >= %{version}
 Requires: tmt-testcloud >= %{version}
-Requires: vagrant python3-nitrate make
+Requires: python3-nitrate make
+Recommends: vagrant
 
 %description all
 All extra dependencies of the Test Management Tool. Install this


### PR DESCRIPTION
As for now 'tmt-all' cannot be installed on rhel-8 or centos-8 without
enabling the vagrant copr repository. Let's remove the requires until
vagrant is directly available in epel.