### PR TITLE
Print errors to stderr

### DIFF
--- a/bin/tmt
+++ b/bin/tmt
@@ -19,10 +19,10 @@ except tmt.utils.RunError as error:
             f"\n{tmt.utils.OUTPUT_WIDTH * '~'}\n" +
             '\n'.join(lines[-tmt.utils.OUTPUT_LINES:]))
     print()
-    click.echo(click.style(error.message, fg='red'))
+    click.echo(click.style(error.message, fg='red'), err=True)
     raise SystemExit(2)
 
 # Basic error message for general errors
 except tmt.utils.GeneralError as error:
-    click.echo(click.style(str(error), fg='red'))
+    click.echo(click.style(str(error), fg='red'), err=True)
     raise SystemExit(2)

--- a/tests/core/error/main.fmf
+++ b/tests/core/error/main.fmf
@@ -1,0 +1,1 @@
+summary: Verify that errors work as expected.

--- a/tests/core/error/main.fmf
+++ b/tests/core/error/main.fmf
@@ -1,1 +1,1 @@
-summary: Verify that errors work as expected.
+summary: Verify that errors work as expected

--- a/tests/core/error/test.sh
+++ b/tests/core/error/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $TmpDir"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    rlPhaseStartTest "plan errors"
+        rlRun "tmt plan ls 2>output" 2 "tmt plan ls without metadata"
+        rlRun "cat output"
+        rlRun "grep \"No metadata found in the '.' directory. Use 'tmt init' to get started.\" output"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "rm -rf output $run" 0 "Remove run directory"
+        rlRun "popd"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/core/error/test.sh
+++ b/tests/core/error/test.sh
@@ -3,19 +3,18 @@
 
 rlJournalStart
     rlPhaseStartSetup
-        rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
-        rlRun "pushd $TmpDir"
-        rlRun "set -o pipefail"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
     rlPhaseEnd
 
-    rlPhaseStartTest "plan errors"
+    rlPhaseStartTest "Test error output"
         rlRun "tmt plan ls 2>output" 2 "tmt plan ls without metadata"
         rlRun "cat output"
-        rlRun "grep \"No metadata found in the '.' directory. Use 'tmt init' to get started.\" output"
+        rlAssertGrep "No metadata found" output
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun "rm -rf output $run" 0 "Remove run directory"
         rlRun "popd"
+        rlRun "rm -rf $tmp" 0 "Remove tmp directory"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/plan/select/test.sh
+++ b/tests/plan/select/test.sh
@@ -38,7 +38,7 @@ rlJournalStart
             rlRun "$tmt plan $name core | tee $output"
             rlAssertGrep "^/plans/features/core" $output
             rlAssertNotGrep "^/plans/features/basic" $output
-            rlRun "$tmt plan $name non-existent | tee $output" 2
+            rlRun "$tmt plan $name non-existent 2>&1 | tee $output" 2
             rlAssertGrep "No plans found." $output
         rlPhaseEnd
     done


### PR DESCRIPTION
Previosly GeneralErorr or RunError errors were printed to stdout,
which is not common for Unix tools.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>