### PR TITLE
Update required fmf version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ __scripts__ = ['bin/tmt']
 
 # Prepare install requires and extra requires
 install_requires = [
-    'fmf>=0.9.2',
+    'fmf>=0.13.0',
     'click',
     'requests',
 ]


### PR DESCRIPTION
Since PR #443 , fmf version 0.9.2 is no longer sufficient to run tmt on master branch due to using `Tree.adjust()` method which was introduced in 0.13. Update the required fmf version.