### PR TITLE
Catch all exceptions when evaluating --condition

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -847,9 +847,9 @@ class Tree(tmt.utils.Common):
             except fmf.utils.FilterError as error:
                 # Handle missing attributes as if condition failed
                 continue
-            except SyntaxError as error:
+            except Exception as error:
                 raise tmt.utils.GeneralError(
-                    f"Invalid condition syntax: {error}")
+                    f"Invalid --condition raised exception: {error}")
             # Filters
             try:
                 if not all([fmf.utils.filter(filter_, filter_vars, regexp=True)


### PR DESCRIPTION
Calling eval() inside fmf.utils.evaluate() may cause all kinds of Python
exceptions, not only SyntaxError, e.g. TypeError can be raised. Catch a
general Exception instead of SyntaxError to avoid tracebacks.

Resolves: #615 