### PR TITLE
Skip import of manual cases with script

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -395,11 +395,14 @@ def create(context, name, template, force, **kwargs):
 @click.option(
     '--case', metavar='CASE',
     help='Identifier of manual test case to be imported.')
+@click.option(
+    '--with-script', default=False, is_flag=True,
+    help='Import manual cases with non-empty script field in Nitrate.')
 @verbose_debug_quiet
 @force_dry
 def import_(
         context, paths, makefile, nitrate, purpose, disabled, manual, plan,
-        case, **kwargs):
+        case, with_script, **kwargs):
     """
     Import old test metadata into the new fmf format.
 
@@ -420,7 +423,7 @@ def import_(
             raise tmt.utils.GeneralError(
                 "Option --case or --plan is mandatory when using --manual.")
         else:
-            tmt.convert.read_manual(plan, case, disabled)
+            tmt.convert.read_manual(plan, case, disabled, with_script)
             return 0
 
     if not paths:

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -54,7 +54,7 @@ except AttributeError:
 #  Convert
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-def read_manual(plan_id, case_id, disabled):
+def read_manual(plan_id, case_id, disabled, with_script):
     """
     Reads metadata of manual test cases from Nitrate
     """
@@ -89,6 +89,11 @@ def read_manual(plan_id, case_id, disabled):
     for case_id in case_ids:
         testcase = nitrate.TestCase(case_id)
         if testcase.status.name != 'CONFIRMED' and not disabled:
+            log.debug(
+                testcase.identifier + ' skipped (testcase is not CONFIRMED).')
+            continue
+        if testcase.script is not None and not with_script:
+            log.debug(testcase.identifier + ' skipped (script is not empty).')
             continue
 
         # Filename sanitization


### PR DESCRIPTION
Manual cases with script non-empty field in Nitrate will be skipped
during import, unless overridden with new option --with-script.
Debug lines added.