### PR TITLE
Correctly handle framework for new plans and tests

### DIFF
--- a/tests/test/lint/test.sh
+++ b/tests/test/lint/test.sh
@@ -17,7 +17,7 @@ rlJournalStart
 
     rlPhaseStartTest "Bad"
         # Remove the test script path
-        rlRun "sed -i '$ s/\s.*$//' test/main.fmf"
+        rlRun "sed -i 's/test:.*/test:/' test/main.fmf"
         rlRun "tmt test lint | tee output" 1
         rlAssertGrep 'fail test script must be defined' output
     rlPhaseEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -275,7 +275,7 @@ class Test(Node):
         # Create metadata
         metadata_path = os.path.join(directory_path, 'main.fmf')
         tmt.utils.create_file(
-            path=metadata_path, content=tmt.templates.TEST_METADATA,
+            path=metadata_path, content=tmt.templates.TEST_METADATA[template],
             name='test metadata', force=force)
 
         # Create script

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -160,7 +160,7 @@ def read(path, makefile, nitrate, purpose, disabled):
     data for individual testcases (if multiple nitrate testcases found).
     """
 
-    data = dict()
+    data = dict(framework='beakerlib')
     echo("Checking the '{0}' directory.".format(path))
 
     # Make sure there is a metadata tree initialized

--- a/tmt/templates.py
+++ b/tmt/templates.py
@@ -7,11 +7,17 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 TEST = dict()
+TEST_METADATA = dict()
 
-TEST_METADATA = """
+TEST_METADATA['shell'] = """
 summary: Concise summary describing what the test does
-contact: Name Surname <email@example.com>
 test: ./test.sh
+""".lstrip()
+
+TEST_METADATA['beakerlib'] = """
+summary: Concise summary describing what the test does
+test: ./test.sh
+framework: beakerlib
 """.lstrip()
 
 TEST['shell'] = """
@@ -56,7 +62,7 @@ DEFAULT_PLAN = """
     discover:
         how: fmf
     execute:
-        how: shell.tmt
+        how: tmt
 """.lstrip()
 
 PLAN = dict()
@@ -74,7 +80,7 @@ summary:
 discover:
     how: fmf
 execute:
-    how: beakerlib
+    how: tmt
 """.lstrip()
 
 PLAN['full'] = """
@@ -87,7 +93,7 @@ prepare:
     how: ansible
     playbooks: plans/packages.yml
 execute:
-    how: beakerlib
+    how: tmt
 """.lstrip()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Set framework when creating and importing tests.
Update plan templates to use the internal executor.