### PR TITLE
 Use fmf to store the newly created nitrate case id 

### DIFF
--- a/tmt/export.py
+++ b/tmt/export.py
@@ -222,13 +222,19 @@ def export_to_nitrate(test):
 
     # Append id of newly created nitrate case to its file
     if new_test_created:
-        fmf_file_path = test.node.sources[-1]
-        echo(style(f"Append test case id into '{fmf_file_path}'.", fg='green'))
+        echo(style(f"Append the nitrate test case id.", fg='green'))
         try:
-            with open(fmf_file_path, encoding='utf-8', mode='a+') as fmf_file:
-                fmf_file.write(f"extra-nitrate: {nitrate_case.identifier}\n")
-        except IOError:
-            raise ConvertError("Unable to open '{0}'.".format(fmf_file_path))
+            with test.node as data:
+                data["extra-nitrate"] = nitrate_case.identifier
+        except AttributeError:
+            # FIXME: Remove this deprecated code after fmf support
+            # for storing modified data is released long enough
+            file_path = test.node.sources[-1]
+            try:
+                with open(file_path, encoding='utf-8', mode='a+') as file:
+                    file.write(f"extra-nitrate: {nitrate_case.identifier}\n")
+            except IOError:
+                raise ConvertError("Unable to open '{0}'.".format(file_path))
 
     # Update nitrate test case
     nitrate_case.update()


### PR DESCRIPTION
It replaces plain text editing of fmf files for nitrate extra args by direct using of FMF
 `modify`.

It works as charm

depends on: https://github.com/psss/fmf/pull/102
solves: https://github.com/psss/tmt/issues/427

## input file
```
components: [cockpit, cockpit-doc, cockpit-system, cockpit-bridge, cockpit-ws]
version_from_comps: [cockpit-bridge]

tags+: [Tier1]
relevancy: |
   distro != rhel-7: False
   distro = rhel-7 && arch=ppc64: False
beaker-task: /CoreOS/cockpit/Sanity/selenium-generic
test: selenium-base.py:BasicTestSuite
plans: [19006]
dependencies: []

/login:
   summary: "Check cockpit basic if is able to"
   /add_ssh_key:
      relevancy: |
         distro <= rhel-7: False
         distro = rhel-7 && arch=ppc64: False
      test+:  .test15BaseSSHKeyAdded
      summary+: "add ssh key for login user"
   /login:
      /sanity:
         test+: .test20Login
         summary+: "login with various scenarios: nonexisting user, bad password, proper user"
      /special_cases:
         test: selenium-login-special.py
         summary: "Check regressions in login cases, (text in bashrc, special login shell)"
         relevancy+: |
            distro <= rhel-8: False

```

## modified file
```
components:
- cockpit
- cockpit-doc
- cockpit-system
- cockpit-bridge
- cockpit-ws
version_from_comps:
- cockpit-bridge
tags+:
- Tier1
relevancy: |
  distro != rhel-7: False
  distro = rhel-7 && arch=ppc64: False
beaker-task: /CoreOS/cockpit/Sanity/selenium-generic
test: selenium-base.py:BasicTestSuite
plans:
- 19006
dependencies: []
/login:
  summary: Check cockpit basic if is able to
  /add_ssh_key:
    relevancy: |
      distro <= rhel-7: False
      distro = rhel-7 && arch=ppc64: False
    test+: .test15BaseSSHKeyAdded
    summary+: add ssh key for login user
    extra-nitrate: TC#0609450
  /login:
    /sanity:
      test+: .test20Login
      summary+: 'login with various scenarios: nonexisting user, bad password, proper
        user'
      extra-nitrate: TC#0609451
    /special_cases:
      test: selenium-login-special.py
      summary: Check regressions in login cases, (text in bashrc, special login shell)
      relevancy+: |
        distro <= rhel-8: False
      extra-nitrate: TC#0609452
```

