### PR TITLE
Improve basic and verbose output of tmt plan show

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -103,6 +103,9 @@ class Provision(tmt.steps.Step):
 class ProvisionPlugin(tmt.steps.Plugin):
     """ Common parent of provision plugins """
 
+    # Default implementation for provision is a virtual machine
+    how = 'virtual'
+
     # List of all supported methods aggregated from all plugins
     _supported_methods = []
 

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -62,6 +62,9 @@ class Report(tmt.steps.Step):
 class ReportPlugin(tmt.steps.Plugin):
     """ Common parent of report plugins """
 
+    # Default implementation for report is display
+    how = 'display'
+
     # List of all supported methods aggregated from all plugins
     _supported_methods = []
 


### PR DESCRIPTION
Remove the show() method obsoleted by dynamic plugins.
Prevent showing duplicate keys in verbose output.
Show 'how' when different from the default method.