### PR TITLE
Improve default plan handling and more [fix #287]

### DIFF
--- a/bin/tmt
+++ b/bin/tmt
@@ -1,10 +1,8 @@
 #!/usr/bin/python
 
-import sys
-import fmf
+import click
 
 import tmt.cli
-import fmf.utils
 
 try:
     tmt.cli.main()
@@ -21,10 +19,10 @@ except tmt.utils.RunError as error:
             f"\n{tmt.utils.OUTPUT_WIDTH * '~'}\n" +
             '\n'.join(lines[-tmt.utils.OUTPUT_LINES:]))
     print()
-    fmf.utils.log.error(error.message)
+    click.echo(click.style(error.message, fg='red'))
     raise SystemExit(2)
 
 # Basic error message for general errors
 except tmt.utils.GeneralError as error:
-    fmf.utils.log.error(error)
+    click.echo(click.style(str(error), fg='red'))
     raise SystemExit(2)

--- a/tests/plan/select/main.fmf
+++ b/tests/plan/select/main.fmf
@@ -1,0 +1,5 @@
+summary: Selecting and filtering plans
+description:
+    For now covered only simple scenarios 'tmt plan ls <name>' and
+    'tmt run plan --name <name>' with valid and invalid names.
+test: ./test.sh

--- a/tests/plan/select/test.sh
+++ b/tests/plan/select/test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "tmt init -t mini"
+    rlPhaseEnd
+
+    rlPhaseStartTest "tmt plan ls"
+        rlRun "tmt plan ls | tee output"
+        rlAssertGrep "/plans/example" output
+        rlRun "tmt plan ls example | tee output"
+        rlAssertGrep "/plans/example" output
+        rlRun "tmt plan ls non-existent | tee output"
+        rlAssertNotGrep "/plans/example" output
+        rlRun '[[ $(wc -l <output) == "0" ]]' 0 "Check no output"
+    rlPhaseEnd
+
+    rlPhaseStartTest "tmt run plan --name"
+        tmt='tmt run -ar provision -h local'
+        rlRun "$tmt plan --name example | tee output"
+        rlAssertGrep "/plans/example" output
+        rlRun "$tmt plan --name non-existent | tee output" 2
+        rlAssertGrep "No plans found." output
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/run/default/test.sh
+++ b/tests/run/default/test.sh
@@ -20,6 +20,7 @@ rlJournalStart
         rlRun "echo 'touch $tmp/no-plan' >> tests/smoke/test.sh"
         rlRun "tmt run $options"
         rlAssertExists "$tmp/no-plan"
+        rlRun "tmt run --last report -fv" 0 "Try --last report (verify #287)"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/templates.py
+++ b/tmt/templates.py
@@ -51,6 +51,14 @@ rlJournalEnd
 #  Plan Templates
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+DEFAULT_PLAN = """
+/plans/default:
+    discover:
+        how: fmf
+    execute:
+        how: shell.tmt
+""".lstrip()
+
 PLAN = dict()
 
 PLAN['mini'] = """


### PR DESCRIPTION
Handle default plan adding during Run initialization.
Provide a meaningful message when no plan found.
Add basic test coverage for plan selection.
Format error messages with click style as well.