### PR TITLE
Handle missing library in existing repository

### DIFF
--- a/tests/discover/libraries/data/certificate.fmf
+++ b/tests/discover/libraries/data/certificate.fmf
@@ -50,5 +50,9 @@ path: /
         destination: custom
 
 /missing:
-    summary: Reference a non-existent library
-    require: library(something/wrong)
+    /repository:
+        summary: Reference a non-existent repository
+        require: library(something/wrong)
+    /library:
+        summary: Reference a non-existent library
+        require: library(openssl/wrong)

--- a/tests/discover/libraries/data/plan.fmf
+++ b/tests/discover/libraries/data/plan.fmf
@@ -42,6 +42,11 @@ execute:
         discover+:
             test: destination
     /missing:
-        summary: "Missing library"
-        discover+:
-            test: missing
+        /library:
+            summary: "Missing library"
+            discover+:
+                test: missing/library
+        /repository:
+            summary: "Missing repository"
+            discover+:
+                test: missing/repository

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -37,8 +37,10 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Missing"
-        rlRun "$tmt missing 2>&1 | tee $tmp/output" 2
+        rlRun "$tmt missing/repository 2>&1 | tee $tmp/output" 2
         rlAssertGrep 'Authentication failed.*something' $tmp/output
+        rlRun "$tmt missing/library 2>&1 | tee $tmp/output" 2
+        rlAssertGrep 'dnf install.*openssl/wrong' $tmp/output
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -128,6 +128,7 @@ class Library(object):
             except tmt.utils.RunError as error:
                 # Fallback to install during the prepare step if in rpm format
                 if self.format == 'rpm':
+                    self.parent.debug(f"Repository '{self.url}' not found.")
                     raise LibraryError
                 self.parent.info(
                     f"Failed to fetch library '{self}' from '{self.url}'.",
@@ -142,6 +143,12 @@ class Library(object):
         # Get the library node, check require and recommend
         library = self.tree.find(self.name)
         if not library:
+            # Fallback to install during the prepare step if in rpm format
+            if self.format == 'rpm':
+                self.parent.debug(
+                    f"Library '{self.name.lstrip('/')}' not found "
+                    f"in the '{self.url}' repo.")
+                raise LibraryError
             raise tmt.utils.GeneralError(
                 f"Library '{self.name}' not found in '{self.repo}'.")
         self.require = tmt.utils.listify(library.get('require', []))


### PR DESCRIPTION
When the library repository is found but the library itself is
missing we should also fallback to installing library as rpm
during the prepare step. This resolves #381.