### PR TITLE
Support libraries stored deep in the repositories

### DIFF
--- a/tests/discover/libraries/data/file.fmf
+++ b/tests/discover/libraries/data/file.fmf
@@ -1,0 +1,8 @@
+summary: A simple test for the file command
+description:
+    Requires a library stored deep in the directory structure.
+test: ./file.sh
+path: /
+require:
+  - url: https://github.com/beakerlib/test
+    name: /very/deep/file

--- a/tests/discover/libraries/data/file.sh
+++ b/tests/discover/libraries/data/file.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm "coreutils"
+        rlRun "rlImport test/file"
+        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $tmp"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun fileCreate
+        rlAssertExists $fileFILENAME
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/discover/libraries/data/plan.fmf
+++ b/tests/discover/libraries/data/plan.fmf
@@ -5,6 +5,11 @@ provision:
 execute:
     how: beakerlib.tmt
 
+/file:
+    summary: "Simple test for the file command"
+    discover+:
+        test: file
+
 /apache:
     summary: "Apache test (library requires another library)"
     discover+:

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -47,6 +47,11 @@ rlJournalStart
         rlAssertGrep 'Reference .* not found.' $tmp/output
     rlPhaseEnd
 
+    rlPhaseStartTest "Deep"
+        rlRun "$tmt file 2>&1 | tee $tmp/output"
+        rlAssertGrep 'the library is stored deep.' $tmp/output
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $tmp" 0 "Removing tmp directory"

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -167,6 +167,22 @@ class Library(object):
         self.require = tmt.utils.listify(library.get('require', []))
         self.recommend = tmt.utils.listify(library.get('recommend', []))
 
+        # Create a symlink if the library is deep in the structure
+        # FIXME: hot fix for https://github.com/beakerlib/beakerlib/pull/72
+        # Covers also cases when library is stored more than 2 levels deep
+        if os.path.dirname(self.name).lstrip('/'):
+            link = self.name.lstrip('/')
+            path = os.path.join(self.tree.root, os.path.basename(self.name))
+            self.parent.debug(
+                f"Create a '{link}' symlink as the library is stored "
+                f"deep in the directory structure.")
+            try:
+                os.symlink(link, path)
+            except OSError as error:
+                self.parent.warn(
+                    f"Unable to create a '{link}' symlink "
+                    f"for a deep library ({error}).")
+
 
 def dependencies(original_require, original_recommend=None, parent=None):
     """


### PR DESCRIPTION
This also covers recently reported problem with importing internal libraries using the full fmf identifier. Would be good to have fixed for the Thursday hacking session. Please, review soon if possible.