### PR TITLE
Simplify test directory copy with enabled symlinks

### DIFF
--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -118,9 +118,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             self.info('directory', git_root, 'green')
             self.debug(f"Copy '{git_root}' to '{testdir}'.")
             if not self.opt('dry'):
-                shutil.copytree(
-                    git_root, testdir,
-                    symlinks=True, ignore_dangling_symlinks=True)
+                shutil.copytree(git_root, testdir, symlinks=True)
 
         # Checkout revision if requested
         ref = self.get('ref')

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -80,9 +80,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
         if directory:
             self.info('directory', directory, 'green')
             self.debug("Copy '{}' to '{}'.".format(directory, testdir))
-            shutil.copytree(
-                directory, testdir,
-                symlinks=True, ignore_dangling_symlinks=True)
+            shutil.copytree(directory, testdir, symlinks=True)
         else:
             os.makedirs(testdir)
 


### PR DESCRIPTION
The `ignore_dangling_symlinks` parameter of `copytree` has no
effect when `symlinks` is True so let's remove it.