### PR TITLE
Improve interactive mode to not fail if last cmd failed

### DIFF
--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -27,6 +27,11 @@ rlJournalStart
         rlRun "grep '^    discover$' -A4 output | grep -i interactive"
     rlPhaseEnd
 
+    rlPhaseStartTest "Failed command"
+        rlRun "$tmt login -c false | tee output"
+        rlAssertGrep "interactive" "output"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $tmp" 0 "Removing tmp directory"

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -223,7 +223,7 @@ class Common(object):
         # Prepare the environment
         if env:
             if not isinstance(env, dict):
-                raise tmt.utils.GeneralError(f"Invalid environment '{env}'.")
+                raise GeneralError(f"Invalid environment '{env}'.")
             # Do not modify current process environment
             environment = os.environ.copy()
             environment.update(env)
@@ -236,9 +236,12 @@ class Common(object):
             try:
                 subprocess.run(
                     command, cwd=cwd, shell=shell, env=environment, check=True)
-                return None if join else (None, None)
             except subprocess.CalledProcessError as error:
-                raise RunError(message, command, error.returncode)
+                # Interactive mode can return non-zero if the last command
+                # failed, ignore errors here
+                pass
+            finally:
+                return None if join else (None, None)
 
         # Create the process
         process = subprocess.Popen(


### PR DESCRIPTION
1. Do not fail if last command in interactive mode failed

If the last command has return code failed, interactive mode
will fail, this is, I believe, confusing to the user.

How to reproduce
```
$ tmt run provision -h container login
$ false
(press ctrl+D)
```

2. Fix faulty call of local GeneralError.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>