### PR TITLE
Send warnings to stderr, introduce a fail() method

### DIFF
--- a/tests/execute/framework/test.sh
+++ b/tests/execute/framework/test.sh
@@ -23,7 +23,8 @@ rlJournalStart
     for execute in tmt detach; do
         for framework in shell beakerlib; do
             rlPhaseStartTest "Old execute methods ($framework.$execute)"
-                rlRun "$tmt execute -h $framework.$execute | tee output" 0,2
+                rlRun "$tmt execute -h $framework.$execute \
+                        2>&1 | tee output" 0,2
                 rlAssertGrep 'execute method has been deprecated' output
                 # Default framework should be picked from the old method
                 rlAssertGrep "Execute '$sh1' as a '$framework' test." output
@@ -35,7 +36,7 @@ rlJournalStart
                 if [[ $framework == beakerlib ]]; then
                     rlAssertGrep "dnf install.*beakerlib" output
                 fi
-                rlAssertGrep "warning.*execute.*deprecated" output
+                rlAssertGrep "warn.*execute.*deprecated" output
             rlPhaseEnd
         done
     done
@@ -43,7 +44,7 @@ rlJournalStart
     # New execute methods
     for execute in tmt detach; do
         rlPhaseStartTest "Combine shell and beakerlib ($execute)"
-            rlRun "$tmt execute --how $execute | tee output"
+            rlRun "$tmt execute --how $execute 2>&1 | tee output"
             # The default test framework should be 'shell'
             rlAssertGrep "Execute '$sh1' as a 'shell' test." output
             rlAssertGrep "Execute '$bl1' as a 'shell' test." output

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -198,27 +198,32 @@ class Common(object):
         with open(os.path.join(self.workdir, 'log.txt'), 'a') as log:
             log.write(message + '\n')
 
-    def info(self, key, value=None, color=None, shift=0):
+    def info(self, key, value=None, color=None, shift=0, err=False):
         """ Show a message unless in quiet mode """
         self._log(self._indent(key, value, color=None, shift=shift))
         if not self.opt('quiet'):
-            echo(self._indent(key, value, color, shift))
+            echo(self._indent(key, value, color, shift), err=err)
 
     def warn(self, message, shift=0):
-        """ Show a yellow warning message on info level """
-        self.info('warning', message, color='yellow', shift=shift)
+        """ Show a yellow warning message on info level, send to stderr """
+        self.info('warn', message, color='yellow', shift=shift, err=True)
 
-    def verbose(self, key, value=None, color=None, shift=0, level=1):
+    def fail(self, message, shift=0):
+        """ Show a red failure message on info level, send to stderr """
+        self.info('fail', message, color='red', shift=shift, err=True)
+
+    def verbose(
+        self, key, value=None, color=None, shift=0, level=1, err=False):
         """ Show message if in requested verbose mode level """
         self._log(self._indent(key, value, color=None, shift=shift))
         if self.opt('verbose') >= level:
-            echo(self._indent(key, value, color, shift))
+            echo(self._indent(key, value, color, shift), err=err)
 
-    def debug(self, key, value=None, color=None, shift=1, level=1):
+    def debug(self, key, value=None, color=None, shift=1, level=1, err=False):
         """ Show message if in requested debug mode level """
         self._log(self._indent(key, value, color=None, shift=shift))
         if self.opt('debug') >= level:
-            echo(self._indent(key, value, color, shift))
+            echo(self._indent(key, value, color, shift), err=err)
 
     def _run(
         self, command, cwd, shell, env, log, join=False, interactive=False,


### PR DESCRIPTION
Both warn() and fail() send their output to stderr.
Add a new 'err' parameter to all logging methods.
Adjust relevant test coverage accordingly.