### PR TITLE
Allow selecting only tests that have changed in git

### DIFF
--- a/spec/steps/discover.fmf
+++ b/spec/steps/discover.fmf
@@ -88,18 +88,21 @@ description: |
 
         See also the `fmf identifier`_ documentation.
 
-        It is also possible to limit tests only to those that have changed in git
-        since a given revision. This can be particularly useful when testing
-        changes to tests themselves (e.g. in a pull request CI).
+        It is also possible to limit tests only to those that have
+        changed in git since a given revision. This can be
+        particularly useful when testing changes to tests
+        themselves (e.g. in a pull request CI).
 
         Related config options (all optional):
 
         modified-only
-            set to True if you want to filter modified tests
+            Set to True if you want to filter modified tests only.
         modified-url
-            will be fetched as "reference" remote in the test dir
+            Will be fetched as a "reference" remote in the test
+            dir.
         modified-ref
-            the ref to compare against
+            The ref to compare against, ``master`` branch is used
+            by default.
 
         .. _fmf identifier: https://fmf.readthedocs.io/en/latest/concept.html#identifiers
         .. _Flexible Metadata Format: https://fmf.readthedocs.io/

--- a/spec/steps/discover.fmf
+++ b/spec/steps/discover.fmf
@@ -88,6 +88,19 @@ description: |
 
         See also the `fmf identifier`_ documentation.
 
+        It is also possible to limit tests only to those that have changed in git
+        since a given revision. This can be particularly useful when testing
+        changes to tests themselves (e.g. in a pull request CI).
+
+        Related config options (all optional):
+
+        modified-only
+            set to True if you want to filter modified tests
+        modified-url
+            will be fetched as "reference" remote in the test dir
+        modified-ref
+            the ref to compare against
+
         .. _fmf identifier: https://fmf.readthedocs.io/en/latest/concept.html#identifiers
         .. _Flexible Metadata Format: https://fmf.readthedocs.io/
     example: |

--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -51,3 +51,10 @@ execute:
             /nopath:
                 discover:
                     how: fmf
+    /modified-only:
+        discover:
+            how: fmf
+            path: ../../..
+            ref: 8329db0421e9
+            modified-only: true
+            modified-ref: 8329db0421e9^

--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -51,10 +51,10 @@ execute:
             /nopath:
                 discover:
                     how: fmf
-    /modified-only:
+    /modified:
         discover:
             how: fmf
             path: ../../..
-            ref: 8329db0421e9
+            ref: 8329db0
             modified-only: true
-            modified-ref: 8329db0421e9^
+            modified-ref: 8329db0^

--- a/tests/discover/main.fmf
+++ b/tests/discover/main.fmf
@@ -12,6 +12,10 @@ path: /tests/discover
     test: ./references.sh
     tier: 2
 
+/modified-only:
+    summary: Check filtering for tests modified since a given ref
+    test: ./modified-only.sh
+
 /filtering:
     summary: Test selection by name and advanced filter
     test: ./filtering.sh

--- a/tests/discover/main.fmf
+++ b/tests/discover/main.fmf
@@ -12,9 +12,9 @@ path: /tests/discover
     test: ./references.sh
     tier: 2
 
-/modified-only:
+/modified:
     summary: Check filtering for tests modified since a given ref
-    test: ./modified-only.sh
+    test: ./modified.sh
 
 /filtering:
     summary: Test selection by name and advanced filter

--- a/tests/discover/modified-only.sh
+++ b/tests/discover/modified-only.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun 'set -o pipefail'
+    rlPhaseEnd
+
+    rlPhaseStartTest 'Command-line'
+        rlRun 'tmt run -dv discover --how fmf  --ref 8329db0421e9 \
+            --modified-only --modified-ref 8329db0421e9^ \
+            | tee output'
+        rlAssertGrep 'summary: 1 test selected' output
+        rlAssertGrep '/tests/core/adjust' output
+    rlPhaseEnd
+
+    rlPhaseStartTest 'Plan'
+        rlRun 'env -C data tmt run -dv discover plan -n fmf/modified-only | tee output'
+        rlAssertGrep 'summary: 1 test selected' output
+        rlAssertGrep '/tests/core/adjust' output
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun 'rm -f output' 0 'Removing tmp file'
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/discover/modified.sh
+++ b/tests/discover/modified.sh
@@ -8,20 +8,21 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest 'Command-line'
-        rlRun 'tmt run -dv discover --how fmf  --ref 8329db0421e9 \
-            --modified-only --modified-ref 8329db0421e9^ \
-            | tee output'
+        rlRun 'tmt run -rdv discover --how fmf --ref 8329db0 \
+            --modified-only --modified-ref 8329db0^ \
+            plan -n features/core finish | tee output'
         rlAssertGrep 'summary: 1 test selected' output
         rlAssertGrep '/tests/core/adjust' output
     rlPhaseEnd
 
     rlPhaseStartTest 'Plan'
-        rlRun 'env -C data tmt run -dv discover plan -n fmf/modified-only | tee output'
+        rlRun 'env -C data tmt run -rdv discover \
+            plan -n fmf/modified finish | tee output'
         rlAssertGrep 'summary: 1 test selected' output
         rlAssertGrep '/tests/core/adjust' output
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun 'rm -f output' 0 'Removing tmp file'
+        rlRun 'rm -f output' 0 'Remove tmp file'
     rlPhaseEnd
 rlJournalEnd

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -151,6 +151,8 @@ class Common(object):
         mode for all included plans and steps). Environment variables
         override command line options.
         """
+        # Translate dashes to underscores to match click's conversion
+        option = option.replace('-', '_')
         # Check the environment first
         if option == 'debug':
             try:


### PR DESCRIPTION
If the plan specifies 'modified_only: True' ('--modified-only' on the
command-line), filter the tests only to those that were modified
relative to 'reference_ref' git ref ('master' by default).

This will enable testing changes to tests (e.g. in pull request CI) via
a static plan stored in the target git repository.

---
Does this make sense or am I going in the wrong direction?