### PR TITLE
Test filter on command line overrides config

### DIFF
--- a/tests/test/select/data/plans.fmf
+++ b/tests/test/select/data/plans.fmf
@@ -1,0 +1,11 @@
+execute:
+    how: tmt
+
+/all:
+    discover:
+        how: fmf
+
+/selected:
+    discover:
+        how: fmf
+        test: tier

--- a/tests/test/select/test.sh
+++ b/tests/test/select/test.sh
@@ -33,13 +33,19 @@ rlJournalStart
     for name in '-n' '--name'; do
         rlPhaseStartTest "tmt run test $name <name>"
             tmt='tmt run -rv discover'
+            # Existing
             rlRun "$tmt test $name enabled | tee $output"
             rlAssertGrep "/tests/enabled/default" $output
             rlAssertNotGrep "/tests/enabled/disabled" $output
             rlAssertNotGrep "/tests/tag/default" $output
             rlAssertNotGrep "/tests/tier/default" $output
+            # Missing
             rlRun "$tmt test $name non-existent | tee $output"
             rlAssertGrep "No tests found" $output
+            # Using 'test --name' overrides 'test' in discover
+            rlRun "$tmt test $name tier/one | tee $output"
+            rlAssertGrep "/tests/tier/one" $output
+            rlAssertNotGrep "/tests/tier/two" $output
         rlPhaseEnd
     done
 

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -182,7 +182,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         filters = self.get('filter', [])
         for filter_ in filters:
             self.info('filter', filter_, 'green')
-        names = self.get('test', [])
+        # Check the 'test --name' option first, then 'test' from discover
+        names = list(tmt.base.Test._opt('names') or self.get('test', []))
         if names:
             self.info('names', fmf.utils.listed(names), 'green')
 


### PR DESCRIPTION
Using `tmt run test --name regexp` should override the default
test name filter detected from the discover step. Extend the
`/tests/test/select` test accordingly.

Resolves #618.