### PR TITLE
Extra check for required packages when using yum

### DIFF
--- a/tests/prepare/require/data/plan.fmf
+++ b/tests/prepare/require/data/plan.fmf
@@ -12,3 +12,8 @@ execute:
     discover:
         how: fmf
         test: missing
+
+/mixed:
+    discover:
+        how: fmf
+        test: mixed

--- a/tests/prepare/require/data/test.fmf
+++ b/tests/prepare/require/data/test.fmf
@@ -9,3 +9,8 @@ path: /
     summary: Test requiring a missing package
     require: forest
     test: rpm -q forest
+
+/mixed:
+    summary: Require one available and one missing
+    require: [tree, forest]
+    test: rpm -q tree forest

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -209,9 +209,11 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
                 self.info('package', summary + ' requested', 'green')
                 for package in sorted(repo_packages):
                     self.verbose(package, shift=1)
-            # Quote package names and install
+            # Quote package names and prepare the rpm check
             packages = ' '.join(
                 [tmt.utils.quote(package) for package in repo_packages])
+            check = f'rpm -q --whatprovides {packages}'
+            # Check and install (extra check for yum to workaround BZ#1920176)
             guest.execute(
-                f'{command} --cacheonly install -y {packages} || '
-                f'{command} install -y {packages}')
+                f'{check} || {command} install -y {packages}' +
+                (f' && {check}' if 'yum' in command else ''))


### PR DESCRIPTION
Because of BZ#1920176 yum does not report a problem when both
available and missing packages are provided in a single command.
Thus we add an extra check after the installation is complete.

Also substitue `dnf/yum --cacheonly` with `rpm -q --whatprovides`
in order to speed up the package preparation and prevent asking
users for sudo password even when all required packages are
already installed on the localhost.

Resolves #516.