### PR TITLE
Use a better trigger name for source code changes

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -801,6 +801,85 @@ some of them it is possible to use the ``--all`` option::
 
     tmt run --all provision --how=local
 
+When the particular step is ``done``, it can't be executed repeatedly
+unless ``--force`` is used::
+
+    $ tmt run -l report
+    /var/tmp/tmt/run-759
+
+    /plans/features/core
+        report
+            status: done
+            summary: 10 tests passed
+
+
+    $ tmt run -l report --force
+    /var/tmp/tmt/run-759
+
+    /plans/features/core
+        report
+            how: display
+            summary: 10 tests passed
+
+
+You might need additional information about your already ``done`` run.
+Therefore use ``--force`` with the ``--verbose`` option::
+
+    $ tmt run -l report -v --force
+    /var/tmp/tmt/run-759
+
+    /plans/features/core
+        report
+            how: display
+                pass /tests/core/adjust
+                pass /tests/core/docs
+                pass /tests/core/dry
+                pass /tests/core/env
+                pass /tests/core/error
+                pass /tests/core/force
+                pass /tests/core/ls
+                pass /tests/core/path
+                pass /tests/core/smoke
+                pass /tests/unit
+            summary: 10 tests passed
+
+
+    $ tmt run -l report -vv --force
+    /var/tmp/tmt/run-759
+
+    /plans/features/core
+        report
+            how: display
+                pass /tests/core/adjust
+                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/adjust/output.txt
+                    journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/adjust/journal.txt
+                pass /tests/core/docs
+                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/docs/output.txt
+                    journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/docs/journal.txt
+                pass /tests/core/dry
+                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/dry/output.txt
+                    journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/dry/journal.txt
+                pass /tests/core/env
+                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/env/output.txt
+                    journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/env/journal.txt
+                pass /tests/core/error
+                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/error/output.txt
+                    journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/error/journal.txt
+                pass /tests/core/force
+                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/force/output.txt
+                    journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/force/journal.txt
+                pass /tests/core/ls
+                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/ls/output.txt
+                    journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/ls/journal.txt
+                pass /tests/core/path
+                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/path/output.txt
+                pass /tests/core/smoke
+                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/smoke/output.txt
+                pass /tests/unit
+                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/unit/output.txt
+            summary: 10 tests passed
+
+
 
 Provision Options
 ------------------------------------------------------------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -801,33 +801,23 @@ some of them it is possible to use the ``--all`` option::
 
     tmt run --all provision --how=local
 
-When the particular step is ``done``, it can't be executed repeatedly
-unless ``--force`` is used::
 
-    $ tmt run -l report
-    /var/tmp/tmt/run-759
+Check Report
+------------------------------------------------------------------
 
+When a particular step is ``done``, it won't be executed
+repeatedly unless ``--force`` is used::
+
+    $ tmt run -l report --verbose
     /plans/features/core
         report
             status: done
             summary: 10 tests passed
 
-
-    $ tmt run -l report --force
-    /var/tmp/tmt/run-759
-
-    /plans/features/core
-        report
-            how: display
-            summary: 10 tests passed
-
-
-You might need additional information about your already ``done`` run.
-Therefore use ``--force`` with the ``--verbose`` option::
+If you need additional information about your already ``done``
+run use ``--force`` together with the ``--verbose`` option::
 
     $ tmt run -l report -v --force
-    /var/tmp/tmt/run-759
-
     /plans/features/core
         report
             how: display
@@ -843,10 +833,9 @@ Therefore use ``--force`` with the ``--verbose`` option::
                 pass /tests/unit
             summary: 10 tests passed
 
+In order to investigate test logs raise verbosity even more::
 
     $ tmt run -l report -vv --force
-    /var/tmp/tmt/run-759
-
     /plans/features/core
         report
             how: display
@@ -859,26 +848,15 @@ Therefore use ``--force`` with the ``--verbose`` option::
                 pass /tests/core/dry
                     output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/dry/output.txt
                     journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/dry/journal.txt
-                pass /tests/core/env
-                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/env/output.txt
-                    journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/env/journal.txt
-                pass /tests/core/error
-                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/error/output.txt
-                    journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/error/journal.txt
-                pass /tests/core/force
-                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/force/output.txt
-                    journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/force/journal.txt
-                pass /tests/core/ls
-                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/ls/output.txt
-                    journal.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/ls/journal.txt
-                pass /tests/core/path
-                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/path/output.txt
-                pass /tests/core/smoke
-                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/core/smoke/output.txt
-                pass /tests/unit
-                    output.txt: /var/tmp/tmt/run-759/plans/features/core/execute/data/tests/unit/output.txt
+                ...
             summary: 10 tests passed
 
+Use level 3 verbosity ``-vvv`` to show the complete test output.
+For more comfortable review, generate an ``html`` report and open
+it in your favorite web browser::
+
+    $ tmt run --last report --how html --open --force
+    $ tmt run -l report -h html -of
 
 
 Provision Options

--- a/spec/context/trigger.fmf
+++ b/spec/context/trigger.fmf
@@ -9,7 +9,7 @@ description: |
     of tests is usually executed for each of them. The ``trigger``
     dimension supports the following values:
 
-    code
+    commit
         Project source code has changed. This can be either a
         pull/merge request or a new commit pushed to a branch.
 


### PR DESCRIPTION
After the discussion the original `code` value sounds too generic
and misleading. Let's use `commit` instead, which is a bit more
specific and closely related to code changes and pull requests.