### PR TITLE
Show the current tmt version in the debug log

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1048,6 +1048,7 @@ class Run(tmt.utils.Common):
         """ Go and do test steps for selected plans """
         # Show run id / workdir path
         self.info(self.workdir, color='magenta')
+        self.debug(f"tmt version: {tmt.__version__}")
         # Attempt to load run data
         self.load()
 


### PR DESCRIPTION
Make it possible to check the debug log and see which `tmt` version was used to run tests:

```
Using tree '/home/psss/git/tmt'.
/var/tmp/tmt/run-893
tmt version: 1.2.1 (26fac0d)
...
```