### PR TITLE
Ensure rsync is installed on the guest if needed

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -27,7 +27,7 @@ Source0: https://github.com/psss/tmt/releases/download/%{version}/tmt-%{version}
 
 # Main tmt package requires the Python module
 Requires: python%{python3_pkgversion}-%{name} == %{version}-%{release}
-Requires: git-core sshpass
+Requires: git-core rsync sshpass
 
 %description
 The tmt Python module and command line tool implement the test
@@ -71,7 +71,7 @@ Summary: Virtual machine provisioner for the Test Management Tool
 Obsoletes: tmt-testcloud < 0.17
 Requires: tmt == %{version}-%{release}
 Requires: python%{python3_pkgversion}-testcloud >= 0.3.5
-Requires: ansible openssh-clients rsync
+Requires: ansible openssh-clients
 
 %description provision-virtual
 Dependencies required to run tests in a local virtual machine.

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -518,10 +518,15 @@ class Login(tmt.utils.Common):
         commands = self.opt('command')
         self.info('login', 'Starting interactive shell', color='yellow')
         for guest in self.parent.plan.provision.guests():
-            # Make sure the workdir is available on the guest
-            guest.push()
+            # Attempt to push the workdir to the guest
+            try:
+                guest.push()
+                cwd = self.parent.workdir
+            except tmt.utils.GeneralError:
+                self.warn("Failed to push workdir to the guest.")
+                cwd = None
+            # Execute all requested commands
             for command in commands:
                 self.debug(f"Run '{command}' in interactive mode.")
-                guest.execute(
-                    command, interactive=True, cwd=self.parent.workdir)
+                guest.execute(command, interactive=True, cwd=cwd)
         self.info('login', 'Interactive shell finished', color='yellow')

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -61,7 +61,10 @@ class Prepare(tmt.steps.Step):
 
         # Required packages
         requires = list(set(
-            self.plan.discover.requires() + self.plan.execute.requires()))
+            self.plan.discover.requires() +
+            self.plan.provision.requires() +
+            self.plan.execute.requires()
+            ))
         if requires:
             data = dict(
                 how='install',

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -41,6 +41,10 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
         """ Return the provisioned guest """
         return self._guest
 
+    def requires(self):
+        """ List of required packages needed for workdir sync """
+        return GuestLocal.requires()
+
 
 class GuestLocal(tmt.Guest):
     """ Local Host """
@@ -62,3 +66,8 @@ class GuestLocal(tmt.Guest):
 
     def pull(self):
         """ Nothing to be done to pull workdir """
+
+    @classmethod
+    def requires(cls):
+        """ No packages needed to sync workdir """
+        return []

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -80,6 +80,10 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
         """ Return the provisioned guest """
         return self._guest
 
+    def requires(self):
+        """ List of required packages needed for workdir sync """
+        return GuestContainer.requires()
+
 
 class GuestContainer(tmt.Guest):
     """ Container Instance """
@@ -194,3 +198,8 @@ class GuestContainer(tmt.Guest):
         if self.container:
             self.podman(['container', 'rm', '-f', self.container])
             self.info('container', 'removed', 'green')
+
+    @classmethod
+    def requires(cls):
+        """ No packages needed to sync workdir to the container """
+        return []


### PR DESCRIPTION
To sync workdir `rsync` is needed on both host & guest.
Move the `rsync` requires to the main `tmt` package.
Implement a `requires()` method for the provision step.
Update `local` and `podman` plugins accordingly.
Allow to `login` even if `rsync` is not installed.
Adjust `Guest.execute()` to accept `cwd=None` as well.

Resolves #437 and fixes #558 as well.