### PR TITLE
Add virtual plans for supported provision methods

### DIFF
--- a/plans/basic.fmf
+++ b/plans/basic.fmf
@@ -1,10 +1,10 @@
-summary:
-    Essential command line features
+summary: Basic command line features
+description:
+    Wide set of tests that cover individual steps, commands
+    and features. Tier 2 tests go a bit more into detail and
+    can take a little bit longer to complete.
 discover:
     how: fmf
-    filter: 'tier: 0,1,2'
-prepare:
-    how: ansible
-    playbooks: ansible/packages.yml
+    filter: 'tier: 1, 2'
 execute:
-    how: beakerlib
+    how: beakerlib.tmt

--- a/plans/core.fmf
+++ b/plans/core.fmf
@@ -1,0 +1,10 @@
+summary: Core functionality
+description:
+    Check common options such as --dry & --force, environment
+    variables handling, exploring tests and plans, presence of
+    documentation.
+discover:
+    how: fmf
+    filter: 'tier: 0'
+execute:
+    how: beakerlib.tmt

--- a/plans/helps.fmf
+++ b/plans/helps.fmf
@@ -1,25 +1,21 @@
-summary:
-    Check help messages
+summary: Check help messages
+description:
+    A couple of oneline examples showing how simple shell
+    tests can be written directly in the discover step. The
+    last one demonstrates a custom script in given directory.
 discover:
-    how: shell
     tests:
-    - name: /help/main
-      test: tmt --help
-    - name: /help/test
-      test: tmt test --help
-    - name: /help/plan
-      test: tmt plan --help
-    - name: /help/smoke
-      test: ./smoke.sh
-      path: /tests/shell
-prepare:
-    how: shell
-    script:
-    - sudo dnf install -y 'dnf-command(copr)'
-    - sudo dnf copr enable -y psss/tmt
-    - sudo dnf install -y tmt
+      - name: /help/main
+        test: tmt --help
+      - name: /help/test
+        test: tmt test --help
+      - name: /help/plan
+        test: tmt plan --help
+      - name: /help/smoke
+        test: ./smoke.sh
+        path: /tests/shell
 execute:
-    how: shell
+    how: shell.tmt
 artifact:
     - build
     - update

--- a/plans/install.fmf
+++ b/plans/install.fmf
@@ -1,0 +1,13 @@
+summary: Tests needing virtualization support
+description:
+    A couple of installation tests which provision a container
+    to verify that package installation works as expected.
+    Thanks to fetching dnf metadata these can take some time.
+discover:
+    how: fmf
+    filter: 'tier: 3'
+execute:
+    how: beakerlib.tmt
+artifact:
+    - build
+    - update

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,27 +1,24 @@
-# Local host
+# Use localhost by default
 provision:
     how: local
 
-# Connect to a running guest
-#provision:
-#    how: connect
-#    guest: 10.20.30.40
-#    key: /home/psss/.ssh/1minutetip_rsa
-#    user: root
-#    password: secret
+# Install packages
+#prepare:
+#  - name: tmt
+#    how: install
+#    package: tmt
+#    copr: psss/tmt
+#    directory: tmp/RPMS/noarch
 
-# Virtual using testcloud
-#provision:
-#    how: virtual.testcloud
-#    image: fedora
-#    image: https://kojipkgs.fedoraproject.org/compose/31/latest-Fedora-31/compose/Cloud/x86_64/images/Fedora-Cloud-Base-31-1.9.x86_64.qcow2
+# Ansible playbook
+#prepare:
+#    how: ansible
+#    playbooks: ansible/packages.yml
 
-# Virtual using vagrant
-#provision:
-#    how: virtual.vagrant
-#    image: fedora/30-cloud-base
-
-# Run tests in a container
-#provision:
-#    how: container
-#    image: fedora:latest
+# Shell commands
+#prepare:
+#    how: shell
+#    script:
+#    - sudo dnf install -y 'dnf-command(copr)'
+#    - sudo dnf copr enable -y psss/tmt
+#    - sudo dnf install -y tmt

--- a/plans/smoke.fmf
+++ b/plans/smoke.fmf
@@ -1,4 +1,8 @@
-summary:
-    Just a basic smoke test
+summary: Just a basic smoke test
+description:
+    Simple use cases should be super simple to write. In order
+    to enable at least a very basic testing of your component
+    in the CI the following two lines should be just enough.
 execute:
+    how: shell.tmt
     script: tmt --help

--- a/plans/unit.fmf
+++ b/plans/unit.fmf
@@ -1,0 +1,15 @@
+summary: Python unit tests
+description:
+    Run all available python unit tests using pytest.
+prepare+:
+  - name: pytest
+    how: install
+    package:
+        - python3-pytest
+        - python3-mock
+execute:
+    how: shell.tmt
+    script: python3 -m pytest tests
+artifact:
+    - build
+    - update

--- a/tests/core/docs/main.fmf
+++ b/tests/core/docs/main.fmf
@@ -1,2 +1,3 @@
 summary: Check that essential documentation is working
 coverage: /stories/docs
+tag-: [container]

--- a/tests/discover/scripts.sh
+++ b/tests/discover/scripts.sh
@@ -7,7 +7,7 @@ rlJournalStart
         rlRun 'set -o pipefail'
     rlPhaseEnd
 
-    plan='plan --name smoke'
+    plan='plan --name /plans/smoke'
 
     rlPhaseStartTest 'All steps'
         rlRun "tmt run discover $plan | tee output"

--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -2,3 +2,4 @@ test: ./test.sh
 contact: Petr Šplíchal <psplicha@redhat.com>
 duration: 5m
 tier: 1
+tag: [container]

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -331,6 +331,7 @@ class Plan(Node):
         """ Initialize the plan """
         super(Plan, self).__init__(node, parent=run)
         self.summary = node.get('summary')
+        self.description = node.get('description')
         self.run = run
 
         # Initialize test steps
@@ -457,6 +458,9 @@ class Plan(Node):
     def show(self):
         """ Show plan details """
         self.ls(summary=True)
+        if self.description:
+            echo(tmt.utils.format(
+                'description', self.description, key_color='green'))
         for step in self.steps(disabled=True):
             step.show()
         if self.environment:

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -987,6 +987,10 @@ class Guest(tmt.utils.Common):
 
     def details(self):
         """ Show guest details such as distro and kernel """
+        # Skip distro & kernel check in dry mode
+        if self.opt('dry'):
+            return
+        # Distro
         try:
             distro = self.execute(
                 'cat /etc/redhat-release', dry=True)[0].strip()
@@ -998,6 +1002,7 @@ class Guest(tmt.utils.Common):
                 distro = None
         if distro:
             self.info('distro', distro, 'green')
+        # Kernel
         kernel = self.execute('uname -r', dry=True)[0].strip()
         self.verbose('kernel', kernel, 'green')
 

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -85,7 +85,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
         try:
             stdout = guest.execute(
                 test.test, cwd=workdir, env=environment,
-                join=True, interactive=self.opt('interactive'), log=log)
+                join=True, interactive=self.get('interactive'), log=log)
             test.returncode = 0
         except tmt.utils.RunError as error:
             stdout = error.stdout

--- a/tmt/steps/provision/minute.py
+++ b/tmt/steps/provision/minute.py
@@ -101,6 +101,8 @@ class ProvisionMinute(tmt.steps.provision.ProvisionPlugin):
     def wake(self, data=None):
         """ Override options and wake up the guest """
         super().wake(['image', 'flavor'])
+        if self.opt('dry'):
+            return
 
         # Read API URL from 1minutetip script
         try:
@@ -319,6 +321,8 @@ class GuestMinute(tmt.Guest):
 
     def start(self):
         """ Start provisioned guest """
+        if self.opt('dry'):
+            return
         self.mt_image = self._convert_image(self.image)
         self.instance_start = datetime.datetime.utcnow().strftime(
             '%Y-%m-%d-%H-%M')

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -111,6 +111,8 @@ class GuestContainer(tmt.Guest):
 
     def start(self):
         """ Start provisioned guest """
+        if self.opt('dry'):
+            return
         # Check if the image is available
         image_id = self.podman(
             ['images', '-q', self.image],

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -355,6 +355,8 @@ class GuestTestcloud(tmt.Guest):
 
     def start(self):
         """ Start provisioned guest """
+        if self.opt('dry'):
+            return
         # Make sure required directories exist
         os.makedirs(TESTCLOUD_DATA, exist_ok=True)
         os.makedirs(TESTCLOUD_IMAGES, exist_ok=True)

--- a/try/connect/basic.fmf
+++ b/try/connect/basic.fmf
@@ -1,0 +1,1 @@
+../../plans/basic.fmf

--- a/try/connect/core.fmf
+++ b/try/connect/core.fmf
@@ -1,0 +1,1 @@
+../../plans/core.fmf

--- a/try/connect/main.fmf
+++ b/try/connect/main.fmf
@@ -1,0 +1,11 @@
+# Connect to a running guest
+provision:
+    how: connect
+    guest: my.test.box
+#    key: /home/psss/.ssh/1minutetip_rsa
+#    user: root
+#    password: secret
+
+artifact:
+    - build
+    - update

--- a/try/connect/smoke.fmf
+++ b/try/connect/smoke.fmf
@@ -1,0 +1,1 @@
+../../plans/smoke.fmf

--- a/try/connect/unit.fmf
+++ b/try/connect/unit.fmf
@@ -1,0 +1,1 @@
+../../plans/unit.fmf

--- a/try/container/basic.fmf
+++ b/try/container/basic.fmf
@@ -1,0 +1,1 @@
+../../plans/basic.fmf

--- a/try/container/core.fmf
+++ b/try/container/core.fmf
@@ -1,0 +1,1 @@
+../../plans/core.fmf

--- a/try/container/main.fmf
+++ b/try/container/main.fmf
@@ -1,0 +1,14 @@
+# Run tests in a container
+provision:
+    how: container
+#    image: fedora
+#    pull: false
+
+artifact:
+    - build
+    - update
+
+# Enable special container filter
+/core:
+    discover+:
+        filter: 'tier:0 & tag:container'

--- a/try/container/smoke.fmf
+++ b/try/container/smoke.fmf
@@ -1,0 +1,1 @@
+../../plans/smoke.fmf

--- a/try/container/unit.fmf
+++ b/try/container/unit.fmf
@@ -1,0 +1,1 @@
+../../plans/unit.fmf

--- a/try/main.fmf
+++ b/try/main.fmf
@@ -1,0 +1,1 @@
+../plans/main.fmf

--- a/try/minute/basic.fmf
+++ b/try/minute/basic.fmf
@@ -1,0 +1,1 @@
+../../plans/basic.fmf

--- a/try/minute/core.fmf
+++ b/try/minute/core.fmf
@@ -1,0 +1,1 @@
+../../plans/core.fmf

--- a/try/minute/main.fmf
+++ b/try/minute/main.fmf
@@ -1,0 +1,9 @@
+# Use 1minutetip backend
+provision:
+    how: minute
+#    image: fedora
+#    flavor: m1.large
+
+artifact:
+    - build
+    - update

--- a/try/minute/smoke.fmf
+++ b/try/minute/smoke.fmf
@@ -1,0 +1,1 @@
+../../plans/smoke.fmf

--- a/try/minute/unit.fmf
+++ b/try/minute/unit.fmf
@@ -1,0 +1,1 @@
+../../plans/unit.fmf

--- a/try/virtual/basic.fmf
+++ b/try/virtual/basic.fmf
@@ -1,0 +1,1 @@
+../../plans/basic.fmf

--- a/try/virtual/core.fmf
+++ b/try/virtual/core.fmf
@@ -1,0 +1,1 @@
+../../plans/core.fmf

--- a/try/virtual/main.fmf
+++ b/try/virtual/main.fmf
@@ -1,0 +1,10 @@
+# Virtual machine via testcloud
+provision:
+    how: virtual
+#    image: fedora
+#    memory: 2048
+#    disk: 10
+
+artifact:
+    - build
+    - update

--- a/try/virtual/smoke.fmf
+++ b/try/virtual/smoke.fmf
@@ -1,0 +1,1 @@
+../../plans/smoke.fmf

--- a/try/virtual/unit.fmf
+++ b/try/virtual/unit.fmf
@@ -1,0 +1,1 @@
+../../plans/unit.fmf


### PR DESCRIPTION
Enable set of relevant plans for each supported method.
Allow to easily run tests for selected/all provision methods.
Fix bugs in the --dry mode revealed by the new test coverage.