### PR TITLE
Clarify playbook path for ansible prepare plugin

### DIFF
--- a/spec/steps/prepare.fmf
+++ b/spec/steps/prepare.fmf
@@ -30,18 +30,14 @@ description: |
     description:
         One or more playbooks can be provided as a list under the
         ``playbooks`` attribute.  Each of them will be applied
-        using ``ansible-playbook`` in the given order.  Optional
-        attribute ``roles`` can be used to enable additional
-        roles.  Role can be either an ansible galaxy role name,
-        git url or a path to file with detailed requirements.
+        using ``ansible-playbook`` in the given order. The path
+        should be relative to the metadata tree root.
     example: |
         prepare:
             how: ansible
-            role:
-                - nginxinc.nginx
             playbook:
-                - common.yml
-                - rhel7.yml
+                - playbooks/common.yml
+                - playbooks/os/rhel7.yml
     link:
       - implemented-by: /tmt/steps/provision
 

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -20,6 +20,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
               - playbook/two.yml
               - playbook/three.yml
 
+    The playbook path should be relative to the metadata tree root.
     Use 'order' attribute to select in which order preparation should
     happen if there are multiple configs. Default order is '50'.
     Default order of required packages installation is '70'.


### PR DESCRIPTION
Also remove the `role` example from the spec to prevent confusion
as this functionality has not been implemented yet.