### PR TITLE
Always enable force mode for display/html report

### DIFF
--- a/tests/report/summary/test.sh
+++ b/tests/report/summary/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Check summary"
-        rlRun "tmt run | tee output" 2 "Run tests in verbose mode"
+        rlRun "tmt run | tee output" 2 "Run tests in concise mode"
         rlAssertGrep "3 tests passed, 2 tests failed and 1 error" "output"
     rlPhaseEnd
 
@@ -21,6 +21,17 @@ rlJournalStart
         rlAssertGrep "pass /test/good/two" "output"
         rlAssertGrep "errr /test/weird/one" "output"
     rlPhaseEnd
+
+    rlPhaseStartTest "Check the last run"
+        rlRun "tmt run -l | tee output" 2 "Last run in concise mode "
+        rlAssertGrep "3 tests passed, 2 tests failed and 1 error" "output"
+        rlRun "tmt run -lv | tee output" 2 "Last run in verbose mode "
+        rlAssertGrep "3 tests passed, 2 tests failed and 1 error" "output"
+        rlAssertGrep "fail /test/bad/one" "output"
+        rlAssertGrep "pass /test/good/one" "output"
+        rlAssertGrep "errr /test/weird/one" "output"
+    rlPhaseEnd
+
 
     rlPhaseStartCleanup
         rlRun "rm output" 0 "Removing tmp directory"

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -130,6 +130,15 @@ class Step(tmt.utils.Common):
             self.debug("Step has not finished. Let's try once more!", level=2)
             self._workdir_cleanup()
 
+        # Special handling for the report step to always enable force mode in
+        # order to cover a very frequent use case 'tmt run --last report'
+        # FIXME find a better way how to enable always-force per plugin
+        if (isinstance(self, tmt.steps.report.Report) and
+                self.data[0].get('how') in ['display', 'html']):
+            self.debug("Report step always force mode enabled.")
+            self._workdir_cleanup()
+            self.status('todo')
+
         # Insert login plugins if requested on the command line
         for plugin in Login.plugins(step=self):
             self.debug(


### PR DESCRIPTION
In order to cover quite common use case to check the last run
results in verbose mode we should not require using `--force`.
Enabling always force per report plugin would need more time.
For now just a quick fix.

Resolves #387.