### PR TITLE
Implement the tmt run --follow option

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -189,6 +189,9 @@ def main(click_contex, root, context, **kwargs):
     '-r', '--rm', '--remove', 'remove', is_flag=True,
     help='Remove the workdir when test run is finished.')
 @click.option(
+    '--follow', is_flag=True,
+    help='Output the logfile as it grows.')
+@click.option(
     '-a', '--all', help='Run all steps, customize some.', is_flag=True)
 @click.option(
     '-u', '--until', type=click.Choice(tmt.steps.STEPS), metavar='STEP',

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -26,6 +26,9 @@ log = fmf.utils.Logging('tmt').logger
 WORKDIR_ROOT = '/var/tmp/tmt'
 WORKDIR_MAX = 1000
 
+# Log in workdir
+LOG_FILENAME = 'log.txt'
+
 # Maximum number of lines of stdout/stderr to show upon errors
 OUTPUT_LINES = 100
 # Default output width
@@ -222,7 +225,7 @@ class Common(object):
         if self.parent:
             self.parent._log(message)
         else:
-            with open(os.path.join(self.workdir, 'log.txt'), 'a') as log:
+            with open(os.path.join(self.workdir, LOG_FILENAME), 'a') as log:
                 log.write(remove_color(message) + '\n')
 
     def info(self, key, value=None, color=None, shift=0, err=False):


### PR DESCRIPTION
Something up for discussion: do we want to exactly mimic `tail -f` behaviour or do we want to somehow modify it? Tail shows the last 10 lines in the file and then adds more once they are added. I followed this approach as I think it's pointless to show the whole log but it may be useful to show at least a few of the last lines to give context.

Resolves: #482 