### PR TITLE
Use emulator_path instead of hard-coded qemu path

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -69,7 +69,8 @@ Dependencies required to run tests in a container environment.
 Summary: Virtual machine provisioner for the Test Management Tool
 Obsoletes: tmt-testcloud < 0.17
 Requires: tmt == %{version}-%{release}
-Requires: ansible python%{python3_pkgversion}-testcloud openssh-clients rsync
+Requires: python%{python3_pkgversion}-testcloud >= 0.3.5
+Requires: ansible openssh-clients rsync
 
 %description provision-virtual
 Dependencies required to run tests in a local virtual machine.

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -78,7 +78,7 @@ DOMAIN_TEMPLATE = """<domain type='kvm'>
     <suspend-to-disk enabled='no'/>
   </pm>
   <devices>
-    <emulator>/usr/bin/qemu-kvm</emulator>
+    <emulator>{{ emulator_path }}</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
       <source file="{{ disk }}"/>


### PR DESCRIPTION
Just trying with a fresh copr repo to prevent conflicts after pull request rebase.