### PR TITLE
Prevent keys mutation when searching plans/stories

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -875,7 +875,7 @@ class Tree(tmt.utils.Common):
         if Plan._opt('conditions'):
             conditions.extend(Plan._opt('conditions'))
         # Build the list and convert to objects
-        keys.append('execute')
+        keys = keys + ['execute']
         return self._filters_conditions(
             [Plan(plan, run=run)
                 for plan in self.tree.prune(keys=keys, names=names)],
@@ -892,7 +892,7 @@ class Tree(tmt.utils.Common):
         if Story._opt('conditions'):
             conditions.extend(Story._opt('conditions'))
         # Build the list and convert to objects
-        keys.append('story')
+        keys = keys + ['story']
         return self._filters_conditions(
             [Story(story) for story in self.tree.prune(
                 keys=keys, names=names, whole=whole)],


### PR DESCRIPTION
Similarly as in #593 for `Tree.tests()` prevent modifying `keys`
parameter provided to `Tree.plans()` and `Tree.stories()` as well.