### PR TITLE
Remove the remaining test case relevancy leftovers

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -248,9 +248,14 @@ Example output of metadata conversion::
     tier: 3
     component: tmt
     enabled: True
-    relevancy:
-    distro = rhel-4, rhel-5: False
-    distro = rhel-6: False
+    adjust:
+      - enabled: false
+        when: distro ~= rhel-4, rhel-5
+        continue: false
+      - environment:
+            PHASES: novalgrind
+        when: arch == s390x
+        continue: false
     Metadata successfully stored into '/home/psss/git/tmt/examples/convert/main.fmf'.
 
 And here's the resulting ``main.fmf`` file::
@@ -279,9 +284,14 @@ And here's the resulting ``main.fmf`` file::
     - NoRHEL5
     - Tier3
     tier: '3'
-    relevancy: |
-        distro = rhel-4, rhel-5: False
-        distro = rhel-6: False
+    adjust:
+      - enabled: false
+        when: distro ~= rhel-4, rhel-5
+        continue: false
+      - environment:
+            PHASES: novalgrind
+        when: arch == s390x
+        continue: false
     extra-summary: tmt convert test
     extra-task: /tmt/smoke
     extra-nitrate: TC#0603489
@@ -307,7 +317,6 @@ directory::
     status: CONFIRMED
     arguments: TEXT='Text with spaces' X=1 Y=2 Z=3
     Structured Field:
-    relevancy: distro = rhel-4, rhel-5: False
     distro = rhel-6: False
     description: Simple smoke test
     purpose-file: Just run 'tmt --help' to make sure the binary is sane.

--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -107,7 +107,6 @@ attributes which are synchronized to corresponding nitrate fields:
 * duration — estimated time
 * enabled — status
 * environment — arguments
-* relevancy — relevancy in the structured field
 * summary — description in the structured field
 * tag — tags tab
 * tier — tags (e.g. ``1`` synced to the ``Tier1`` tag)

--- a/spec/steps/discover.fmf
+++ b/spec/steps/discover.fmf
@@ -30,8 +30,6 @@ description: |
             result: respect
             tag: [tag]
             tier: 1
-            relevancy: |
-                distro < rhel-8: False
 
         /test/two:
             summary: Short test summary.

--- a/spec/steps/provision.fmf
+++ b/spec/steps/provision.fmf
@@ -5,10 +5,8 @@ description: |
     should be provisioned. Provides a generic and an extensible
     way to write down essential hardware requirements. For example
     one consistent way how to specify "at least 2 GB of RAM" for
-    all supported provisioners.
-
-    * Possible grouping of test cases based on test case relevancy
-    * Might fail if cannot provision according to the constraints
+    all supported provisioners. Might fail if cannot provision
+    according to the constraints.
 
 example: |
     provision:

--- a/stories/cli/test.fmf
+++ b/stories/cli/test.fmf
@@ -76,7 +76,6 @@ story: 'As a user I want to comfortably work with tests'
             * enabled — status
             * environment — arguments
             * path — not synced
-            * relevancy — relevancy in the structured field
             * result — not synced
             * summary — description in the structured field
             * tag — tags tab

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -540,7 +540,7 @@ def read_nitrate_case(testcase):
         if relevancy:
             data['adjust'] = relevancy_to_adjust(relevancy)
             echo(style('adjust:', fg='green'))
-            echo(pprint.pformat(data['adjust']))
+            echo(tmt.utils.dict_to_yaml(data['adjust']).strip())
     except tmt.utils.StructuredFieldError:
         pass
 

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -153,7 +153,6 @@ def export_to_nitrate(test, create, general):
 
     # Mapping of structured field sections to fmf case attributes
     section_to_attr = {
-        'relevancy': test.relevancy,
         'description': test.summary,
         'purpose-file': test.description,
         'hardware': test.node.get('extra-hardware'),


### PR DESCRIPTION
Also fix the `tmt test export` regression caused by this.