### PR TITLE
base.Plan: Fix gates/artifacts conversion to list

### DIFF
--- a/spec/plans/gate.fmf
+++ b/spec/plans/gate.fmf
@@ -13,7 +13,7 @@ description: |
     release-update
         block releasing an erratum / bodhi update
 
-    Each testset can define one or more gates it should be blocking.
+    Each plan can define one or more gates it should be blocking.
     Attached is an example of configuring multiple gates.
 
 example: |
@@ -37,7 +37,7 @@ example: |
             /features:
                 summary: Verify important features
         /update:
-            # This enables the 'release-update' gate for all three testsets
+            # This enables the 'release-update' gate for all three plans
             gate:
                 - release-update
             /basic:

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -434,10 +434,10 @@ class Plan(Node):
             self.node.get('finish'), self)
 
         # Relevant gates (convert to list if needed)
-        self.gates = node.get('gates')
-        if self.gates:
-            if not isinstance(self.gates, list):
-                self.gates = [self.gates]
+        self.gate = node.get('gate')
+        if self.gate:
+            if not isinstance(self.gate, list):
+                self.gate = [self.gate]
 
         # Environment variables, make sure that values are string
         self._environment = dict([

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -433,15 +433,11 @@ class Plan(Node):
         self.finish = tmt.steps.finish.Finish(
             self.node.get('finish'), self)
 
-        # Relevant artifacts & gates (convert to list if needed)
-        self.artifacts = node.get('artifacts')
-        if self.artifacts:
-            if not isinstance(artifacts, list):
-                artifacts = [artifacts]
+        # Relevant gates (convert to list if needed)
         self.gates = node.get('gates')
         if self.gates:
-            if not isinstance(gates, list):
-                gates = [gates]
+            if not isinstance(self.gates, list):
+                self.gates = [self.gates]
 
         # Environment variables, make sure that values are string
         self._environment = dict([


### PR DESCRIPTION
Previously the code would crash with a use before assignment, as for the
variables the reference to self has been missing.
This patch fixes this oversight.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>