### PR TITLE
Correct type of Tier attribute in examples

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -152,7 +152,7 @@ condition::
     $ tmt tests ls --filter 'tier: 0'
     /tests/docs
 
-    $ tmt tests ls --condition 'tier > 0'
+    $ tmt tests ls --condition 'int(tier) > 0'
     /tests/ls
 
 In order to select tests under the current working directory use

--- a/stories/cli/test.fmf
+++ b/stories/cli/test.fmf
@@ -117,6 +117,7 @@ story: 'As a user I want to comfortably work with tests'
         - tmt test ls .
         - tmt test ls REGEXP
         - tmt test show --filter tier:1
-        - tmt test show --condition 'tier < 2'
+        - tmt test show --condition 'int(tier) < 2'
+        - tmt test show --condition '"gcc" in require'
     implemented: /tmt/base.py
     documented: /docs/examples#filter-tests


### PR DESCRIPTION
Just changing the examples. 
Fix #358