### PR TITLE
Remove vagrant from tmt-all recommended packages

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -81,7 +81,6 @@ Requires: tmt >= %{version}
 Requires: tmt-provision-container >= %{version}
 Requires: tmt-provision-virtual >= %{version}
 Requires: python3-nitrate make
-Recommends: vagrant
 
 %description all
 All extra dependencies of the Test Management Tool. Install this


### PR DESCRIPTION
This brings too many unnecessary weak dependencies.
Should go into the new vagrant provision subpackage.