### PR TITLE
Always run Login plugin even if step is done

### DIFF
--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -32,6 +32,12 @@ rlJournalStart
         rlAssertGrep "interactive" "output"
     rlPhaseEnd
 
+    rlPhaseStartTest "Last run"
+        rlRun "$tmt"
+        rlRun "tmt run -l login -c true | tee output"
+        rlAssertGrep "interactive" "output"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $tmp" 0 "Removing tmp directory"

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -159,6 +159,12 @@ class Step(tmt.utils.Common):
                 if classes is None or isinstance(plugin, classes)],
             key=lambda plugin: plugin.order)
 
+    def try_running_login(self):
+        """ Run all loaded Login plugin instances of the step """
+        for plugin in self.plugins():
+            if isinstance(plugin, Login):
+                plugin.go()
+
     def go(self):
         """ Execute the test step """
         # Show step header and how

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -115,6 +115,7 @@ class Discover(tmt.steps.Step):
         if self.status() == 'done':
             self.info('status', 'done', 'green', shift=1)
             self.summary()
+            self.try_running_login()
             return
 
         # Perform test discovery, gather discovered tests

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -120,6 +120,7 @@ class Execute(tmt.steps.Step):
         if self.status() == 'done':
             self.info('status', 'done', 'green', shift=1)
             self.summary()
+            self.try_running_login()
             return
 
         # Make sure that guests are prepared

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -56,6 +56,7 @@ class Finish(tmt.steps.Step):
         if self.status() == 'done':
             self.info('status', 'done', 'green', shift=1)
             self.summary()
+            self.try_running_login()
             return
 
         # Go and execute each plugin on all guests

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -56,6 +56,7 @@ class Prepare(tmt.steps.Step):
         if self.status() == 'done':
             self.info('status', 'done', 'green', shift=1)
             self.summary()
+            self.try_running_login()
             return
 
         # Required packages

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -84,6 +84,7 @@ class Provision(tmt.steps.Step):
         if self.status() == 'done':
             self.info('status', 'done', 'green', shift=1)
             self.summary()
+            self.try_running_login()
             return
 
         # Provision guests

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -47,6 +47,7 @@ class Report(tmt.steps.Step):
         if self.status() == 'done':
             self.info('status', 'done', 'green', shift=1)
             self.summary()
+            self.try_running_login()
             return
 
         # Perform the reporting


### PR DESCRIPTION
This allows connecting to a machine provisioned in the last run (which can be useful for debugging). So running
```
tmt run provision -h container
tmt run -l login
```
now works as expected.

Resolves: #284 