### PR TITLE
Give a nice error for expired kerberos [fix #57]

### DIFF
--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -233,6 +233,7 @@ def read_nitrate(beaker_task, common_data, disabled):
     # traceback when nitrate not installed or config file not available.
     try:
         import nitrate
+        import gssapi
     except ImportError:
         raise ConvertError('Install nitrate module to import metadata.')
 
@@ -249,7 +250,7 @@ def read_nitrate(beaker_task, common_data, disabled):
         else:
             testcases = list(nitrate.TestCase.search(
                 script=beaker_task, case_status__in=[1, 2, 4]))
-    except nitrate.NitrateError as error:
+    except (nitrate.NitrateError, gssapi.raw.misc.GSSError) as error:
         raise ConvertError(error)
     if not testcases:
         echo("No {0}testcase found for '{1}'.".format(

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -26,8 +26,9 @@ def import_nitrate():
     # traceback when nitrate not installed or config file not available.
     # And we want to keep the core tmt package with minimal dependencies.
     try:
-        global nitrate, DEFAULT_PRODUCT
+        global nitrate, DEFAULT_PRODUCT, gssapi
         import nitrate
+        import gssapi
         DEFAULT_PRODUCT = nitrate.Product(name='RHEL Tests')
     except ImportError:
         raise ConvertError("Install nitrate to export tests there.")
@@ -44,6 +45,7 @@ def export_to_nitrate(test, create, general):
     try:
         nitrate_id = test.node.get('extra-nitrate')[3:]
         nitrate_case = nitrate.TestCase(int(nitrate_id))
+        nitrate_case.summary # Make sure we connect to the server now
         echo(style(f"Test case '{nitrate_case.identifier}' found.", fg='blue'))
     except TypeError:
         # Create a new nitrate test case
@@ -52,6 +54,8 @@ def export_to_nitrate(test, create, general):
             new_test_created = True
         else:
             raise ConvertError("Nitrate test case id not found.")
+    except (nitrate.NitrateError, gssapi.raw.misc.GSSError) as error:
+        raise ConvertError(error)
 
     # Summary
     summary = test.node.get(


### PR DESCRIPTION
Example error messages upon an expired ticket:

````
> tmt test export --nitrate .
Major (851968): Unspecified GSS failure.  Minor code may provide more information, Minor (2529638944): Ticket expired

> tmt test import
...
Nitrate Major (851968): Unspecified GSS failure.  Minor code may provide more information, Minor (2529638944): Ticket expired
```