### PR TITLE
Make file descriptors non-blocking

### DIFF
--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -16,6 +16,7 @@ import yaml
 import re
 import io
 import os
+import fcntl
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
@@ -315,6 +316,11 @@ class Common(object):
             # Start the timer
             timer = Timer(timeout, kill)
             timer.start()
+
+            # Make sure that the read operation on the file descriptors
+            # never blocks
+            for fd in descriptors:
+                fcntl.fcntl(fd, fcntl.F_SETFL, os.O_NONBLOCK)
 
             # Capture the output
             while process.poll() is None:


### PR DESCRIPTION
This will make sure that the readline() call will never block. It will
return an empty string instead. The program will then go back in the
loop and check whether the subprocess is still running, and if so, it
will wait on select() again.