### PR TITLE
Support short options for selecting tests & plans

### DIFF
--- a/tests/plan/select/main.fmf
+++ b/tests/plan/select/main.fmf
@@ -1,5 +1,5 @@
 summary: Selecting and filtering plans
 description:
-    For now covered only simple scenarios 'tmt plan ls <name>' and
-    'tmt run plan --name <name>' with valid and invalid names.
+    Verify selecting plans by name and filter works as expected
+    for 'tmt plan ls', 'tmt plan show' and 'tmt run plan'.
 test: ./test.sh

--- a/tests/plan/select/test.sh
+++ b/tests/plan/select/test.sh
@@ -3,32 +3,47 @@
 
 rlJournalStart
     rlPhaseStartSetup
-        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
-        rlRun "pushd $tmp"
+        rlRun "output=\$(mktemp)" 0 "Create output file"
         rlRun "set -o pipefail"
-        rlRun "tmt init -t mini"
     rlPhaseEnd
 
     rlPhaseStartTest "tmt plan ls"
-        rlRun "tmt plan ls | tee output"
-        rlAssertGrep "/plans/example" output
-        rlRun "tmt plan ls example | tee output"
-        rlAssertGrep "/plans/example" output
-        rlRun "tmt plan ls non-existent | tee output"
-        rlAssertNotGrep "/plans/example" output
-        rlRun '[[ $(wc -l <output) == "0" ]]' 0 "Check no output"
+        rlRun "tmt plan ls | tee $output"
+        rlAssertGrep "/plans/features/core" $output
+        rlAssertGrep "/plans/features/basic" $output
     rlPhaseEnd
 
-    rlPhaseStartTest "tmt run plan --name"
-        tmt='tmt run -ar provision -h local'
-        rlRun "$tmt plan --name example | tee output"
-        rlAssertGrep "/plans/example" output
-        rlRun "$tmt plan --name non-existent | tee output" 2
-        rlAssertGrep "No plans found." output
+    rlPhaseStartTest "tmt plan ls <name>"
+        rlRun "tmt plan ls core | tee $output"
+        rlAssertGrep "/plans/features/core" $output
+        rlAssertNotGrep "/plans/features/basic" $output
     rlPhaseEnd
+
+    rlPhaseStartTest "tmt plan ls non-existent"
+        rlRun "tmt plan ls non-existent | tee $output"
+        rlRun "[[ $(wc -l <$output) == 0 ]]" 0 "Check no output"
+    rlPhaseEnd
+
+    for filter in '-f' '--filter'; do
+        rlPhaseStartTest "tmt plan show $filter <filter>"
+            rlRun "tmt plan show $filter description:.*fast.* | tee $output"
+            rlAssertGrep '/plans/features/core' $output
+            rlAssertNotGrep '/plans/features/basic' $output
+        rlPhaseEnd
+    done
+
+    for name in '-n' '--name'; do
+        rlPhaseStartTest "tmt run plan $name <name>"
+            tmt='tmt run -r discover'
+            rlRun "$tmt plan $name core | tee $output"
+            rlAssertGrep "/plans/features/core" $output
+            rlAssertNotGrep "/plans/features/basic" $output
+            rlRun "$tmt plan $name non-existent | tee $output" 2
+            rlAssertGrep "No plans found." $output
+        rlPhaseEnd
+    done
 
     rlPhaseStartCleanup
-        rlRun "popd"
-        rlRun "rm -r $tmp" 0 "Removing tmp directory"
+        rlRun "rm $output" 0 "Remove output file"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/test/select/main.fmf
+++ b/tests/test/select/main.fmf
@@ -1,0 +1,5 @@
+summary: Selecting and filtering tests
+description:
+    Verify selecting tests by name and filter works as expected
+    for 'tmt test ls', 'tmt test show' and 'tmt run test'.
+test: ./test.sh

--- a/tests/test/select/test.sh
+++ b/tests/test/select/test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "output=\$(mktemp)" 0 "Create output file"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    rlPhaseStartTest "tmt test ls"
+        rlRun "tmt test ls | tee $output"
+        rlAssertGrep "/tests/core/docs" $output
+        rlAssertGrep "/tests/core/dry" $output
+    rlPhaseEnd
+
+    rlPhaseStartTest "tmt test ls <name>"
+        rlRun "tmt test ls docs | tee $output"
+        rlAssertGrep "/tests/core/docs" $output
+        rlAssertNotGrep "/tests/core/dry" $output
+    rlPhaseEnd
+
+    rlPhaseStartTest "tmt test ls non-existent"
+        rlRun "tmt test ls non-existent | tee $output"
+        rlRun "[[ $(wc -l <$output) == 0 ]]" 0 "Check no output"
+    rlPhaseEnd
+
+    for filter in '-f' '--filter'; do
+        rlPhaseStartTest "tmt test show $filter <filter>"
+            rlRun "tmt test show $filter tier:0 | tee $output"
+            rlAssertGrep '/tests/core/smoke' $output
+            rlAssertNotGrep "/tests/core/docs" $output
+        rlPhaseEnd
+    done
+
+    for name in '-n' '--name'; do
+        rlPhaseStartTest "tmt run test $name <name>"
+            tmt='tmt run -r plan --name core discover -v'
+            rlRun "$tmt test $name docs | tee $output"
+            rlAssertGrep "/tests/core/docs" $output
+            rlAssertNotGrep "/tests/core/dry" $output
+            rlRun "$tmt test $name non-existent | tee $output"
+            rlAssertGrep "No tests found" $output
+        rlPhaseEnd
+    done
+
+    rlPhaseStartCleanup
+        rlRun "rm $output" 0 "Remove output file"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -69,7 +69,25 @@ def force_dry(function):
 
 
 def name_filter_condition(function):
-    """ Common filter option """
+    """ Common filter options (short & long) """
+    options = [
+        click.argument(
+            'names', nargs=-1, metavar='[REGEXP]'),
+        click.option(
+            '-f', '--filter', 'filters', metavar='FILTER', multiple=True,
+            help="Apply advanced filter (see 'pydoc fmf.filter')."),
+        click.option(
+            '-c', '--condition', 'conditions', metavar="EXPR", multiple=True,
+            help="Use arbitrary Python expression for filtering."),
+        ]
+
+    for option in reversed(options):
+        function = option(function)
+    return function
+
+
+def name_filter_condition_long(function):
+    """ Common filter options (long only) """
     options = [
         click.argument(
             'names', nargs=-1, metavar='[REGEXP]'),
@@ -213,13 +231,13 @@ run.add_command(tmt.steps.Login.command())
 @run.command()
 @click.pass_context
 @click.option(
-    '--name', 'names', metavar='REGEXP', multiple=True,
+    '-n', '--name', 'names', metavar='REGEXP', multiple=True,
     help="Regular expression to match plan name.")
 @click.option(
-    '--filter', 'filters', metavar='FILTER', multiple=True,
+    '-f', '--filter', 'filters', metavar='FILTER', multiple=True,
     help="Apply advanced filter (see 'pydoc fmf.filter').")
 @click.option(
-    '--condition', 'conditions', metavar="EXPR", multiple=True,
+    '-c', '--condition', 'conditions', metavar="EXPR", multiple=True,
     help="Use arbitrary Python expression for filtering.")
 @verbose_debug_quiet
 def plans(context, **kwargs):
@@ -235,13 +253,13 @@ def plans(context, **kwargs):
 @run.command()
 @click.pass_context
 @click.option(
-    '--name', 'names', metavar='REGEXP', multiple=True,
+    '-n', '--name', 'names', metavar='REGEXP', multiple=True,
     help="Regular expression to match test name.")
 @click.option(
-    '--filter', 'filters', metavar='FILTER', multiple=True,
+    '-f', '--filter', 'filters', metavar='FILTER', multiple=True,
     help="Apply advanced filter (see 'pydoc fmf.filter').")
 @click.option(
-    '--condition', 'conditions', metavar="EXPR", multiple=True,
+    '-c', '--condition', 'conditions', metavar="EXPR", multiple=True,
     help="Use arbitrary Python expression for filtering.")
 @verbose_debug_quiet
 def tests(context, **kwargs):
@@ -431,7 +449,7 @@ def import_(
 
 @tests.command()
 @click.pass_context
-@name_filter_condition
+@name_filter_condition_long
 @click.option(
     '--nitrate', is_flag=True,
     help='Export test metadata to Nitrate.')
@@ -594,7 +612,7 @@ def stories(context, **kwargs):
 
 @stories.command()
 @click.pass_context
-@name_filter_condition
+@name_filter_condition_long
 @implemented_tested_documented
 @verbose_debug_quiet
 def ls(
@@ -615,7 +633,7 @@ def ls(
 
 @stories.command()
 @click.pass_context
-@name_filter_condition
+@name_filter_condition_long
 @implemented_tested_documented
 @verbose_debug_quiet
 def show(
@@ -659,7 +677,7 @@ def create(context, name, template, force, **kwargs):
 @click.option(
     '--code', is_flag=True, help='Show code coverage.')
 @click.pass_context
-@name_filter_condition
+@name_filter_condition_long
 @implemented_tested_documented
 @verbose_debug_quiet
 def coverage(
@@ -715,7 +733,7 @@ def coverage(
 
 @stories.command()
 @click.pass_context
-@name_filter_condition
+@name_filter_condition_long
 @implemented_tested_documented
 @click.option(
     '--format', 'format_', default='rst', show_default=True, metavar='FORMAT',


### PR DESCRIPTION
Selecting tests or plans (for example to be executed or listed) is
a very common use case. Let's add short selection options to the
following commands:

    tmt run test
    tmt run plan
    tmt test ls
    tmt plan ls
    tmt test show
    tmt plan show
    tmt test lint
    tmt plan lint

We keep long options only for story commands because of the
collision with '-c' which is already used for '--covered':

    tmt story ls
    tmt story show
    tmt story coverage

Also keep long options only for export because of possible future
collision with '-f' for '--force' when overwriting existing files.

    tmt story export
    tmt test export