### PR TITLE
Store relevant bugs during test import

### DIFF
--- a/examples/convert/Makefile
+++ b/examples/convert/Makefile
@@ -42,5 +42,7 @@ $(METADATA): Makefile
 	@echo "Confidential:    no" >> $(METADATA)
 	@echo "Destructive:     no" >> $(METADATA)
 	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5" >> $(METADATA)
+	@echo "Bug:             12345" >> $(METADATA)
+	@echo "Bug:             1234567" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/tests/test/import/data/parent/child/Makefile
+++ b/tests/test/import/data/parent/child/Makefile
@@ -45,5 +45,6 @@ $(METADATA): Makefile
 	@echo "Environment:     TEST=one two three" >> $(METADATA)
 	@echo "Environment:     CONTEXT=distro=fedora" >> $(METADATA)
 	@echo "Releases:        -RHEL4 -RHELClient5 -RHELServer5" >> $(METADATA)
+	@echo "Bug:             1234567" >> $(METADATA)
 
 	rhts-lint $(METADATA)

--- a/tests/test/import/test.sh
+++ b/tests/test/import/test.sh
@@ -48,6 +48,11 @@ rlJournalStart
         rlAssertGrep 'CONTEXT: distro=fedora' 'output'
     rlPhaseEnd
 
+    rlPhaseStartTest 'Relevant bugs'
+        rlRun 'tmt test show | tee output'
+        rlAssertGrep 'relates.*1234567' 'output'
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "rm -r $tmp" 0 "Removing tmp directory"
         rlRun 'popd'


### PR DESCRIPTION
Check both Makefile and Nitrate for relevant bugs.
Store the information under the new `link` attribute.
Extend `/tests/test/import` with the relevant coverage.

Resolves #527.