### PR TITLE
Define `exclude` and `disable` attributes

### DIFF
--- a/spec/steps/prepare.fmf
+++ b/spec/steps/prepare.fmf
@@ -71,6 +71,15 @@ description: |
         preparation error is thrown ('fail'), which is the default
         behaviour.
 
+        Specific packages can be excluded from installation by
+        using the ``exclude`` attribute. This is useful in conjuction
+        with CI systems, which usually provide the list of packages
+        to be installed from the tested artifact. An example usage
+        is to exclude conflicting packages from installation.
+
+        To disable the installation of an artifact, the attribute
+        `disable` with value `true` can be used.
+
     example: |
         prepare:
             how: install
@@ -88,6 +97,16 @@ description: |
             copr: psss/tmt
             package: tmt-all
             missing: fail
+
+        prepare:
+            how: install
+            exclude:
+              - curl-minimal
+              - libcurl-minimal
+
+        prepare:
+            how: install
+            disable: true
 
     implemented:
       - /tmt/steps/provision/localhost


### PR DESCRIPTION
For the `prepare` step we need to provide users a way
to configure the artifact installation. Currently there are
two use cases:

  * exclude some package from installation
  * completely disable the artifact installation

Note that the CI system prepares a high priority repository
with the to-be-installed artifacts on the system.

For more information see:
https://pagure.io/fedora-ci/general/issue/184
https://pagure.io/fedora-ci/general/issue/29

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>