### PR TITLE
Save root in run.yaml

### DIFF
--- a/tests/run/root/main.fmf
+++ b/tests/run/root/main.fmf
@@ -1,0 +1,6 @@
+summary: Check whether loading root when using --id works
+description:
+    When using tmt run --id the root directory should
+    be loaded from run.yaml so that the user doesn't have
+    to specify it manually. The fmf tree will then be loaded
+    from the root directory.

--- a/tests/run/root/test.sh
+++ b/tests/run/root/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
         rlRun "tmt test create -t shell tests/test"
         rlRun "tmt plans create -t mini plans/test-plan"
         rlRun "tmt run --until report provision -h local"
-        rlRun "cd .. && tmt run --last --since report"
+        rlRun "cd .. && tmt run -vvvddd --last --since report"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/run/root/test.sh
+++ b/tests/run/root/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun "tmt init"
+        rlRun "tmt test create -t shell tests/test"
+        rlRun "tmt plans create -t mini plans/test-plan"
+        rlRun "tmt run --until report provision -h local"
+        rlRun "cd .. && tmt run --last --since report"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -745,33 +745,27 @@ class Run(tmt.utils.Common):
         super().__init__(workdir=id_ or True, context=context)
         # Store workdir as the last run id
         self.config.last_run(self.workdir)
-        # Save the tree
-        try:
-            self.tree = tree if tree else tmt.Tree('.')
-            self.debug(f"Using tree '{self.tree.root}'.")
-            self.insert_default_plan()
-
-        # Create an empty default plan if no fmf metadata found
-        except tmt.utils.MetadataError:
-            self.create_default_plan()
-
+        self._save_tree(tree)
         self._plans = None
         self._environment = dict()
         self.remove = self.opt('remove')
 
-    def insert_default_plan(self):
-        # Insert default plan if no plan detected
+    def _save_tree(self, tree):
+        """ Save metadata tree, handle the default plan """
         default_plan = tmt.utils.yaml_to_dict(tmt.templates.DEFAULT_PLAN)
-        if not list(self.tree.tree.prune(keys=['execute'])):
-            self.tree.tree.update(default_plan)
-            self.debug(f"No plan found, adding the default plan.")
-
-    def create_default_plan(self):
-        default_plan = tmt.utils.yaml_to_dict(tmt.templates.DEFAULT_PLAN)
-        # The default discover method for this case is 'shell'
-        default_plan['/plans/default']['discover']['how'] = 'shell'
-        self.tree = tmt.Tree(tree=fmf.Tree(default_plan))
-        self.debug(f"No metadata found, using the default plan.")
+        try:
+            self.tree = tree if tree else tmt.Tree('.')
+            self.debug(f"Using tree '{self.tree.root}'.")
+            # Insert default plan if no plan detected
+            if not list(self.tree.tree.prune(keys=['execute'])):
+                self.tree.tree.update(default_plan)
+                self.debug(f"No plan found, adding the default plan.")
+        # Create an empty default plan if no fmf metadata found
+        except tmt.utils.MetadataError:
+            # The default discover method for this case is 'shell'
+            default_plan['/plans/default']['discover']['how'] = 'shell'
+            self.tree = tmt.Tree(tree=fmf.Tree(default_plan))
+            self.debug(f"No metadata found, using the default plan.")
 
     @property
     def environment(self):
@@ -801,14 +795,8 @@ class Run(tmt.utils.Common):
 
         # If run id was given and root was not explicitly specified,
         # create a new Tree from the root in run.yaml
-        if self._workdir and not self.opt('root'):
-            if 'root' in data:
-                try:
-                    self.tree = tmt.Tree(data['root'])
-                    self.debug(f"Using tree '{self.tree.root}'.")
-                    self.insert_default_plan()
-                except fmf.utils.GeneralError:
-                    self.create_default_plan()
+        if self._workdir and 'root' in data and not self.opt('root'):
+            self._save_tree(tmt.Tree(data['root']) if data['root'] else None)
 
         # Filter plans by name unless specified on the command line
         plan_options = ['names', 'filters', 'conditions']

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -129,7 +129,7 @@ def implemented_tested_documented(function):
 @click.pass_context
 @click.option(
     '-r', '--root', metavar='PATH', show_default=True,
-    help='Path to the tree root. \'.\' by default.')
+    help="Path to the tree root, '.' by default.")
 @verbose_debug_quiet
 def main(context, root, **kwargs):
     """ Test Management Tool """

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -128,12 +128,13 @@ def implemented_tested_documented(function):
 @click.group(invoke_without_command=True, cls=CustomGroup)
 @click.pass_context
 @click.option(
-    '-r', '--root', metavar='PATH', default='.', show_default=True,
-    help='Path to the tree root.')
+    '-r', '--root', metavar='PATH', show_default=True,
+    help='Path to the tree root. \'.\' by default.')
 @verbose_debug_quiet
 def main(context, root, **kwargs):
     """ Test Management Tool """
     # Initialize metadata tree
+    root = root or os.curdir
     tree = tmt.Tree(root)
     tree._save_context(context)
     context.obj = tmt.utils.Common()


### PR DESCRIPTION
This change makes `tmt run --id X` run correctly without specifying the `--root` explicitly when running the tests in a different working directory than they were originally run.