### PR TITLE
Use extra-task as summary in test export

### DIFF
--- a/tmt/export.py
+++ b/tmt/export.py
@@ -54,7 +54,8 @@ def export_to_nitrate(test, create, general):
             raise ConvertError("Nitrate test case id not found.")
 
     # Summary
-    summary = test.node.get('extra-summary', test.summary)
+    summary = test.node.get(
+        'extra-summary', test.node.get('extra-task', test.summary))
     if summary:
         nitrate_case.summary = summary
         echo(style('summary: ', fg='green') + summary)


### PR DESCRIPTION
While extra-task doesn't say much about test's purpose it states which
component it is. Such information is necessary for review of integration
results or where many components are mixed.

Compare "git-lfs/Sanity/Smoke" vs "Essential functionality" as summary of failed case in the TCMS test run.
 