### PR TITLE
Remove `directory` from main.fmf; update COPR repo

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -7,8 +7,7 @@ provision:
 #  - name: tmt
 #    how: install
 #    package: tmt
-#    copr: psss/tmt
-#    directory: tmp/RPMS/noarch
+#    copr: packit/psss-tmt-master
 
 # Ansible playbook
 #prepare:
@@ -20,5 +19,5 @@ provision:
 #    how: shell
 #    script:
 #    - sudo dnf install -y 'dnf-command(copr)'
-#    - sudo dnf copr enable -y psss/tmt
+#    - sudo dnf copr enable -y packit/psss-tmt-master
 #    - sudo dnf install -y tmt


### PR DESCRIPTION
This is not a functional change, as the code is commented out.
It doesn't make much sense to combine installation from COPR and `directory` at the same time. (If I just blindly un-comment it, it fails.)

Also fix up copr repo to point to our packit (master) builds.