### PR TITLE
Detect beakerlib libraries from recommend as well

### DIFF
--- a/spec/tests/recommend.fmf
+++ b/spec/tests/recommend.fmf
@@ -1,4 +1,4 @@
-summary: Packages recommended for the test execution
+summary: Packages or libraries recommended for the test execution
 
 story:
     As a tester I want to specify additional packages which should
@@ -20,8 +20,9 @@ description: |
     version and thus can better ensure that the right packages are
     correctly installed as expected.
 
-    Note that beakerlib libraries are not supported by this
-    attribute, use :ref:`/spec/tests/require` instead.
+    Note that beakerlib libraries are supported by this attribute
+    as well. See the :ref:`/spec/tests/require` attribute for more
+    details about available reference options.
 
     Should be a ``string`` or a ``list of strings`` using package
     specification supported by ``dnf`` which takes care of the

--- a/tests/discover/libraries/data/apache.sh
+++ b/tests/discover/libraries/data/apache.sh
@@ -5,10 +5,7 @@
 rlJournalStart
     rlPhaseStartSetup
         rlAssertRpm "httpd"
-        # TODO Enable once beakerlib support is ready
-        #rlRun "rlImport httpd/http"
-        source ../../../../../libs/openssl/certgen/lib.sh
-        source ../../../../../libs/httpd/http/lib.sh
+        rlRun "rlImport httpd/http"
         rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
         rlRun "pushd $tmp"
     rlPhaseEnd

--- a/tests/discover/libraries/data/certificate.fmf
+++ b/tests/discover/libraries/data/certificate.fmf
@@ -18,6 +18,16 @@ path: /
       - url: https://github.com/beakerlib/openssl
         name: /certgen
 
+/recommend:
+    summary: Generate a certificate (recommend)
+    description:
+        The old backward compatible way to require a beakerlib
+        library using the 'library(component/lib)' format
+        specified in the 'recommend' attribute.
+    recommend:
+      - library(openssl/certgen)
+      - library(wrong/certgen)
+
 /nick:
     summary: Custom repo name and recommended packages
     description:

--- a/tests/discover/libraries/data/certificate.sh
+++ b/tests/discover/libraries/data/certificate.sh
@@ -5,9 +5,7 @@
 rlJournalStart
     rlPhaseStartSetup
         rlAssertRpm "openssl"
-        # TODO Enable once beakerlib support is ready
-        #rlRun "rlImport openssl/certgen"
-        source ../../../../../libs/openssl/certgen/lib.sh
+        rlRun "rlImport openssl/certgen"
         rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
         rlRun "pushd $tmp"
     rlPhaseEnd

--- a/tests/discover/libraries/data/plan.fmf
+++ b/tests/discover/libraries/data/plan.fmf
@@ -21,6 +21,10 @@ execute:
         summary: "Certificate test (fmf format)"
         discover+:
             test: fmf
+    /recommend:
+        summary: "Certificate test (recommended library)"
+        discover+:
+            test: recommend
     /nick:
         summary: "Certificate test (custom nick name)"
         discover+:

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -21,6 +21,11 @@ rlJournalStart
         rlAssertGrep "Fetch library 'openssl/certgen'" $tmp/output
     rlPhaseEnd
 
+    rlPhaseStartTest "Recommend"
+        rlRun "$tmt recommend | tee $tmp/output" 0
+        rlAssertGrep "Fetch library 'openssl/certgen'" $tmp/output
+    rlPhaseEnd
+
     rlPhaseStartTest "Conflict"
         rlRun "$tmt conflict 2>&1 | tee $tmp/output" 2
         rlAssertGrep 'Library.*conflicts' $tmp/output

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -160,13 +160,17 @@ def dependencies(original_require, original_recommend=None, parent=None):
     """
     # Initialize lists, use set for require & recommend
     processed_require = set()
-    processed_recommend = set(original_recommend or [])
+    processed_recommend = set()
     gathered_libraries = []
+    if not original_require:
+        original_require = []
+    if not original_recommend:
+        original_recommend = []
 
-    for require in original_require:
-        # Library require
+    for dependency in original_require + original_recommend:
+        # Library require/recommend
         try:
-            library = Library(require, parent=parent)
+            library = Library(dependency, parent=parent)
             gathered_libraries.append(library)
             # Recursively check for possible dependent libraries
             requires, recommends, libraries = dependencies(
@@ -174,9 +178,12 @@ def dependencies(original_require, original_recommend=None, parent=None):
             processed_require.update(set(requires))
             processed_recommend.update(set(recommends))
             gathered_libraries.extend(libraries)
-        # Regular package require
+        # Regular package require/recommend
         except LibraryError:
-            processed_require.add(require)
+            if dependency in original_require:
+                processed_require.add(dependency)
+            if dependency in original_recommend:
+                processed_recommend.add(dependency)
 
     # Convert to list and return the results
     processed_require = list(processed_require)

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -160,7 +160,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             # Prefix test path with 'tests' and possible 'path' prefix
             test.path = os.path.join(prefix_path, test.path.lstrip('/'))
             # Check for possible required beakerlib libraries
-            if test.require:
+            if test.require or test.recommend:
                 test.require, test.recommend, _ = tmt.beakerlib.dependencies(
                     test.require, test.recommend, parent=self)
 


### PR DESCRIPTION
Allows to specify beakerlib libraries in the `recommend` attribute which might be useful as a temporary solution for example when the library has a different name in the upstream repo and internal task library.