### PR TITLE
Add report:junit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ extras_require = {
     'docs': ['sphinx', 'sphinx_rtd_theme', 'mock'],
     'tests': ['pytest', 'python-coveralls', 'mock'],
     'provision': ['testcloud'],
+    'report': ['junit_xml']
 }
 extras_require['all'] = [dependency
     for extra in extras_require.values()

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -1,0 +1,47 @@
+import os
+
+from junit_xml import TestSuite, TestCase
+import click
+import tmt
+
+class ReportJUnit(tmt.steps.report.ReportPlugin):
+    """
+    Write test results in JUnit xml format
+
+    """
+
+    # Supported methods
+    _methods = [tmt.steps.Method(name='junit', doc=__doc__, order=50)]
+
+    _keys =  ['file']
+
+    @classmethod
+    def options(cls, how=None):
+        """ Prepare command line options for connect """
+        return [
+            click.option(
+                '--file', metavar='PATH',
+                help='Path where to store junit to'),
+            ] + super().options(how)
+
+    def go(self):
+        """ Discover available tests """
+        super().go()
+
+        suite = TestSuite(self.step.plan.name)
+        for result in self.step.plan.execute.results():
+            jux_result = result.result
+            jux_logs = {}
+            for log_path in result.log:
+                jux_logs[os.path.basename(log_path)] = self.step.plan.execute.read(log_path)
+                case = TestCase(result.name, None, 0.0, jux_logs.get('out.log',None), jux_logs.get('err.log', None))
+                if jux_result == 'error':
+                    case.add_error_info("error")
+                elif jux_result == "fail":
+                    case.add_failure_info("fail")
+                suite.test_cases.append(case)
+        f_path = self.opt("file", self.workdir + '/junit.xml')
+        with open (f_path, 'w') as fw:
+            TestSuite.to_file(fw, [suite])
+        self.info("xunit", f_path, 'green')
+


### PR DESCRIPTION
PoC to see if it could work like this. Depends on [junit_xml](https://pypi.org/project/junit-xml/)

For plan
```
summary: Basic smoke test
environment:
    FOO: 1
provision:
    how: container
    image: fedora
execute:
    how: shell.tmt
    script:
        - bash -c true
        - bash -c false
        - zzzz
```

It produces junit.xml (` tmt run --all report --how junit -v `)
```xml
<?xml version="1.0" ?>
<testsuites disabled="0" errors="1" failures="1" tests="3" time="0.0">
	<testsuite disabled="0" errors="1" failures="1" name="/plans/example" skipped="0" tests="3" time="0">
		<testcase name="/script-00"/>
		<testcase name="/script-01">
			<failure message="fail" type="failure"/>
			<system-out>Error: exec session exited with non-zero exit code 1: OCI runtime error
</system-out>
		</testcase>
		<testcase name="/script-02">
			<error message="error" type="error"/>
			<system-out>sh: zzzz: command not found
Error: exec session exited with non-zero exit code 127: OCI runtime error
</system-out>
		</testcase>
	</testsuite>
</testsuites>
```