### PR TITLE
Handle default branch in Library

### DIFF
--- a/tests/unit/test_beakerlib.py
+++ b/tests/unit/test_beakerlib.py
@@ -18,26 +18,26 @@ def test_library():
         assert library.format == 'rpm'
         assert library.repo == 'openssl'
         assert library.url == 'https://github.com/beakerlib/openssl'
-        assert library.ref == 'master' # default branch is called master
+        assert library.ref == 'master' # The default branch is master
         assert library.dest == tmt.beakerlib.DEFAULT_DESTINATION
         shutil.rmtree(library.parent.workdir)
 
 
 @pytest.mark.web
-def test_library_from_fmf():
+@pytest.mark.parametrize(
+        'url, name, default_branch', [
+        ('https://github.com/beakerlib/httpd', '/http', 'master'),
+        ('https://github.com/beakerlib/example', '/file', 'main')
+        ])
+def test_library_from_fmf(url, name, default_branch):
     """ Fetch beakerlib library referenced by fmf identifier """
-    library = tmt.beakerlib.Library(
-        {
-            'url': 'https://github.com/beakerlib/httpd',
-            'name': '/http'
-        }
-    )
+    library = tmt.beakerlib.Library(dict(url=url, name=name))
     assert library.format == 'fmf'
-    assert library.ref == 'master' # default branch is called master
-    assert library.url == 'https://github.com/beakerlib/httpd'
+    assert library.ref == default_branch
+    assert library.url == url
     assert library.dest == tmt.beakerlib.DEFAULT_DESTINATION
-    assert library.repo == 'httpd'
-    assert library.name == '/http'
+    assert library.repo == url.split('/')[-1]
+    assert library.name == name
     shutil.rmtree(library.parent.workdir)
 
 
@@ -61,7 +61,7 @@ def test_dependencies():
     assert libraries[0].repo == 'httpd'
     assert libraries[0].name == '/http'
     assert libraries[0].url == 'https://github.com/beakerlib/httpd'
-    assert libraries[0].ref == 'master' # default branch is called master
+    assert libraries[0].ref == 'master' # The default branch is master
     assert libraries[0].dest == tmt.beakerlib.DEFAULT_DESTINATION
     assert libraries[1].repo == 'openssl'
     assert libraries[1].name == '/certgen'

--- a/tests/unit/test_beakerlib.py
+++ b/tests/unit/test_beakerlib.py
@@ -18,9 +18,27 @@ def test_library():
         assert library.format == 'rpm'
         assert library.repo == 'openssl'
         assert library.url == 'https://github.com/beakerlib/openssl'
-        assert library.ref == 'master'
+        assert library.ref == 'master' # default branch is called master
         assert library.dest == tmt.beakerlib.DEFAULT_DESTINATION
         shutil.rmtree(library.parent.workdir)
+
+
+@pytest.mark.web
+def test_library_from_fmf():
+    """ Fetch beakerlib library referenced by fmf identifier """
+    library = tmt.beakerlib.Library(
+        {
+            'url': 'https://github.com/beakerlib/httpd',
+            'name': '/http'
+        }
+    )
+    assert library.format == 'fmf'
+    assert library.ref == 'master' # default branch is called master
+    assert library.url == 'https://github.com/beakerlib/httpd'
+    assert library.dest == tmt.beakerlib.DEFAULT_DESTINATION
+    assert library.repo == 'httpd'
+    assert library.name == '/http'
+    shutil.rmtree(library.parent.workdir)
 
 
 @pytest.mark.web
@@ -43,7 +61,7 @@ def test_dependencies():
     assert libraries[0].repo == 'httpd'
     assert libraries[0].name == '/http'
     assert libraries[0].url == 'https://github.com/beakerlib/httpd'
-    assert libraries[0].ref == 'master'
+    assert libraries[0].ref == 'master' # default branch is called master
     assert libraries[0].dest == tmt.beakerlib.DEFAULT_DESTINATION
     assert libraries[1].repo == 'openssl'
     assert libraries[1].name == '/certgen'

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -113,7 +113,7 @@ class Library(object):
             # The url must be identical
             if library.url != self.url:
                 raise tmt.utils.GeneralError(
-                    f"Library '{self.repo}' with url '{self.url}' conflicts "
+                    f"Library '{self}' with url '{self.url}' conflicts "
                     f"with already fetched library from '{library.url}'.")
             # Use the default branch if no ref provided
             if self.ref is None:
@@ -121,8 +121,9 @@ class Library(object):
             # The same ref has to be used
             if library.ref != self.ref:
                 raise tmt.utils.GeneralError(
-                    f"Library '{self.repo}' using ref '{self.ref}' conflicts "
-                    f"with already fetched library using ref '{library.ref}'.")
+                    f"Library '{self}' using ref '{self.ref}' conflicts "
+                    f"with already fetched library '{library}' "
+                    f"using ref '{library.ref}'.")
             self.parent.debug(f"Library '{self}' already fetched.", level=3)
             # Reuse the existing metadata tree
             self.tree = library.tree


### PR DESCRIPTION
Implemented inside tmt, once fmf.utils.fetch() is ready we can start
using that.

Resolves: #530