### PR TITLE
Strip whitespace before relevancy comment

### DIFF
--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -19,7 +19,7 @@ log = fmf.utils.Logging('tmt').logger
 
 
 # Test case relevancy regular expressions
-RELEVANCY_COMMENT =  r"^([^#]*)#\s*(.+)$"
+RELEVANCY_COMMENT =  r"^([^#]*?)\s*#\s*(.+)$"
 RELEVANCY_RULE = r"^([^:]+)\s*:\s*(.+)$"
 RELEVANCY_EXPRESSION = (
     r"^\s*(.*?)\s*(!?contains|!?defined|[=<>!]+)\s*(.*?)\s*$")


### PR DESCRIPTION
To allow rules as `arch != x86_64: False # reasoning`
Previously if failed with (note the trailing space):
Invalid test case relevancy decision 'False '.