### PR TITLE
Provide aggregated test metadata for execution

### DIFF
--- a/spec/steps/execute.fmf
+++ b/spec/steps/execute.fmf
@@ -9,6 +9,15 @@ description: |
     This is a **required** attribute. Each plan has to define this
     step.
 
+    For each test, a separate directory is created for storing
+    artifacts related to the test execution. Its path is
+    constructed from the test name and it's stored under the
+    ``execute/logs`` directory. It contains a ``metadata.yaml``
+    file with the aggregated L1 metadata which can be used by the
+    test :ref:`/spec/tests/framework`. In addition to supported
+    :ref:`/spec/tests` attributes it also contains fmf ``name`` of
+    the test.
+
     For each ``plan`` the execute step should produce a
     ``results.yaml`` file with the list of results for each test
     in the following format::
@@ -21,7 +30,6 @@ description: |
             result: OUTCOME
             log: PATH
             duration: DURATION
-
 
     Where ``OUTCOME`` is the result of the test execution. It can
     have the following values:

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -206,6 +206,22 @@ class ExecutePlugin(tmt.steps.Plugin):
         path = os.path.join(directory, filename)
         return path if full else os.path.relpath(path, self.step.workdir)
 
+    def prepare_tests(self):
+        """
+        Prepare discovered tests for testing
+
+        Check which tests have been discovered, for each test prepare
+        the aggregated metadata in a 'metadata.yaml' file under the test
+        logs directory and finally return a list of discovered tests.
+        """
+        tests = self.step.plan.discover.tests()
+        for test in tests:
+            metadata_filename = self.log(
+                test, filename='metadata.yaml', full=True, create=True)
+            self.write(
+                metadata_filename, test.export(keys=['name'] + test._keys))
+        return tests
+
     def check_shell(self, test):
         """ Check result of a shell test """
         # Prepare the log path

--- a/tmt/steps/execute/detach.py
+++ b/tmt/steps/execute/detach.py
@@ -105,9 +105,10 @@ class ExecuteDetach(tmt.steps.execute.ExecutePlugin):
         if self.opt('dry'):
             return
 
-        # Prepare the runner and remove logs
+        # Remove old logs, prepare the runner and tests
         self.remove_logs()
         self.prepare_runner()
+        self.prepare_tests()
 
         # For each guest execute all tests
         for guest in self.step.plan.provision.guests():

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -110,7 +110,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             return
 
         # For each guest execute all tests
-        tests = self.step.plan.discover.tests()
+        tests = self.prepare_tests()
         for guest in self.step.plan.provision.guests():
 
             # Push workdir to guest and execute tests


### PR DESCRIPTION
For each test prepare a 'test.yaml' file with aggregated L1
metadata under the execute step directory so that beakerlib can
pull needed data from there. This is necessary to completely get
rid of the old Makefile approach. See the beakerlib issue for more
details on this: https://github.com/beakerlib/beakerlib/issues/57