### PR TITLE
Convert adds extra-summary as well

### DIFF
--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -233,6 +233,7 @@ def read(path, makefile, nitrate, purpose, disabled):
             beaker_task = re.search(r'Name:\s*(.*)\n', testinfo).group(1)
             echo(style('task: ', fg='green') + beaker_task)
             data['extra-task'] = beaker_task
+            data['extra-summary'] = beaker_task
         except AttributeError:
             raise ConvertError("Unable to parse 'Name' from testinfo.desc.")
         # Summary


### PR DESCRIPTION
Having this temporary attribute in main.fmf allows virtual testcases to
easily append suffixes so they are distinguishable from TCMS (when
exported)

E.g.
main.fmf -> extra-task: /Script, extra-summary: /Script
python2.fmf -> extra-summary+: " (python2)"
python3.fmf -> extra-summary+: " (python3)"

Export then creates two cases with script = /Script and named
/Script (python2)
/Script (python3)