### PR TITLE
Retry requests in case of network failure

### DIFF
--- a/tmt/steps/provision/minute.py
+++ b/tmt/steps/provision/minute.py
@@ -10,6 +10,7 @@ import time
 import urllib3.exceptions
 
 import tmt
+from tmt.utils import retry_session
 
 
 DEFAULT_USER = 'root'
@@ -38,7 +39,7 @@ def run_openstack(url, cmd, cached_list=False):
     # is unfortunately necessary here for the plugin to work.
     requests.packages.urllib3.disable_warnings(
         category=urllib3.exceptions.InsecureRequestWarning)
-    response = requests.post(url, verify=False, data=data)
+    response = retry_session().post(url, verify=False, data=data)
     if response.ok:
         # The output is in the form of: <stdout>\n<exit>\n.
         split = response.text.rsplit('\n', 2)
@@ -231,7 +232,7 @@ class GuestMinute(tmt.Guest):
         return True
 
     def _setup_machine(self):
-        response = requests.get(
+        response = retry_session().get(
             f'{self.api_url}?image_name={self.mt_image}'
             f'&user={self.username}&osver=rhos10', verify=False)
         if not response.ok:

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -7,7 +7,7 @@ import tmt
 import click
 import requests
 
-from tmt.utils import ProvisionError, WORKDIR_ROOT
+from tmt.utils import ProvisionError, WORKDIR_ROOT, retry_session
 
 def import_testcloud():
     """
@@ -248,7 +248,7 @@ class GuestTestcloud(tmt.Guest):
         """ Get url, retry when fails, return response """
         for i in range(1, DEFAULT_CONNECT_TIMEOUT):
             try:
-                response = requests.get(url)
+                response = retry_session().get(url)
                 if response.ok:
                     return response
             except requests.RequestException:

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -16,6 +16,9 @@ import yaml
 import re
 import io
 import os
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 log = fmf.utils.Logging('tmt').logger
 
@@ -854,6 +857,28 @@ def public_git_url(url):
 
     # Otherwise return unmodified
     return url
+
+
+def retry_session(retries=3, backoff_factor=0.1, method_whitelist=False,
+                  status_forcelist=(429, 500, 502, 503, 504)):
+    """
+    Create a requests.Session() that retries on request failure.
+
+    'method_whitelist' is set to False to retry on all http request methods
+    by default.
+    """
+    session = requests.Session()
+    retry = Retry(
+        total=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        method_whitelist=method_whitelist,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I initially wanted to create the method within `Common` class but that wouldn't be usable in `run_openstack` function in `minute.py` so I ended up creating a function for the functionality. Returning only the session (and not performing the request) helps with versatility - it can work for all http methods.

Resolves: #290 