### PR TITLE
Testcloud: Use qemu usermode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
 extras_require = {
     'docs': ['sphinx', 'sphinx_rtd_theme', 'mock'],
     'tests': ['pytest', 'python-coveralls', 'mock', 'requre'],
-    'provision': ['testcloud'],
+    'provision': ['testcloud>=0.5.0'],
     'convert': ['nitrate'],
     'report-html': ['jinja2'],
 }

--- a/tmt.spec
+++ b/tmt.spec
@@ -70,7 +70,7 @@ Dependencies required to run tests in a container environment.
 Summary: Virtual machine provisioner for the Test Management Tool
 Obsoletes: tmt-testcloud < 0.17
 Requires: tmt == %{version}-%{release}
-Requires: python%{python3_pkgversion}-testcloud >= 0.3.5
+Requires: python%{python3_pkgversion}-testcloud >= 0.5.0
 Requires: ansible openssh-clients
 
 %description provision-virtual

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -200,6 +200,8 @@ class Guest(tmt.utils.Common):
 
     def _ssh_guest(self):
         """ Return user@guest """
+        if ":" in self.guest:
+            return f'{self.user}@{self.guest.split(":")[0]}'
         return f'{self.user}@{self.guest}'
 
     def _ssh_options(self, join=False):
@@ -208,6 +210,8 @@ class Guest(tmt.utils.Common):
             '-oStrictHostKeyChecking=no',
             '-oUserKnownHostsFile=/dev/null',
             ]
+        if ":" in self.guest:
+            options.append(f'-p {self.guest.split(":")[1]}')
         if self.key:
             options.extend(['-i', self.key])
         return ' '.join(options) if join else options

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -177,6 +177,7 @@ class Guest(tmt.utils.Common):
     The following keys are expected in the 'data' dictionary::
 
         guest ...... hostname or ip address
+        port ....... port to connect to
         user ....... user name to log in
         key ........ private key
         password ... password
@@ -187,7 +188,7 @@ class Guest(tmt.utils.Common):
 
     # List of supported keys
     # (used for import/export to/from attributes during load and save)
-    _keys = ['guest', 'user', 'key', 'password']
+    _keys = ['guest', 'port', 'user', 'key', 'password']
 
     def __init__(self, data, name=None, parent=None):
         """ Initialize guest data """
@@ -200,8 +201,6 @@ class Guest(tmt.utils.Common):
 
     def _ssh_guest(self):
         """ Return user@guest """
-        if ":" in self.guest:
-            return f'{self.user}@{self.guest.split(":")[0]}'
         return f'{self.user}@{self.guest}'
 
     def _ssh_options(self, join=False):
@@ -210,8 +209,8 @@ class Guest(tmt.utils.Common):
             '-oStrictHostKeyChecking=no',
             '-oUserKnownHostsFile=/dev/null',
             ]
-        if ":" in self.guest:
-            options.append(f'-p {self.guest.split(":")[1]}')
+        if self.port:
+            options.extend(['-p', str(self.port)])
         if self.key:
             options.extend(['-i', self.key])
         return ' '.join(options) if join else options

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -314,9 +314,8 @@ class GuestTestcloud(tmt.Guest):
 
     @staticmethod
     def _create_template():
-        """ Create libvirt domain template if it does not exist """
-        if os.path.exists(DOMAIN_TEMPLATE_FILE):
-            return
+        """ Create libvirt domain template """
+        # Write always to ovewrite possible outdated version
         with open(DOMAIN_TEMPLATE_FILE, 'w') as template:
             template.write(DOMAIN_TEMPLATE)
 
@@ -414,7 +413,8 @@ class GuestTestcloud(tmt.Guest):
         # Create instance
         self.instance_name = self._random_name()
         self.instance = testcloud.instance.Instance(
-            name=self.instance_name, image=self.image, connection='qemu:///session')
+            name=self.instance_name, image=self.image,
+            connection='qemu:///session')
         self.verbose('name', self.instance_name, 'green')
 
         # Prepare ssh key
@@ -432,10 +432,11 @@ class GuestTestcloud(tmt.Guest):
                 libvirt.libvirtError) as error:
             raise ProvisionError(
                 f'Failed to boot testcloud instance ({error}).')
-        self.instance.create_ip_file(self.instance.get_ip())
-        # create_port_file(self.guest) is called by tescloud in write_domain_xml() that gets
-        # called by spawn_vm()
-        self.guest = "%s:%s" % (self.instance.get_ip(), self.instance.get_instance_port())
+        self.guest = self.instance.get_ip()
+        self.port = self.instance.get_instance_port()
+        self.verbose('ip', self.guest, 'green')
+        self.verbose('port', self.port, 'green')
+        self.instance.create_ip_file(self.guest)
 
         # Wait a bit until the box is up
         timeout = DEFAULT_CONNECT_TIMEOUT


### PR DESCRIPTION
Testcloud 0.5.0 is required and is available in all supported Fedoras, pypi and EPEL 8.