### PR TITLE
Handle testcloud problem with the images directory

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -391,6 +391,10 @@ class GuestTestcloud(tmt.Guest):
             self.image.prepare()
         except FileNotFoundError:
             raise ProvisionError(f"Image '{self.image.local_path}' not found.")
+        except testcloud.exceptions.TestcloudPermissionsError:
+            raise ProvisionError(
+                f"Failed to prepare the image. "
+                f"Check the '{TESTCLOUD_IMAGES}' directory permissions.")
 
         # Create instance
         self.instance_name = self._random_name()


### PR DESCRIPTION
Should be merged only after the [testcloud change](https://pagure.io/testcloud/pull-request/65) is released and the new exception is available.