### PR TITLE
Use the default branch in the discover fmf plugin

### DIFF
--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -1,5 +1,5 @@
 execute:
-    how: shell
+    how: tmt
 
 /smoke:
     provision:

--- a/tests/discover/references.sh
+++ b/tests/discover/references.sh
@@ -59,7 +59,7 @@ rlJournalStart
     rlPhaseStartTest $plan
         rlRun 'tmt run -dddv discover plan --name $plan | tee output'
         rlAssertGrep 'Cloning into' output
-        rlAssertGrep 'Checkout ref.*master' output
+        rlAssertNotGrep 'Checkout ref.*master' output
         rlAssertGrep /tests/core/docs output
         rlAssertGrep /tests/core/env output
         rlAssertGrep /tests/core/ls output
@@ -69,7 +69,7 @@ rlJournalStart
     rlPhaseStartTest $plan
         rlRun 'tmt run -dddv discover plan --name $plan | tee output'
         rlAssertGrep 'Cloning into' output
-        rlAssertGrep 'Checkout ref.*master' output
+        rlAssertNotGrep 'Checkout ref.*master' output
         rlAssertGrep '2 tests selected' output
         rlAssertGrep /tests/full output
         rlAssertGrep /tests/smoke output
@@ -80,6 +80,7 @@ rlJournalStart
         rlRun 'tmt run -dddv discover plan --name $plan | tee output'
         rlAssertGrep 'Cloning into' output
         rlAssertGrep 'Checkout ref.*5407fe5' output
+        rlAssertGrep 'hash.*5407fe5' output
         rlAssertGrep '2 tests selected' output
         rlAssertGrep /tests/docs output
         rlAssertNotGrep /tests/env output
@@ -91,6 +92,7 @@ rlJournalStart
         rlRun 'tmt run -dddv discover plan --name $plan | tee output'
         rlAssertGrep 'Cloning into' output
         rlAssertGrep 'Checkout ref.*eae4d52' output
+        rlAssertGrep 'hash.*eae4d52' output
         rlAssertGrep '2 tests selected' output
         rlAssertGrep /tests/full output
         rlAssertGrep /tests/smoke output

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -138,10 +138,7 @@ class Library(object):
                     ['git', 'clone', self.url, directory],
                     shell=False, env={"GIT_ASKPASS": "echo"})
                 # Detect the default branch from the origin
-                # The ref format is 'ref: refs/remotes/origin/master'
-                head = os.path.join(directory, '.git/refs/remotes/origin/HEAD')
-                with open(head) as ref:
-                    self.default_branch = ref.read().strip().split('/')[-1]
+                self.default_branch = tmt.utils.default_branch(directory)
                 # Use the default branch if no ref provided
                 if self.ref is None:
                     self.ref = self.default_branch

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -952,6 +952,18 @@ def remove_color(text):
     return re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', '', text)
 
 
+def default_branch(repository, remote='origin'):
+    """ Detect default branch from given local git repository """
+    head = os.path.join(repository, f'.git/refs/remotes/{remote}/HEAD')
+    # Make sure the HEAD reference is available
+    if not os.path.exists(head):
+        subprocess.run(
+            f'git remote set-head {remote} --auto'.split(), cwd=repository)
+    # The ref format is 'ref: refs/remotes/origin/main'
+    with open(head) as ref:
+        return ref.read().strip().split('/')[-1]
+
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  StructuredField
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Instead of `master` use the default branch from origin.
Add new function `default_branch()` to common utils.
Adjust relevant discover tests accordingly.
Show the current commit hash in verbose mode.

Resolves #505.