### PR TITLE
Implement the 'tmt --version' option [fix #445]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # Prepare variables
 TMP = $(CURDIR)/tmp
 VERSION = $(shell grep ^Version tmt.spec | sed 's/.* //')
+COMMIT = $(shell git rev-parse --short HEAD)
+REPLACE_VERSION = "s/running from the source/$(VERSION) ($(COMMIT))/"
 PACKAGE = tmt-$(VERSION)
 FILES = LICENSE README.rst \
 		Makefile tmt.spec setup.py \
@@ -40,6 +42,7 @@ source: clean tmp
 	mkdir -p $(TMP)/SOURCES
 	mkdir -p $(TMP)/$(PACKAGE)
 	cp -a $(FILES) $(TMP)/$(PACKAGE)
+	sed -i $(REPLACE_VERSION) $(TMP)/$(PACKAGE)/tmt/__init__.py
 	rm $(TMP)/$(PACKAGE)/tmt/steps/provision/{base,vagrant}.py
 tarball: source man
 	cd $(TMP) && tar cfz SOURCES/$(PACKAGE).tar.gz $(PACKAGE)
@@ -61,8 +64,11 @@ images:
 
 # Python packaging
 wheel:
+	cp -a tmt/__init__.py tmt/__init__.py.backup
+	sed -i $(REPLACE_VERSION) tmt/__init__.py
 	python setup.py bdist_wheel
 	python3 setup.py bdist_wheel
+	mv tmt/__init__.py.backup tmt/__init__.py
 upload:
 	twine upload dist/*.whl
 

--- a/tests/core/docs/test.sh
+++ b/tests/core/docs/test.sh
@@ -14,6 +14,11 @@ rlJournalStart
         rlRun "set -o pipefail"
     rlPhaseEnd
 
+    rlPhaseStartTest "version"
+        rlRun "tmt --version | tee output" 0 "Check version"
+        rlAssertGrep "tmt version:" "output"
+    rlPhaseEnd
+
     rlPhaseStartTest "help"
         rlRun "tmt --help | tee help" 0 "Run help"
         rlAssertGrep "Test Management Tool" "help"

--- a/tmt/__init__.py
+++ b/tmt/__init__.py
@@ -1,6 +1,9 @@
 """ Test Management Tool """
 
-from tmt.base import Tree, Test, Plan, Story, Run, Result, Status
-from tmt.steps.provision import Guest
+# Version is replaced before building the package
+__version__ = 'running from the source'
 
 __all__ = ['Tree', 'Test', 'Plan', 'Story', 'Run', 'Guest', 'Result', 'Status']
+
+from tmt.base import Tree, Test, Plan, Story, Run, Result, Status
+from tmt.steps.provision import Guest

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -154,8 +154,16 @@ def implemented_tested_documented(function):
          'to define individual dimensions or the @FILE notation to load data '
          'from provided yaml file. Can be specified multiple times. ')
 @verbose_debug_quiet
+@click.option(
+    '--version', is_flag=True,
+    help='Show tmt version and commit hash.')
 def main(click_contex, root, context, **kwargs):
     """ Test Management Tool """
+    # Show current tmt version and exit
+    if kwargs.get('version'):
+        print(f"tmt version: {tmt.__version__}")
+        raise SystemExit(0)
+
     # Save click context and fmf context for future use
     tmt.utils.Common._save_context(click_contex)
     click_contex.obj = tmt.utils.Common()


### PR DESCRIPTION
Instead of hard coding the version into the sources let's replace
the default string before building the packages.