### PR TITLE
Add support for running tests without defined plan

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -507,6 +507,13 @@ steps for all discovered test plans are executed::
         finish
             summary: 0 tasks completed
 
+Even if there are no :ref:`/spec/plans` defined it is still
+possible to execute tests and custom scripts. See the default
+:ref:`/stories/cli/run/default/plan` story for details. For
+example, in order to run beakerlib tests you could do this::
+
+    tmt run -a execute -h beakerlib
+
 
 Dry run mode is enabled with the ``--dry`` option::
 

--- a/stories/cli/run.fmf
+++ b/stories/cli/run.fmf
@@ -1,14 +1,58 @@
 story: 'As a user I want to execute tests easily'
 
 /default:
-    story: 'Default should cover the most common use case'
-    description:
-        Run all relevant tests on the default environment.
-        Default environment should be something safe which
-        should not modify user environment. Perhaps something
-        like 'x86_64 virtual machine from the testing farm'?
-    implemented: /tmt/base.py
-    example: tmt run
+    /run:
+        summary: 'Default should cover the most common use case'
+        story:
+            As a user I want to easily and safely execute all
+            available tests in the default environment.
+        description:
+            Run all relevant tests in a local virtual machine so
+            that the test environment can be safely prepared and
+            adjusted as needed without affecting or possibly
+            breaking user environment such as laptop.
+        implemented: /tmt/base.py
+        documented: /docs/examples.rst#run
+        example: tmt run
+    /plan:
+        summary: 'Plan should not be required for test execution'
+        story:
+            As a tester I want to execute tests in the default
+            environment without having to define a plan.
+        description: |
+            Even if there are no :ref:`/spec/plans` defined it is
+            still possible to execute tests and custom scripts. In
+            that case the default :ref:`/spec/steps` configuration
+            is applied and tests are executed using the ``shell``
+            method.
+
+            In order to discover available tests, the ``fmf``
+            method is used if metadata tree is detected otherwise
+            test discovery defaults to the ``shell`` method as well.
+
+            Individual steps of the default plan can be adjusted
+            as needed in the same way as if it was a real plans.
+            For example use ``execute -h beakerlib`` to execute
+            tests using the beakerlib method.
+        example: |
+            /plans/default:
+                summary:
+                    Default plan when fmf metadata found
+                discover:
+                    how: fmf
+                execute:
+                    how: shell
+
+            /plans/default:
+                summary:
+                    Default plan when no fmf metadata around
+                discover:
+                    how: shell
+                execute:
+                    how: shell
+        implemented: /tmt/base.py
+        tested: /tests/run/default
+        documented: /docs/examples.rst#run
 
 /select:
     story: 'Select multiple steps to be executed'

--- a/tests/run/default/main.fmf
+++ b/tests/run/default/main.fmf
@@ -1,0 +1,6 @@
+summary: Check whether default plan works
+description:
+    If there is no plan detected a 'default plan' is used to allow
+    running tests and arbitrary commands without existing plan.
+    This should work both when no fmf metadata are found and when
+    there is a metadata tree but it does not contain any plan.

--- a/tests/run/default/test.sh
+++ b/tests/run/default/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "options='-av provision -h local'"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    rlPhaseStartTest "No Metadata"
+        rlRun "tmt run $options execute -h shell -s 'touch $tmp/no-metadata'"
+        rlAssertExists "$tmp/no-metadata"
+    rlPhaseEnd
+
+    rlPhaseStartTest "No Plan"
+        rlRun "tmt init"
+        rlRun "tmt test create -t shell tests/smoke"
+        rlRun "echo 'touch $tmp/no-plan' >> tests/smoke/test.sh"
+        rlRun "tmt run $options"
+        rlAssertExists "$tmp/no-plan"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -rf $tmp" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -76,13 +76,6 @@ def test_create():
     os.chdir(original_directory)
     shutil.rmtree(tmp)
 
-def test_no_metadata():
-    """ No metadata found """
-    tmp = tempfile.mkdtemp()
-    result = runner.invoke(tmt.cli.main, ['--root', tmp, 'run'])
-    assert result.exception
-    os.rmdir(tmp)
-
 def test_step():
     """ Select desired step"""
     for step in ['discover', 'provision', 'prepare']:

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -102,9 +102,14 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 raise tmt.utils.DiscoverError(
                     f"Provided path '{path}' is not a directory.")
             fmf_root = path or self.step.plan.run.tree.root
-            output = self.run(
-                'git rev-parse --show-toplevel', cwd=fmf_root, dry=True)
-            git_root = output[0].strip('\n')
+            # Check git repository root (use fmf root if not found)
+            try:
+                output = self.run(
+                    'git rev-parse --show-toplevel', cwd=fmf_root, dry=True)
+                git_root = output[0].strip('\n')
+            except tmt.utils.RunError:
+                self.debug(f"Git root not found, using '{fmf_root}.'")
+                git_root = fmf_root
             # Set path to relative path from the git root to fmf root
             path = os.path.relpath(fmf_root, git_root)
             self.info('directory', git_root, 'green')

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -71,12 +71,15 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
             # Create a simple fmf node, adjust its name
             tests.child(name, data)
 
-        # Copy directory tree to the workdir
+        # Copy directory tree (if defined) to the workdir
         directory = self.step.plan.run.tree.root
         testdir = os.path.join(self.workdir, 'tests')
-        self.info('directory', directory, 'green')
-        self.debug("Copy '{}' to '{}'.".format(directory, testdir))
-        shutil.copytree(directory, testdir)
+        if directory:
+            self.info('directory', directory, 'green')
+            self.debug("Copy '{}' to '{}'.".format(directory, testdir))
+            shutil.copytree(directory, testdir)
+        else:
+            os.makedirs(testdir)
 
         # Use a tmt.Tree to apply possible command line filters
         tests = tmt.Tree(tree=tests).tests()

--- a/tmt/steps/execute/simple.py
+++ b/tmt/steps/execute/simple.py
@@ -108,7 +108,7 @@ class ExecuteSimple(tmt.steps.execute.ExecutePlugin):
             elif exit_code == '1':
                 data['result'] = 'fail'
         except tmt.utils.FileError:
-            log.debug(f"Exit code not found for test '{test.name}'.", level=3)
+            self.debug(f"Exit code not found for test '{test.name}'.", level=3)
         return tmt.Result(data, test.name)
 
     def check_beakerlib(self, test):

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -408,10 +408,13 @@ class RunError(GeneralError):
         self.stdout = stdout
         self.stderr = stderr
 
-class SpecificationError(GeneralError):
+class MetadataError(GeneralError):
+    """ General metadata error """
+
+class SpecificationError(MetadataError):
     """ Metadata specification error """
 
-class ConvertError(GeneralError):
+class ConvertError(MetadataError):
     """ Metadata conversion error """
 
 class StructuredFieldError(GeneralError):


### PR DESCRIPTION
Inject a default plan if metadata or plan not detected.
Fix broken help message for plugins when no fmf around.
Adjust discover steps to work without the tree root.
Fix a minor typo in the simple execute plugin.