### PR TITLE
Add COPR build for master

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,3 +19,15 @@ jobs:
     targets:
     - fedora-all
     - epel-8
+
+- job: copr_build
+  trigger: commit
+  metadata:
+    branch: master
+    targets:
+    - fedora-all
+    - epel-8
+    list_on_homepage: True
+    preserve_project: True
+    owner: psss
+    project: tmt


### PR DESCRIPTION
I remember that you were interested in the COPR builds for new commits to `master` branch.

This will build in your COPR project (`psss/tmt`). (Packit should ask you for `builder` permission.)
If you don't set the `owner`+`project`, we will create `packit/psss-tmt-master` for you.