### PR TITLE
Preserve symlinks during discover, pull and push

### DIFF
--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -118,7 +118,9 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             self.info('directory', git_root, 'green')
             self.debug(f"Copy '{git_root}' to '{testdir}'.")
             if not self.opt('dry'):
-                shutil.copytree(git_root, testdir)
+                shutil.copytree(
+                    git_root, testdir,
+                    symlinks=True, ignore_dangling_symlinks=True)
 
         # Checkout revision if requested
         ref = self.get('ref')

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -80,7 +80,9 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
         if directory:
             self.info('directory', directory, 'green')
             self.debug("Copy '{}' to '{}'.".format(directory, testdir))
-            shutil.copytree(directory, testdir)
+            shutil.copytree(
+                directory, testdir,
+                symlinks=True, ignore_dangling_symlinks=True)
         else:
             os.makedirs(testdir)
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -369,14 +369,16 @@ class Guest(tmt.utils.Common):
         """ Push workdir to guest """
         self.debug(f"Push workdir to guest '{self.guest}'.")
         self.run(
-            f'rsync -Rrze "{self._ssh_command(join=True)}" --delete '
-            f'{self.parent.plan.workdir} {self._ssh_guest()}:/')
+            f'rsync -Rrz --links --safe-links --delete '
+            f'-e "{self._ssh_command(join=True)}" '
+            f'--safe-links {self.parent.plan.workdir} {self._ssh_guest()}:/')
 
     def pull(self):
         """ Pull workdir from guest """
         self.debug(f"Pull workdir from guest '{self.guest}'.")
         self.run(
-            f'rsync -Rrze "{self._ssh_command(join=True)}" '
+            f'rsync -Rrz --links --safe-links '
+            f'-e "{self._ssh_command(join=True)}" '
             f'{self._ssh_guest()}:{self.parent.plan.workdir} /')
 
     def stop(self):


### PR DESCRIPTION
Make sure symlinks are correctly copied to workdir.
Resolves #402.