### PR TITLE
Pass the "component" test attribute to beakerlib as PACKAGES

### DIFF
--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -65,6 +65,8 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
         if test.framework == 'beakerlib':
             environment = environment.copy()
             environment['BEAKERLIB_DIR'] = data_directory
+            if test.component:
+                environment['PACKAGES'] = ' '.join(test.component)
 
         # Prepare custom function to log output in verbose mode
         def log(key, value=None, color=None, shift=1, level=1):


### PR DESCRIPTION
This makes beakerlib print out some meaningful data in the "Package:"
field of the journal even if the runtest.sh script doesn't set the
PACKAGE variable.