### PR TITLE
Prevent koji from trying to build packages on i686

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -5,6 +5,7 @@ Release: 1%{?dist}
 Summary: Test Management Tool
 License: MIT
 BuildArch: noarch
+%{?kernel_arches:ExclusiveArch: %{kernel_arches} noarch}
 
 URL: https://github.com/psss/tmt
 Source0: https://github.com/psss/tmt/releases/download/%{version}/tmt-%{version}.tar.gz


### PR DESCRIPTION
This is because libguestfs-tools-c package, which is needed for
testcloud, is not built for i686 and thus causes build failures.
See also: https://bugzilla.redhat.com/show_bug.cgi?id=1743421