### PR TITLE
Remove the whole rhts-lint line during test import

### DIFF
--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -219,7 +219,7 @@ def read(path, makefile, nitrate, purpose, disabled):
                 r'^include /usr/share/rhts/lib/rhts-make.include',
                 '-include /usr/share/rhts/lib/rhts-make.include',
                 makefile, flags=re.MULTILINE)
-        makefile = makefile.replace('rhts-lint testinfo.desc', '')
+        makefile = re.sub('.*rhts-lint.*', '', makefile)
 
         # Create testinfo.desc file with resolved variables
         try:


### PR DESCRIPTION
Makefile can contain a different form of the rhts-lint line:

    [ -x /usr/bin/rhts-lint ] && rhts-lint $(METADATA)

Let's remove the whole line to make sure we cover these cases
(and similar ones) as well.