### PR TITLE
Check for Nitrate test duplicates before creating new one

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -379,7 +379,7 @@ class Test(Node):
         return valid
 
     def export(
-            self, format_='yaml', keys=None, create=False, general=False, find_nitrate_cases=False):
+            self, format_='yaml', keys=None):
         """
         Export test data into requested format
 
@@ -404,7 +404,7 @@ class Test(Node):
 
         # Export to Nitrate test case management system
         elif format_ == 'nitrate':
-            tmt.export.export_to_nitrate(self, create, general, find_nitrate_cases)
+            tmt.export.export_to_nitrate(self)
 
         # Common node export otherwise
         else:

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -379,7 +379,7 @@ class Test(Node):
         return valid
 
     def export(
-            self, format_='yaml', keys=None, create=False, general=False):
+            self, format_='yaml', keys=None, create=False, general=False, find_nitrate_cases=False):
         """
         Export test data into requested format
 
@@ -404,7 +404,7 @@ class Test(Node):
 
         # Export to Nitrate test case management system
         elif format_ == 'nitrate':
-            tmt.export.export_to_nitrate(self, create, general)
+            tmt.export.export_to_nitrate(self, create, general, find_nitrate_cases)
 
         # Common node export otherwise
         else:

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -485,12 +485,13 @@ def import_(
     '--format', 'format_', default='yaml', show_default=True, metavar='FORMAT',
     help='Output format.')
 @click.option(
+    '--duplicate / --no-duplicate', default=False, show_default=True,
+    help='Allow or prevent creating duplicates in Nitrate by searching for '
+         'existing test cases with the same fmf identifier.')
+@click.option(
     '-d', '--debug', is_flag=True,
     help='Provide as much debugging details as possible.')
-@click.option(
-    '--no-duplicate', is_flag=True,
-    help='Search for Nitrate cases for fmf identifier before creating new one')
-def export(context, format_, nitrate, create, general, no_duplicate, **kwargs):
+def export(context, format_, nitrate, **kwargs):
     """
     Export test data into the desired format.
 
@@ -500,7 +501,7 @@ def export(context, format_, nitrate, create, general, no_duplicate, **kwargs):
     tmt.Test._save_context(context)
     for test in context.obj.tree.tests():
         if nitrate:
-            test.export(format_='nitrate', create=create, general=general, find_nitrate_cases=no_duplicate)
+            test.export(format_='nitrate')
         else:
             echo(test.export(format_=format_))
 

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -487,7 +487,10 @@ def import_(
 @click.option(
     '-d', '--debug', is_flag=True,
     help='Provide as much debugging details as possible.')
-def export(context, format_, nitrate, create, general, **kwargs):
+@click.option(
+    '--no-duplicate', is_flag=True,
+    help='Search for Nitrate cases for fmf identifier before creating new one')
+def export(context, format_, nitrate, create, general, no_duplicate, **kwargs):
     """
     Export test data into the desired format.
 
@@ -497,7 +500,7 @@ def export(context, format_, nitrate, create, general, **kwargs):
     tmt.Test._save_context(context)
     for test in context.obj.tree.tests():
         if nitrate:
-            test.export(format_='nitrate', create=create, general=general)
+            test.export(format_='nitrate', create=create, general=general, find_nitrate_cases=no_duplicate)
         else:
             echo(test.export(format_=format_))
 


### PR DESCRIPTION
This is important in case of virtual hierarchy. If you remove `extra-nitrate:` key.

My usecase is:

I'm using automatic conversion of fmf data from python unittest to FMF files.
and in case I'll remove TCMS key (by mistake, or want to regenerate all FMF files), it will create new TCMS testcases, it does not try to find if there already exist any node with the same FMF identifier in TCMS.

