### PR TITLE
Improve minute provision image selection

### DIFF
--- a/tmt/steps/provision/minute.py
+++ b/tmt/steps/provision/minute.py
@@ -307,7 +307,7 @@ class GuestMinute(tmt.Guest):
             mt_image = f'1MT-Fedora-{fedora_match.group("ver")}'
 
         # RHEL shortened names
-        rhel_match = re.match(r'^rhel-?(?P<ver>\d+)$', image_lower)
+        rhel_match = re.match(r'^rhel-?(?P<ver>\d+(?:\.\d)*)$', image_lower)
         if rhel_match:
             rhel_re = re.compile(r'1MT-RHEL-*{}'.format(
                 re.escape(rhel_match.group('ver'))))
@@ -326,7 +326,7 @@ class GuestMinute(tmt.Guest):
             mt_image = f'1MT-CentOS-{centos_match.group("ver")}'
 
         # Check if the image is valid
-        if not mt_image in images:
+        if mt_image not in images:
             raise tmt.utils.ProvisionError(
                 f"Image '{image}' is not a valid 1minutetip image.")
         return mt_image


### PR DESCRIPTION
This PR improves the following:
- RHEL exact version can easily be specified using short image name (e.g. `rhel-8.1` or `rhel8.1.0`)
- Latest images are now chosen from released images, so `provision -i fedora` now results in F32 instead of F33. The same goes for RHEL (the difference is that with RHEL, if a released image matching the user input doesn't exist, minute now tries to use unreleased image. This allows easily specifying beta versions).

Resolves: #335 