### PR TITLE
Remove the remaining 'tmt test convert' references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,10 +56,10 @@ List tests, show details, check against the specification::
     tmt test show
     tmt test lint
 
-Create a new test, convert old metadata::
+Create a new test, import test metadata from other formats::
 
     tmt test create
-    tmt test convert
+    tmt test import
 
 List plans, show details, check against the specification::
 

--- a/stories/docs.fmf
+++ b/stories/docs.fmf
@@ -13,7 +13,7 @@ story:
     example:
         - tmt --help
         - tmt run --help
-        - tmt test convert --help
+        - tmt test import --help
     tested: /tests/docs
     implemented: /tmt/cli
 

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -19,7 +19,7 @@ def test_convert():
     tmp = tempfile.mkdtemp()
     os.system('cp -a {} {}'.format(CONVERT, tmp))
     path = os.path.join(tmp, 'convert')
-    command = 'test convert --no-nitrate {}'.format(path)
+    command = 'test import --no-nitrate {}'.format(path)
     result = runner.invoke(tmt.cli.main, command.split())
     assert result.exit_code == 0
     assert 'Metadata successfully stored' in result.output


### PR DESCRIPTION
The `tmt test convert` command has been (long ago) obsoleted with `tmt test import`. Let's not mention it anywhere anymore.