### PR TITLE
Multiple enhancements for package preparation

### DIFF
--- a/tests/prepare/require/test.sh
+++ b/tests/prepare/require/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
 
     rlPhaseStartTest "Require a missing package"
         rlRun "tmt run plan --name missing | tee output" 2
-        rlAssertGrep 'package forest is not installed' output
+        rlAssertGrep 'Unable to find a match: forest' output
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -60,7 +60,8 @@ class Prepare(tmt.steps.Step):
             return
 
         # Required packages
-        requires = self.plan.discover.requires() + self.plan.execute.requires()
+        requires = list(set(
+            self.plan.discover.requires() + self.plan.execute.requires()))
         if requires:
             data = dict(
                 how='install',

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -199,9 +199,19 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
 
         # Install from repositories
         if repo_packages:
-            summary = fmf.utils.listed(repo_packages, max=3)
-            self.info('package', summary, 'green')
+            # Show a brief summary by default
+            if not self.opt('verbose'):
+                summary = fmf.utils.listed(repo_packages, max=3)
+                self.info('package', summary, 'green')
+            # Provide a full list of packages in verbose mode
+            else:
+                summary = fmf.utils.listed(repo_packages, 'package')
+                self.info('package', summary + ' requested', 'green')
+                for package in sorted(repo_packages):
+                    self.verbose(package, shift=1)
+            # Quote package names and install
             packages = ' '.join(
-                [tmt.utils.quote(package) for package in packages])
+                [tmt.utils.quote(package) for package in repo_packages])
             guest.execute(
-                f'rpm -q {packages} || {command} install -y {packages}')
+                f'{command} --cacheonly install -y {packages} || '
+                f'{command} install -y {packages}')


### PR DESCRIPTION
Remove duplicate entries for required packages.
Show a full list of packages in verbose mode.
Use `dnf/yum --cacheonly` instead of `rpm -q`.

Resolves #401.