### PR TITLE
State explicitly that execution is finished

### DIFF
--- a/tmt/steps/execute/run.sh
+++ b/tmt/steps/execute/run.sh
@@ -289,4 +289,5 @@ tmt_verbose 0 "$tmt_WD $ main $tmt_TYPE < $tmt_TESTS_F"
 
 tmt_main < <( grep -vE '^\s*$' "$tmt_TESTS_F" )
 
+tmt_verbose 0 "Test execution finished."
 echo 'D'


### PR DESCRIPTION
to stderr, for `detach` executor.

_ _ _ _

Can be later parsed to check for test suite finish.