### PR TITLE
Create a new test in the current working directory

### DIFF
--- a/tests/test/create/main.fmf
+++ b/tests/test/create/main.fmf
@@ -1,0 +1,2 @@
+summary: Check that a test is created correctly
+test: ./test.sh

--- a/tests/test/create/test.sh
+++ b/tests/test/create/test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    DIR_DOT_SYNTAX="some/nice/dir/structure"
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "mkdir -p $DIR_DOT_SYNTAX"
+        rlRun "set -o pipefail"
+        rlRun "tmt init"
+    rlPhaseEnd
+
+    rlPhaseStartTest "shell template"
+        rlRun "tmt test create test_shell --template shell"
+        rlAssertExists "$tmp/test_shell/main.fmf"
+        rlAssertExists "$tmp/test_shell/test.sh"
+    rlPhaseEnd
+
+    rlPhaseStartTest "existing directory and files"
+        rlRun -s "tmt test create test_shell --template shell" 2 "test already exists"
+        rlAssertGrep "File '$tmp/test_shell/main.fmf' already exists." "${rlRun_LOG}"
+        rlAssertGrep "Directory '$tmp/test_shell' already exists." "${rlRun_LOG}"
+        rlAssertExists "$tmp/test_shell/main.fmf"
+        rlAssertExists "$tmp/test_shell/test.sh"
+    rlPhaseEnd
+
+    rlPhaseStartTest "beakerlib template"
+        rlRun "tmt test create test_beakerlib --template beakerlib"
+        rlAssertExists "$tmp/test_beakerlib/main.fmf"
+        rlAssertExists "$tmp/test_beakerlib/test.sh"
+    rlPhaseEnd
+
+    rlPhaseStartTest "non-existent template"
+        rlRun -s "tmt test create non-existent --template non-existent" 2 "Template doesn't exist"
+        rlAssertGrep "Invalid template 'non-existent'." "${rlRun_LOG}"
+    rlPhaseEnd
+
+    rlPhaseStartTest "With '.' syntax"
+        rlRun "cd $DIR_DOT_SYNTAX"
+        rlRun "tmt test create . --template shell"
+        rlAssertExists "$tmp/$DIR_DOT_SYNTAX/main.fmf"
+        rlAssertExists "$tmp/$DIR_DOT_SYNTAX/test.sh"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/test/create/test.sh
+++ b/tests/test/create/test.sh
@@ -12,32 +12,36 @@ rlJournalStart
         rlRun "tmt init"
     rlPhaseEnd
 
-    rlPhaseStartTest "shell template"
+    rlPhaseStartTest "Shell template"
         rlRun "tmt test create test_shell --template shell"
         rlAssertExists "$tmp/test_shell/main.fmf"
         rlAssertExists "$tmp/test_shell/test.sh"
     rlPhaseEnd
 
-    rlPhaseStartTest "existing directory and files"
-        rlRun -s "tmt test create test_shell --template shell" 2 "test already exists"
-        rlAssertGrep "File '$tmp/test_shell/main.fmf' already exists." "${rlRun_LOG}"
-        rlAssertGrep "Directory '$tmp/test_shell' already exists." "${rlRun_LOG}"
+    rlPhaseStartTest "Existing directory and files"
+        rlRun -s "tmt test create test_shell --template shell" \
+            2 "test already exists"
+        rlAssertGrep "File '$tmp/test_shell/main.fmf' already exists." \
+            "${rlRun_LOG}"
+        rlAssertGrep "Directory '$tmp/test_shell' already exists." \
+            "${rlRun_LOG}"
         rlAssertExists "$tmp/test_shell/main.fmf"
         rlAssertExists "$tmp/test_shell/test.sh"
     rlPhaseEnd
 
-    rlPhaseStartTest "beakerlib template"
+    rlPhaseStartTest "BeakerLib template"
         rlRun "tmt test create test_beakerlib --template beakerlib"
         rlAssertExists "$tmp/test_beakerlib/main.fmf"
         rlAssertExists "$tmp/test_beakerlib/test.sh"
     rlPhaseEnd
 
     rlPhaseStartTest "non-existent template"
-        rlRun -s "tmt test create non-existent --template non-existent" 2 "Template doesn't exist"
+        rlRun -s "tmt test create non-existent --template non-existent" \
+            2 "Template doesn't exist"
         rlAssertGrep "Invalid template 'non-existent'." "${rlRun_LOG}"
     rlPhaseEnd
 
-    rlPhaseStartTest "With '.' syntax"
+    rlPhaseStartTest "Using the '.' syntax"
         rlRun "cd $DIR_DOT_SYNTAX"
         rlRun "tmt test create . --template shell"
         rlAssertExists "$tmp/$DIR_DOT_SYNTAX/main.fmf"

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -302,16 +302,14 @@ class Test(Node):
                 name='test metadata',
                 force=force)
         except KeyError:
-            raise tmt.utils.GeneralError(
-                f"Invalid template '{template}'.")
+            raise tmt.utils.GeneralError(f"Invalid template '{template}'.")
 
         # Create script
         script_path = os.path.join(directory_path, 'test.sh')
         try:
             content = tmt.templates.TEST[template]
         except KeyError:
-            raise tmt.utils.GeneralError(
-                f"Invalid template '{template}'.")
+            raise tmt.utils.GeneralError(f"Invalid template '{template}'.")
         tmt.utils.create_file(
             path=script_path, content=content,
             name='test script', force=force, mode=0o755)

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -287,14 +287,23 @@ class Test(Node):
     def create(name, template, tree, force=False):
         """ Create a new test """
         # Create directory
-        directory_path = os.path.join(tree.root, name.lstrip('/'))
-        tmt.utils.create_directory(directory_path, 'test directory')
+        if name == '.':
+            directory_path = os.getcwd()
+        else:
+            directory_path = os.path.join(tree.root, name.lstrip('/'))
+            tmt.utils.create_directory(directory_path, 'test directory')
 
         # Create metadata
         metadata_path = os.path.join(directory_path, 'main.fmf')
-        tmt.utils.create_file(
-            path=metadata_path, content=tmt.templates.TEST_METADATA[template],
-            name='test metadata', force=force)
+        try:
+            tmt.utils.create_file(
+                path=metadata_path,
+                content=tmt.templates.TEST_METADATA[template],
+                name='test metadata',
+                force=force)
+        except KeyError:
+            raise tmt.utils.GeneralError(
+                f"Invalid template '{template}'.")
 
         # Create script
         script_path = os.path.join(directory_path, 'test.sh')
@@ -302,7 +311,7 @@ class Test(Node):
             content = tmt.templates.TEST[template]
         except KeyError:
             raise tmt.utils.GeneralError(
-                "Invalid template '{}'.".format(template))
+                f"Invalid template '{template}'.")
         tmt.utils.create_file(
             path=script_path, content=content,
             name='test script', force=force, mode=0o755)

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -308,7 +308,7 @@ def tests(context, **kwargs):
 @verbose_debug_quiet
 def ls(context, **kwargs):
     """
-    List available tests
+    List available tests.
 
     Regular expression can be used to filter tests by name.
     Use '.' to select tests under the current working directory.
@@ -324,7 +324,7 @@ def ls(context, **kwargs):
 @verbose_debug_quiet
 def show(context, **kwargs):
     """
-    Show test details
+    Show test details.
 
     Regular expression can be used to filter tests by name.
     Use '.' to select tests under the current working directory.
@@ -344,7 +344,7 @@ def show(context, **kwargs):
 @verbose_debug_quiet
 def lint(context, **kwargs):
     """
-    Check tests against the L1 metadata specification
+    Check tests against the L1 metadata specification.
 
     Regular expression can be used to filter tests for linting.
     Use '.' to select tests under the current working directory.
@@ -481,7 +481,7 @@ def import_(
     help='Provide as much debugging details as possible.')
 def export(context, format_, nitrate, create, general, **kwargs):
     """
-    Export test data into the desired format
+    Export test data into the desired format.
 
     Regular expression can be used to filter tests by name.
     Use '.' to select tests under the current working directory.
@@ -522,7 +522,7 @@ def plans(context, **kwargs):
 @verbose_debug_quiet
 def ls(context, **kwargs):
     """
-    List available plans
+    List available plans.
 
     Regular expression can be used to filter plans by name.
     Use '.' to select plans under the current working directory.
@@ -538,7 +538,7 @@ def ls(context, **kwargs):
 @verbose_debug_quiet
 def show(context, **kwargs):
     """
-    Show plan details
+    Show plan details.
 
     Regular expression can be used to filter plans by name.
     Use '.' to select plans under the current working directory.
@@ -555,7 +555,7 @@ def show(context, **kwargs):
 @verbose_debug_quiet
 def lint(context, **kwargs):
     """
-    Check plans against the L2 metadata specification
+    Check plans against the L2 metadata specification.
 
     Regular expression can be used to filter plans by name.
     Use '.' to select plans under the current working directory.
@@ -633,7 +633,7 @@ def ls(
     context, implemented, tested, documented, covered,
     unimplemented, untested, undocumented, uncovered, **kwargs):
     """
-    List available stories
+    List available stories.
 
     Regular expression can be used to filter stories by name.
     Use '.' to select stories under the current working directory.
@@ -654,7 +654,7 @@ def show(
     context, implemented, tested, documented, covered,
     unimplemented, untested, undocumented, uncovered, **kwargs):
     """
-    Show story details
+    Show story details.
 
     Regular expression can be used to filter stories by name.
     Use '.' to select stories under the current working directory.
@@ -699,7 +699,7 @@ def coverage(
     implemented, tested, documented, covered,
     unimplemented, untested, undocumented, uncovered, **kwargs):
     """
-    Show code, test and docs coverage for given stories
+    Show code, test and docs coverage for given stories.
 
     Regular expression can be used to filter stories by name.
     Use '.' to select stories under the current working directory.
@@ -760,7 +760,7 @@ def export(
     implemented, tested, documented, covered,
     unimplemented, untested, undocumented, uncovered, **kwargs):
     """
-    Export selected stories into desired format
+    Export selected stories into desired format.
 
     Regular expression can be used to filter stories by name.
     Use '.' to select stories under the current working directory.

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -369,7 +369,12 @@ _test_templates = listed(tmt.templates.TEST, join='or')
 @verbose_debug_quiet
 @force_dry
 def create(context, name, template, force, **kwargs):
-    """ Create a new test based on given template. """
+    """
+    Create a new test based on given template.
+
+    Specify directory name or use '.' to create tests under the
+    current working directory.
+    """
     tmt.Test._save_context(context)
     tmt.Test.create(name, template, context.obj.tree, force)
 


### PR DESCRIPTION
https://github.com/psss/tmt/issues/534
I added `try` expression to solve exception with the non-existent template:
```
$ tmt test create -t AHOJ test
Directory '/tmp/test_tmt/test' created.
Traceback (most recent call last):
  File "/usr/bin/tmt", line 8, in <module>
    tmt.cli.main()
  File "/usr/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/lib/python3.8/site-packages/tmt/cli.py", line 371, in create
    tmt.Test.create(name, template, context.obj.tree, force)
  File "/usr/lib/python3.8/site-packages/tmt/base.py", line 284, in create
    path=metadata_path, content=tmt.templates.TEST_METADATA[template],
KeyError: 'AHOJ'
```

I didn't find a better solution then using `os.getcwd()` method for NAME='.' case. 
```
$ cd test_tmt/
$ mkdir -p some/nice/dir/structure
$ cd some/nice/dir/structure
$ tmt tests create -t beakerlib .
Test metadata '/tmp/test_tmt/some/nice/dir/structure/main.fmf' created.
Test script '/tmp/test_tmt/some/nice/dir/structure/test.sh' created.
[dkarpele@redhat structure]$ cd /tmp/test_tmt/ ; tree
.
├── plans
│   └── example.fmf
└── some
    └── nice
        └── dir
            └── structure
                ├── main.fmf
                └── test.sh

5 directories, 3 files
[dkarpele@redhat test_tmt]$
```