### PR TITLE
Use 'output.txt' filename for the main test output

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -10,6 +10,9 @@ TEST_DATA = 'data'
 # Default test framework
 DEFAULT_FRAMEWORK = 'shell'
 
+# The main test output filename
+TEST_OUTPUT_FILENAME = 'output.txt'
+
 
 class Execute(tmt.steps.Step):
     """
@@ -226,7 +229,7 @@ class ExecutePlugin(tmt.steps.Plugin):
     def check_shell(self, test):
         """ Check result of a shell test """
         # Prepare the log path
-        data = {'log': self.data_path(test, 'out.log')}
+        data = {'log': self.data_path(test, TEST_OUTPUT_FILENAME)}
         # Process the exit code
         try:
             data['result'] = {0: 'pass', 1: 'fail'}[test.returncode]
@@ -241,7 +244,7 @@ class ExecutePlugin(tmt.steps.Plugin):
         """ Check result of a beakerlib test """
         # Initialize data, prepare log paths
         data = {'result': 'error', 'log': []}
-        for log in ['out.log', 'journal.txt']:
+        for log in [TEST_OUTPUT_FILENAME, 'journal.txt']:
             if os.path.isfile(self.data_path(test, log, full=True)):
                 data['log'].append(self.data_path(test, log))
         # Check beakerlib log for the result

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -1,7 +1,9 @@
 import os
-import tmt
 import time
 import click
+
+import tmt
+from tmt.steps.execute import TEST_OUTPUT_FILENAME
 
 
 class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
@@ -85,7 +87,8 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
                 self.debug(f"Test duration '{test.duration}' exceeded.")
         end = time.time()
         self.write(
-            self.data_path(test, 'out.log', full=True), stdout or '', level=3)
+            self.data_path(test, TEST_OUTPUT_FILENAME, full=True),
+            stdout or '', level=3)
         duration = time.strftime("%H:%M:%S", time.gmtime(end - start))
         duration = click.style(duration, fg='cyan')
         shift = 1 if self.opt('verbose') < 2 else 2

--- a/tmt/steps/execute/run.sh
+++ b/tmt/steps/execute/run.sh
@@ -26,7 +26,7 @@ tmt_TESTS_D='discover'
 tmt_TESTS_F="${tmt_TESTS_D}/run.yaml"
 
 tmt_LOG_D='execute'
-tmt_LOGOUT_F="out.log"
+tmt_LOGOUT_F="output.txt"
 tmt_LOGCODE_F="exitcode.log"
 tmt_JOURNAL_F="journal.txt"
 

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -1,6 +1,7 @@
 import os
 
 import tmt
+from tmt.steps.execute import TEST_OUTPUT_FILENAME
 
 class ReportDisplay(tmt.steps.report.ReportPlugin):
     """
@@ -17,7 +18,7 @@ class ReportDisplay(tmt.steps.report.ReportPlugin):
         """ Print result details based on the verbose mode """
         # -v prints just result + name
         # -vv prints path to logs
-        # -vvv prints also content of out.log
+        # -vvv prints also test output
         self.verbose(result.show(), shift=1)
         if verbosity == 1:
             return
@@ -27,8 +28,8 @@ class ReportDisplay(tmt.steps.report.ReportPlugin):
             full_path = os.path.join(self.step.plan.execute.workdir, log_file)
             # List path to logs (-vv and more)
             self.verbose(log_name, full_path, color='yellow', shift=2)
-            # Show content of out.log (-vvv and more)
-            if verbosity > 2 and log_name in ['out.log']:
+            # Show the whole test output (-vvv and more)
+            if verbosity > 2 and log_name == TEST_OUTPUT_FILENAME:
                 self.verbose(
                     'content', self.read(full_path), color='yellow', shift=2)
 


### PR DESCRIPTION
This allows to directly open logs from the html report.
Otherwise firefox would always ask which editor to use.