### PR TITLE
Disable authentication when fetching libraries

### DIFF
--- a/tests/discover/libraries/data/certificate.fmf
+++ b/tests/discover/libraries/data/certificate.fmf
@@ -48,3 +48,7 @@ path: /
       - url: https://github.com/beakerlib/openssl
         name: /certgen
         destination: custom
+
+/missing:
+    summary: Reference a non-existent library
+    require: library(something/wrong)

--- a/tests/discover/libraries/data/plan.fmf
+++ b/tests/discover/libraries/data/plan.fmf
@@ -41,3 +41,7 @@ execute:
         summary: "Custom destination directory"
         discover+:
             test: destination
+    /missing:
+        summary: "Missing library"
+        discover+:
+            test: missing

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -36,6 +36,11 @@ rlJournalStart
         rlAssertGrep 'Cloning into.*custom/openssl' $tmp/output
     rlPhaseEnd
 
+    rlPhaseStartTest "Missing"
+        rlRun "$tmt missing 2>&1 | tee $tmp/output" 2
+        rlAssertGrep 'Authentication failed.*something' $tmp/output
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $tmp" 0 "Removing tmp directory"

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -124,7 +124,7 @@ class Library(object):
             try:
                 self.parent.run(
                     ['git', 'clone', self.url, directory],
-                    shell=False, env={"GIT_TERMINAL_PROMPT": "0"})
+                    shell=False, env={"GIT_ASKPASS": "echo"})
             except tmt.utils.RunError as error:
                 # Fallback to install during the prepare step if in rpm format
                 if self.format == 'rpm':


### PR DESCRIPTION
Completely turn off authentication when cloning the repo.
This disables unwanted pop-up windows as well [fix #340].
Extend the test coverage with a missing library use case.