### PR TITLE
Small documentation cleanup

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -430,7 +430,7 @@ inheritance to prevent unnecessary duplication of the data::
         how: ansible
         playbooks: ansible/packages.yml
     execute:
-        how: beakerlib
+        how: tmt
 
     /basic:
         summary: Quick set of basic functionality tests
@@ -648,10 +648,7 @@ steps for all discovered test plans are executed::
 
 Even if there are no :ref:`/spec/plans` defined it is still
 possible to execute tests and custom scripts. See the default
-:ref:`/stories/cli/run/default/plan` story for details. For
-example, in order to run beakerlib tests you could do this::
-
-    tmt run -a execute -h beakerlib
+:ref:`/stories/cli/run/default/plan` story for details.
 
 Dry run mode is enabled with the ``--dry`` option::
 
@@ -720,6 +717,9 @@ Run only a subset of available tests across all plans::
             tests: 0 tests selected
         ...
 
+To run only tests defined in the current working directory::
+
+    $ tmt run test --name .
 
 Select Steps
 ------------------------------------------------------------------

--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -34,7 +34,7 @@ __ https://docs.fedoraproject.org/en-US/quick-docs/getting-started-with-virtuali
 __ https://kojipkgs.fedoraproject.org/compose/
 
 
-Package Cache
+Container Package Cache
 ------------------------------------------------------------------
 
 Using containers can speed up your testing. However, fetching

--- a/examples/discover/discover.fmf
+++ b/examples/discover/discover.fmf
@@ -1,7 +1,7 @@
 summary:
     Demonstrate various test discover options
 execute:
-    how: beakerlib
+    how: tmt
 provision:
     how: local
 

--- a/examples/inherit/main.fmf
+++ b/examples/inherit/main.fmf
@@ -5,7 +5,7 @@ prepare:
     how: ansible
     playbooks: ansible/packages.yml
 execute:
-    how: beakerlib
+    how: tmt
 
 /basic:
     summary: Quick set of basic functionality tests

--- a/examples/multiple/basic.fmf
+++ b/examples/multiple/basic.fmf
@@ -24,4 +24,4 @@ prepare:
     name: services
     script: systemctl start service
 execute:
-    how: beakerlib
+    how: tmt

--- a/examples/systemd/ci.fmf
+++ b/examples/systemd/ci.fmf
@@ -8,7 +8,7 @@ prepare:
     playbooks:
         - ci/rhel-8.yml
 execute:
-    how: beakerlib
+    how: tmt
 
 # Individual plans
 /pull-request/smoke:

--- a/spec/steps/execute.fmf
+++ b/spec/steps/execute.fmf
@@ -110,7 +110,7 @@ description: |
     tested:
       - /tests/execute/framework
 
-/shell:
+/script:
     summary: Execute shell scripts
     story: As a user I want to easily run shell script as a test.
     description:
@@ -135,6 +135,7 @@ description: |
 
     /simple:
         summary: Simple use case should be super simple to write
+        title: Simplest usage
         description: |
             As the `how` keyword can be omitted when using the
             default executor you can just define the shell
@@ -144,8 +145,9 @@ description: |
             execute:
                 script: tmt --help
 
-    /multi:
+    /several:
         summary: Multiple shell commands
+        title: Multiple commands
         description:
             You can also include several commands as a list.
             Executor will run commands one-by-one and check exit
@@ -158,8 +160,9 @@ description: |
                     - echo foo > /var/www/html/index.html
                     - curl http://localhost/ | grep foo
 
-    /script:
+    /multi:
         summary: Multi-line shell script
+        title: Multi-line script
         description:
             Providing a multi-line shell script is also supported.
             In that case executor will store given script into a

--- a/spec/steps/execute.fmf
+++ b/spec/steps/execute.fmf
@@ -135,7 +135,7 @@ description: |
 
     /simple:
         summary: Simple use case should be super simple to write
-        title: Simplest usage
+        title: The simplest usage
         description: |
             As the `how` keyword can be omitted when using the
             default executor you can just define the shell

--- a/spec/stories/title.fmf
+++ b/spec/stories/title.fmf
@@ -1,0 +1,11 @@
+summary:
+    User prefered title
+
+description:
+    Sometimes one wants to use their prefered title
+    instead of story's name in the documention.
+
+example: |
+    title: Nice title
+
+implemented: /tmt/base

--- a/spec/stories/title.fmf
+++ b/spec/stories/title.fmf
@@ -1,9 +1,16 @@
 summary:
-    User prefered title
+    Title to be used when generating documentation
+
+story:
+    As a story writer I want to specify a title which should be
+    used when generating online documentation from user stories.
 
 description:
-    Sometimes one wants to use their prefered title
-    instead of story's name in the documention.
+    When converting user stories into the reStructuredText format
+    in order to render content into online documentation it is
+    sometimes useful to provide a custom user story title rather
+    then using the story name which can be too short to describe
+    well the section content.
 
 example: |
     title: Nice title

--- a/tests/discover/libraries/data/apache.fmf
+++ b/tests/discover/libraries/data/apache.fmf
@@ -2,6 +2,7 @@ summary: A simple test for the Apache web server
 description:
     Requires a library which requires another library.
 test: ./apache.sh
+framework: beakerlib
 path: /
 require:
   - wget

--- a/tests/discover/libraries/data/apache.sh
+++ b/tests/discover/libraries/data/apache.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 rlJournalStart

--- a/tests/discover/libraries/data/plan.fmf
+++ b/tests/discover/libraries/data/plan.fmf
@@ -3,7 +3,7 @@ discover:
 provision:
     how: container
 execute:
-    how: beakerlib.tmt
+    how: tmt
 
 /file:
     summary: "Simple test for the file command"

--- a/tests/execute/duration/data/plan.fmf
+++ b/tests/execute/duration/data/plan.fmf
@@ -3,4 +3,4 @@ discover:
 provision:
     how: local
 execute:
-    how: shell.tmt
+    how: tmt

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -680,10 +680,7 @@ class Story(Node):
         # Title and its anchor
         if title:
             depth = len(re.findall('/', self.name)) - 1
-            if self.title:
-                title = self.title
-            else:
-                title = re.sub('.*/', '', self.name)
+            title = self.title or re.sub('.*/', '', self.name)
             output += f'\n.. _{self.name}:\n'
             output += '\n{}\n{}\n'.format(title, '=~^:-><'[depth] * len(title))
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -573,6 +573,7 @@ class Story(Node):
     # Supported attributes (listed in display order)
     _keys = [
         'summary',
+        'title',
         'story',
         'description',
         'example',
@@ -679,7 +680,10 @@ class Story(Node):
         # Title and its anchor
         if title:
             depth = len(re.findall('/', self.name)) - 1
-            title = re.sub('.*/', '', self.name)
+            if self.title:
+                title = self.title
+            else:
+                title = re.sub('.*/', '', self.name)
             output += f'\n.. _{self.name}:\n'
             output += '\n{}\n{}\n'.format(title, '=~^:-><'[depth] * len(title))
 


### PR DESCRIPTION
- Avoid deprecated execution methods in docs
  They will be removed in March 2021 so we shouldn't use them
- Package Cache is only about container
- Add explict `tmt run tests --name .` example
- Spec/execute examples renamed so they don't look like an option