### PR TITLE
Avoid double fmf extension when creating plans and stories

### DIFF
--- a/tests/plan/create/test.sh
+++ b/tests/plan/create/test.sh
@@ -17,6 +17,11 @@ rlJournalStart
         rlAssertGrep "url:.*ext/repo" "plans/custom.fmf"
     rlPhaseEnd
 
+    rlPhaseStartTest "Valid data - fmf extension included"
+        rlRun "tmt plan create plan.fmf --template mini"
+        rlAssertExists "$TMP/plan.fmf"
+    rlPhaseEnd
+
     rlPhaseStartTest "Invalid yaml"
         yaml='{how: "fmf"; name: "int"; url: "https://int/repo"}'
         rlRun "tmt plan create /plans/bad --template mini \

--- a/tests/story/create/main.fmf
+++ b/tests/story/create/main.fmf
@@ -1,0 +1,2 @@
+summary: Check that a story is created correctly
+test: ./test.sh

--- a/tests/story/create/test.sh
+++ b/tests/story/create/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "tmt init"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun "tmt story create story --template mini"
+        rlAssertExists "$tmp/story.fmf"
+    rlPhaseEnd
+
+    rlPhaseStartTest "With fmf extension"
+        rlRun "tmt story create story2.fmf --template mini"
+        rlAssertExists "$tmp/story2.fmf"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -421,7 +421,9 @@ class Plan(Node):
         # Prepare paths
         (directory, plan) = os.path.split(name)
         directory_path = os.path.join(tree.root, directory.lstrip('/'))
-        plan_path = os.path.join(directory_path, plan + '.fmf')
+        has_fmf_ext = os.path.splitext(plan)[1] == '.fmf'
+        plan_path = os.path.join(directory_path,
+                                plan + ('' if has_fmf_ext else '.fmf'))
 
         # Create directory & plan
         tmt.utils.create_directory(directory_path, 'plan directory')
@@ -566,7 +568,9 @@ class Story(Node):
         # Prepare paths
         (directory, story) = os.path.split(name)
         directory_path = os.path.join(tree.root, directory.lstrip('/'))
-        story_path = os.path.join(directory_path, story + '.fmf')
+        has_fmf_ext = os.path.splitext(story)[1] == '.fmf'
+        story_path = os.path.join(directory_path,
+                                  story + ('' if has_fmf_ext else '.fmf'))
 
         # Create directory & story
         tmt.utils.create_directory(directory_path, 'story directory')


### PR DESCRIPTION
As mentioned in the issue, the problem was present in creating plans and stories, however, it doesn't occur when creating tests. The name of the fmf file is hardcoded to `main.fmf` hence there shouldn't be a problem.

Resolves: #298 