### PR TITLE
Clean up obsolete names in examples and templates

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -389,7 +389,7 @@ and detailed plan information, respectively::
           filter tier: 0,1
          prepare
              how ansible
-       playbooks plans/packages.yml
+        playbook plans/packages.yml
 
     /plans/helps
          summary Check help messages
@@ -434,10 +434,10 @@ inheritance to prevent unnecessary duplication of the data::
 
     discover:
         how: fmf
-        repository: https://github.com/psss/tmt
+        url: https://github.com/psss/tmt
     prepare:
         how: ansible
-        playbooks: ansible/packages.yml
+        playbook: ansible/packages.yml
     execute:
         how: tmt
 
@@ -470,7 +470,7 @@ step could look like this::
     prepare:
       - name: packages
         how: ansible
-        playbooks: plans/packages.yml
+        playbook: plans/packages.yml
       - name: services
         how: shell
         script: systemctl start service
@@ -482,10 +482,10 @@ the :ref:`/spec/steps/discover` step::
     discover:
       - name: upstream
         how: fmf
-        repository: https://github.com/psss/tmt
+        url: https://github.com/psss/tmt
       - name: fedora
         how: fmf
-        repository: https://src.fedoraproject.org/rpms/tmt/
+        url: https://src.fedoraproject.org/rpms/tmt/
 
 
 Extend Steps
@@ -685,8 +685,8 @@ Choose which plans should be executed::
     /plans/basic
         discover
             how: fmf
-            repository: https://github.com/psss/tmt
-            revision: devel
+            url: https://github.com/psss/tmt
+            ref: devel
             filter: tier: 0,1
             tests: 2 tests selected
         provision
@@ -707,8 +707,8 @@ Run only a subset of available tests across all plans::
     /plans/basic
         discover
             how: fmf
-            repository: https://github.com/psss/tmt
-            revision: devel
+            url: https://github.com/psss/tmt
+            ref: devel
             filter: tier: 0,1
             tests: 1 test selected
         ...
@@ -748,8 +748,8 @@ running them choose the ``discover`` step::
     /plans/basic
         discover
             how: fmf
-            repository: https://github.com/psss/tmt
-            revision: devel
+            url: https://github.com/psss/tmt
+            ref: devel
             filter: tier: 0,1
             tests: 2 tests selected
 
@@ -769,8 +769,8 @@ test environment provisioning::
     /plans/basic
         discover
             how: fmf
-            repository: https://github.com/psss/tmt
-            revision: devel
+            url: https://github.com/psss/tmt
+            ref: devel
             filter: tier: 0,1
             tests: 2 tests selected
                 /one/tests/docs

--- a/examples/discover/discover.fmf
+++ b/examples/discover/discover.fmf
@@ -15,7 +15,7 @@ provision:
             summary: Full from directory
             discover:
                 how: fmf
-                revision: devel
+                ref: devel
                 filter: 'tier: 1'
 
     /repository:
@@ -23,11 +23,11 @@ provision:
             summary: Minimal from repository
             discover:
                 how: fmf
-                repository: https://github.com/psss/tmt
+                url: https://github.com/psss/tmt
         /full:
             summary: Full from repository
             discover:
                 how: fmf
-                repository: https://github.com/psss/tmt
-                revision: devel
+                url: https://github.com/psss/tmt
+                ref: devel
                 filter: 'tier: 1'

--- a/examples/inherit/main.fmf
+++ b/examples/inherit/main.fmf
@@ -1,9 +1,9 @@
 discover:
     how: fmf
-    repository: https://github.com/psss/tmt
+    url: https://github.com/psss/tmt
 prepare:
     how: ansible
-    playbooks: ansible/packages.yml
+    playbook: ansible/packages.yml
 execute:
     how: tmt
 

--- a/examples/l2/bed.fmf
+++ b/examples/l2/bed.fmf
@@ -11,7 +11,7 @@
     # Setup with ansible
     prepare:
         how: ansible
-        playbooks:
+        playbook:
             - 'dependencies.yml'
             - 'selenium.yml'
     # Use restraint with isolation enabled

--- a/examples/l2/tooling.fmf
+++ b/examples/l2/tooling.fmf
@@ -5,9 +5,9 @@
         /sti:
             execute:
                 how: sti
-                playbooks:
+                playbook:
                     - 'tests.yml'
-                tags:
+                tag:
                     - 'classic'
         # Simple shell script
         /shell:
@@ -27,6 +27,6 @@
             discover:
                 how: fmf
                 filter: 'tier: 1, 2'
-                repository: https://src.fedoraproject.org/tests/python
+                url: https://src.fedoraproject.org/tests/python
             execute:
                 how: restraint

--- a/examples/multiple/basic.fmf
+++ b/examples/multiple/basic.fmf
@@ -8,18 +8,18 @@ discover:
   - name: tier0
     how: fmf
     filter: 'tier: 0'
-    repository: https://github.com/psss/tmt
+    url: https://github.com/psss/tmt
   - name: tier1
     how: fmf
     filter: 'tier: 1'
-    repository: https://github.com/psss/tmt
+    url: https://github.com/psss/tmt
   - name: all
     how: fmf
-    repository: https://github.com/psss/tmt
+    url: https://github.com/psss/tmt
 prepare:
   - how: ansible
     name: packages
-    playbooks: plans/packages.yml
+    playbook: plans/packages.yml
   - how: shell
     name: services
     script: systemctl start service

--- a/examples/symlinks/plans/main.fmf
+++ b/examples/symlinks/plans/main.fmf
@@ -13,7 +13,7 @@ provision:
 # Ansible playbook
 #prepare:
 #    how: ansible
-#    playbooks: ansible/packages.yml
+#    playbook: ansible/packages.yml
 
 # Shell commands
 #prepare:

--- a/examples/systemd/ci.fmf
+++ b/examples/systemd/ci.fmf
@@ -2,10 +2,10 @@
 # Common configuration
 discover:
     how: fmf
-    repository: "https://github.com/systemd-rhel/tests"
+    url: "https://github.com/systemd-rhel/tests"
 prepare:
     how: ansible
-    playbooks:
+    playbook:
         - ci/rhel-8.yml
 execute:
     how: tmt

--- a/examples/together/main.fmf
+++ b/examples/together/main.fmf
@@ -6,7 +6,7 @@
         how: fmf
     prepare:
         how: ansible
-        playbooks: packages.yaml
+        playbook: packages.yaml
     execute:
         how: shell
 

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -21,7 +21,7 @@ artifact:
 # Ansible playbook
 #prepare:
 #    how: ansible
-#    playbooks: ansible/packages.yml
+#    playbook: ansible/packages.yml
 
 # Shell commands
 #prepare:

--- a/spec/steps/prepare.fmf
+++ b/spec/steps/prepare.fmf
@@ -41,9 +41,9 @@ description: |
     example: |
         prepare:
             how: ansible
-            roles:
+            role:
                 - nginxinc.nginx
-            playbooks:
+            playbook:
                 - common.yml
                 - rhel7.yml
     implemented:

--- a/stories/coverage.fmf
+++ b/stories/coverage.fmf
@@ -68,5 +68,5 @@ story:
             There should be an easy way to filter based on tests
             tags.
         example: |
-            tmt story ls --filter "tags:Tier1"
+            tmt story ls --filter "tag:fast"
         priority: should

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -15,7 +15,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
 
         prepare:
             how: ansible
-            playbooks:
+            playbook:
               - playbook/one.yml
               - playbook/two.yml
               - playbook/three.yml

--- a/tmt/templates.py
+++ b/tmt/templates.py
@@ -88,10 +88,10 @@ summary:
     Essential command line features
 discover:
     how: fmf
-    repository: https://github.com/psss/tmt
+    url: https://github.com/psss/tmt
 prepare:
     how: ansible
-    playbooks: plans/packages.yml
+    playbook: plans/packages.yml
 execute:
     how: tmt
 """.lstrip()


### PR DESCRIPTION
There was a bunch of forgotten old names scattered across docs and templates.