### PR TITLE
Implement tmt status command

### DIFF
--- a/tests/status/base/main.fmf
+++ b/tests/status/base/main.fmf
@@ -1,0 +1,2 @@
+summary: Checks whether tmt status works correctly
+test: ./test.sh

--- a/tests/status/base/test.sh
+++ b/tests/status/base/test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "tmt init"
+        rlRun "tmt plan create -t mini plan1"
+        rlRun "tmt plan create -t mini plan2"
+        rlRun "tmt run -a -S report provision -h local | tee run-output"
+        rlRun "runid=\$(head -n 1 run-output)" 0 "Get the run ID"
+    rlPhaseEnd
+
+    rlPhaseStartTest "No verbosity"
+        rlRun "tmt status | tee output"
+        rlAssertGrep "done\s+$runid" "output" -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verbose"
+        rlRun "tmt status -v | tee output"
+        rlAssertGrep "done\s+$runid\s+/plan1" "output" -E
+        rlAssertGrep "done\s+$runid\s+/plan2" "output" -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Very verbose"
+        rlRun "tmt status -vv | tee output"
+        rlAssertGrep "(done\s+){4}todo\s+done\s+$runid\s+/plan1" "output" -E
+        rlAssertGrep "(done\s+){4}todo\s+done\s+$runid\s+/plan2" "output" -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Specify ID"
+        rlRun "tmt status -i $runid | tee output"
+        rlAssertGrep "done\s+$runid" "output" -E
+        rlRun "wc -l output | tee lines" 0 "Get the number of lines"
+        rlLog "There should be the heading and one run"
+        rlAssertGrep "2" "lines"
+
+        rlRun "tmt status -i /not/a/valid/runid | tee output" 0 "Use an invalid ID"
+        rlRun "wc -l output | tee lines" 0 "Get the number of lines"
+        rlLog "There should only be the heading"
+        rlAssertGrep "1" "lines"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Different root"
+        rlRun "tmprun=\$(mktemp -d)" 0 "Create a temporary directory for runs"
+        rlRun "tmt run -a -i $tmprun/run provision -h local"
+        rlRun "tmt status $tmprun | tee output"
+        rlRun "wc -l output | tee lines" 0 "Get the number of lines"
+        rlLog "The status should only show one run and its heading"
+        rlAssertGrep "2" "lines"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Filters"
+        rlRun "tmt status --finished | tee output"
+        rlAssertGrep "done\s+$runid" "output" -E
+        rlRun "tmt run provision -h local | tee run-output"
+        rlRun "runid=\$(head -n 1 run-output)" 0 "Get the run ID"
+        rlRun "tmt status --abandoned | tee output"
+        rlAssertGrep "done\s+$runid" "output" -E
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "tmt run -i $runid finish" 0 "Get rid of an active provision"
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+        rlRun "rm -r $tmprun" 0 "Remove a temporary directory for runs"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/status/base/test.sh
+++ b/tests/status/base/test.sh
@@ -38,7 +38,7 @@ rlJournalStart
         rlLog "There should be the heading and one run"
         rlAssertGrep "2" "lines"
 
-        rlRun "tmt status -i /not/a/valid/runid | tee output" 0 "Use an invalid ID"
+        rlRun "tmt status -i /not/a/valid/runid | tee output" 0 "Invalid ID"
         rlRun "wc -l output | tee lines" 0 "Get the number of lines"
         rlLog "There should only be the heading"
         rlAssertGrep "1" "lines"
@@ -60,6 +60,11 @@ rlJournalStart
         rlRun "runid=\$(head -n 1 run-output)" 0 "Get the run ID"
         rlRun "tmt status --abandoned | tee output"
         rlAssertGrep "done\s+$runid" "output" -E
+        rlRun "tmt run -a provision -h local prepare -h shell -s false \
+            | tee run-output" 2 "Let the prepare step fail"
+        rlRun "runid=\$(head -n 1 run-output)" 0 "Get the run ID"
+        rlRun "tmt status --active | tee output"
+        rlAssertGrep "todo\s+$runid" "output" -E
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/__init__.py
+++ b/tmt/__init__.py
@@ -1,6 +1,6 @@
 """ Test Management Tool """
 
-from tmt.base import Tree, Test, Plan, Story, Run, Result
+from tmt.base import Tree, Test, Plan, Story, Run, Result, Status
 from tmt.steps.provision import Guest
 
-__all__ = ['Tree', 'Test', 'Plan', 'Story', 'Run', 'Guest', 'Result']
+__all__ = ['Tree', 'Test', 'Plan', 'Story', 'Run', 'Guest', 'Result', 'Status']

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -890,6 +890,14 @@ class Run(tmt.utils.Common):
         self._environment = dict()
         self.remove = self.opt('remove')
 
+    def _use_default_plan(self):
+        """ Prepare metadata tree with only the default plan """
+        default_plan = tmt.utils.yaml_to_dict(tmt.templates.DEFAULT_PLAN)
+        # The default discover method for this case is 'shell'
+        default_plan['/plans/default']['discover']['how'] = 'shell'
+        self.tree = tmt.Tree(tree=fmf.Tree(default_plan))
+        self.debug(f"No metadata found, using the default plan.")
+
     def _save_tree(self, tree):
         """ Save metadata tree, handle the default plan """
         default_plan = tmt.utils.yaml_to_dict(tmt.templates.DEFAULT_PLAN)
@@ -902,10 +910,7 @@ class Run(tmt.utils.Common):
                 self.debug(f"No plan found, adding the default plan.")
         # Create an empty default plan if no fmf metadata found
         except tmt.utils.MetadataError:
-            # The default discover method for this case is 'shell'
-            default_plan['/plans/default']['discover']['how'] = 'shell'
-            self.tree = tmt.Tree(tree=fmf.Tree(default_plan))
-            self.debug(f"No metadata found, using the default plan.")
+            self._use_default_plan()
 
     @property
     def environment(self):
@@ -936,7 +941,12 @@ class Run(tmt.utils.Common):
         # If run id was given and root was not explicitly specified,
         # create a new Tree from the root in run.yaml
         if self._workdir and 'root' in data and not self.opt('root'):
-            self._save_tree(tmt.Tree(data['root']) if data['root'] else None)
+            if data['root']:
+                self._save_tree(tmt.Tree(data['root']))
+            else:
+                # The run was used without any metadata, default plan
+                # was used, load it
+                self._use_default_plan()
 
         # Filter plans by name unless specified on the command line
         plan_options = ['names', 'filters', 'conditions']

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1240,8 +1240,14 @@ class Status(tmt.utils.Common):
                 os.path.join(abs_path, 'run.yaml'))
             if not os.path.isdir(abs_path) or invalid_id or invalid_run:
                 continue
+            # Creating a and loading a run may override the data in the
+            # context which could affect the status of the following runs.
+            # Backup the inner context object to later recover it to
+            # its initial state.
+            backup = copy.deepcopy(self._context.obj)
             run = Run(abs_path, self._context.obj.tree, self._context)
             self.process_run(run)
+            self._context.obj = backup
 
 
 class Result(object):

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1192,7 +1192,7 @@ class Status(tmt.utils.Common):
         for plan in run.plans:
             if self.plan_matches_filters(plan):
                 for step in plan.steps(disabled=True):
-                    column = step.status() + ' '
+                    column = (step.status() or '----') + ' '
                     echo(self.colorize_column(column), nl=False)
                 echo(f' {run.workdir}  {plan.name}')
 

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -835,3 +835,47 @@ def init(context, path, template, force, **kwargs):
         tmt.Test.create('/tests/example', 'shell', tree, force)
         tmt.Plan.create('/plans/example', 'full', tree, force)
         tmt.Story.create('/stories/example', 'full', tree, force)
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Status
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+@main.command()
+@click.pass_context
+@click.argument('path', default=tmt.utils.WORKDIR_ROOT)
+@click.option(
+    '-i', '--id', help=
+    'Run id (name or directory path) to show status of.', metavar="ID")
+@click.option(
+    '--abandoned', is_flag=True, default=False,
+    help='List runs which have provision step completed but finish step '
+         'not yet done.')
+@click.option(
+    '--active', is_flag=True, default=False,
+    help='List runs where at least one of the enabled steps has not '
+         'been finished.')
+@click.option(
+    '--finished', is_flag=True, default=False,
+    help='List all runs which have all enabled steps completed.')
+@verbose_debug_quiet
+def status(context, path, abandoned, active, finished, **kwargs):
+    """
+    Show status of runs.
+
+    Lists past runs in the given directory filtered using options.
+    /var/tmp/tmt is used by default.
+
+    By default, status of the whole runs is listed. With more
+    verbosity (-v), status of every plan is shown. By default,
+    the last completed step is displayed, 'done' is used when
+    all enabled steps are completed. Status of every step is
+    displayed with the most verbosity (-vv).
+
+    """
+    if [abandoned, active, finished].count(True) > 1:
+        raise tmt.utils.GeneralError(
+            "Options --abandoned, --active and --finished cannot be "
+            "used together.")
+    if not os.path.exists(path):
+        raise tmt.utils.GeneralError(f"Path {path} doesn't exist.")

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -879,3 +879,5 @@ def status(context, path, abandoned, active, finished, **kwargs):
             "used together.")
     if not os.path.exists(path):
         raise tmt.utils.GeneralError(f"Path {path} doesn't exist.")
+    status_obj = tmt.Status(context=context)
+    status_obj.show()


### PR DESCRIPTION
I am creating this draft PR to gather some feedback on the functionality proposed in #416 . All of the options are implemented so the output can be filtered using options `--active`, `--abandoned`, `--finished`. 

One of the aspects I am not completely sure about is how the command should work after calling for example `tmt run provision` and then `tmt status`. The verbose status of the run looks like this:
```
disc prov prep exec repo fini  id
todo done todo todo todo todo  /var/tmp/tmt/run-004  /test
```
The current implementation shows `discover` as the overall status of the run/plan when running only with `-v` or with no verbosity because it is the first step that hasn't been done. Would it perhaps make more sense to use `prepare` which is the next step after the last done step?

When discussing this, @lukaszachy also suggested that it would perhaps be good to introduce new status - running for steps that are in progress but haven't finished yet (currently it's either todo or done). What do you think about this @psss ? Also, is there a way how to check if a directory is a valid run directory? I haven't been able to figure out how to do so.