### PR TITLE
Add hint to stdout in case of timeout

### DIFF
--- a/tests/execute/duration/test.sh
+++ b/tests/execute/duration/test.sh
@@ -11,6 +11,11 @@ rlJournalStart
         rlPhaseStartTest "Test $method"
             rlRun "tmt run -vfi $tmp -a execute -h $method test --name good" 0
             rlRun "tmt run -vfi $tmp -a execute -h $method test --name long" 2
+            if [ "$method" == "tmt" ]; then
+                rlRun -s "tmt run --last report -fvvv" 2
+                rlAssertGrep "Test duration '3s' exceeded." $rlRun_LOG
+                rlAssertGrep "HINT: https://tmt.readthedocs.io/en/latest/spec/tests.html#duration" $rlRun_LOG
+            fi
         rlPhaseEnd
     done
 

--- a/tests/execute/duration/test.sh
+++ b/tests/execute/duration/test.sh
@@ -11,11 +11,10 @@ rlJournalStart
         rlPhaseStartTest "Test $method"
             rlRun "tmt run -vfi $tmp -a execute -h $method test --name good" 0
             rlRun "tmt run -vfi $tmp -a execute -h $method test --name long" 2
-            if [ "$method" == "tmt" ]; then
-                rlRun -s "tmt run --last report -fvvv" 2
-                rlAssertGrep "Test duration '3s' exceeded." $rlRun_LOG
-                rlAssertGrep "HINT: https://tmt.readthedocs.io/en/latest/spec/tests.html#duration" $rlRun_LOG
-            fi
+            rlRun -s "tmt run --last report -fvvv" 2
+            rlAssertGrep "Maximum test time '3s' exceeded." $rlRun_LOG
+            rlAssertGrep "Adjust the test 'duration' attribute" $rlRun_LOG
+            rlAssertGrep "spec/tests.html#duration" $rlRun_LOG
         rlPhaseEnd
     done
 

--- a/tmt/steps/execute/detach.py
+++ b/tmt/steps/execute/detach.py
@@ -130,7 +130,7 @@ class ExecuteDetach(tmt.steps.execute.ExecutePlugin):
             guest.pull()
             self.show_logs()
             for test in self.step.plan.discover.tests():
-                test.duration = self.test_duration(start, end)
+                test.real_duration = self.test_duration(start, end)
                 self._results.append(self.check(test))
 
     def results(self):

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -84,6 +84,10 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             test.returncode = error.returncode
             if test.returncode == tmt.utils.PROCESS_TIMEOUT:
                 timeout = ' (timeout)'
+                stdout += f"""
+Test duration '{test.duration}' exceeded.
+HINT: https://tmt.readthedocs.io/en/latest/spec/tests.html#duration
+                """
                 self.debug(f"Test duration '{test.duration}' exceeded.")
         end = time.time()
         self.write(

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -84,19 +84,15 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             test.returncode = error.returncode
             if test.returncode == tmt.utils.PROCESS_TIMEOUT:
                 timeout = ' (timeout)'
-                stdout += f"""
-Test duration '{test.duration}' exceeded.
-HINT: https://tmt.readthedocs.io/en/latest/spec/tests.html#duration
-                """
                 self.debug(f"Test duration '{test.duration}' exceeded.")
         end = time.time()
         self.write(
             self.data_path(test, TEST_OUTPUT_FILENAME, full=True),
             stdout or '', level=3)
-        test.duration = self.test_duration(start, end)
+        test.real_duration = self.test_duration(start, end)
+        duration = click.style(test.real_duration, fg='cyan')
         shift = 1 if self.opt('verbose') < 2 else 2
-        self.verbose(
-            f"{test.duration} {test.name}{timeout}", color='cyan', shift=shift)
+        self.verbose(f"{duration} {test.name}{timeout}", shift=shift)
 
     def check(self, test):
         """ Check the test result """

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -420,17 +420,18 @@ class Common(object):
         except OSError as error:
             raise FileError(f"Failed to read '{path}'.\n{error}")
 
-    def write(self, path, data, level=2):
+    def write(self, path, data, mode='w', level=2):
         """ Write a file to the workdir """
         if self.workdir:
             path = os.path.join(self.workdir, path)
-        self.debug(f"Write file '{path}'.", level=level)
+        action = 'Append to' if mode == 'a' else 'Write'
+        self.debug(f"{action} file '{path}'.", level=level)
         # Dry mode
         if self.opt('dry'):
             return
         try:
-            with open(path, 'w', encoding='utf-8', errors='replace') as target:
-                return target.write(data)
+            with open(path, mode, encoding='utf-8', errors='replace') as file:
+                return file.write(data)
         except OSError as error:
             raise FileError(f"Failed to write '{path}'.\n{error}")
 


### PR DESCRIPTION
For better visibility let's add a note about timeout
also to standard output of the test.

Implemented only for `tmt` method, as with detached
it is hard to do.

Resolves #627

```
$ tmt run 
/var/tmp/tmt/run-126

/plan
    discover
        how: shell
        directory: /home/mvadkert/temp/testik
        summary: 1 test selected
    provision
        how: local
        distro: Fedora 30 (Thirty)
        summary: 1 guest provisioned
    prepare
        summary: 0 preparations applied
    execute
        how: tmt
        summary: 1 test executed
    report
        how: display
        summary: 1 error
    finish
        summary: 0 tasks completed

total: 1 error
```

```
$ tmt run --last report -fvvv
/var/tmp/tmt/run-126

/plan
    report
        how: display
        order: 50
            errr /testik (timeout)
                output.txt: /var/tmp/tmt/run-126/plan/execute/data/testik/output.txt
                content: 
                    HEEEELLPPP
                    
                    Test duration '1s' exceeded.
                    HINT: https://tmt.readthedocs.io/en/latest/spec/tests.html#duration
                                    
        summary: 1 error

total: 1 error
```

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>