### PR TITLE
Implement tmt clean

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -180,7 +180,9 @@ Here's the overview of core classes::
     │   ├── GuestLocal
     │   ├── GuestMinute
     │   └── GuestTestcloud
-    └── Run
+    ├── Run
+    ├── Status
+    └── Clean
 
 
 Attributes

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1083,3 +1083,156 @@ one enabled step has not been finished)::
     $ tmt status --active
     status     id
     prepare    /var/tmp/tmt/run-002
+
+
+
+Clean
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When running tests, a lot of metadata can gather over time taking
+a lot of space. It may be useful to clean it every now and then
+using the ``clean`` command. Its goal is to stop the running
+guests, remove working directories or remove images. Without any
+subcommand, all of these actions are done::
+
+    $ tmt clean
+    clean
+        guests
+        runs
+        images
+            testcloud
+
+It may be useful to see exactly which runs are affected using
+the ``--verbose`` option::
+
+    $ tmt clean -v
+    clean
+        guests
+            Stopping guests in run '/var/tmp/tmt/run-001' plan '/base'.
+        runs
+            Removing workdir '/var/tmp/tmt/run-003'.
+            Removing workdir '/var/tmp/tmt/run-002'.
+            Removing workdir '/var/tmp/tmt/run-001'.
+        images
+            testcloud
+                warn: Directory '/var/tmp/tmt/testcloud/images' does not exist.
+
+However, before cleaning up all available metadata, you may want
+to see what would actually happen using ``--dry`` mode::
+
+    $ tmt clean -v --dry
+    clean
+        guests
+            Would stop guests in run '/var/tmp/tmt/run-001' plan '/advanced'.
+            Would stop guests in run '/var/tmp/tmt/run-001' plan '/base'.
+        runs
+            Would remove workdir '/var/tmp/tmt/run-002'.
+            Would remove workdir '/var/tmp/tmt/run-001'.
+        images
+            testcloud
+                warn: Directory '/var/tmp/tmt/testcloud/images' does not exist.
+
+In some cases, you may want to have a bit more control over the
+behaviour which can be achieved using subcommands and their
+options. All of the options described above can be used with
+individual subcommands too.
+
+
+Clean guests
+------------------------------------------------------------------
+
+The subcommand ``clean guests`` aims to stop all running guests.
+By default, runs are taken from ``/var/tmp/tmt``, this can be
+changed using an argument to the subcommand::
+
+    $ tmt clean guests -v /tmp/run
+    clean
+        guests
+            Stopping guests in run '/tmp/run/002' plan '/advanced'.
+            Stopping guests in run '/tmp/run/002' plan '/base'.
+
+You may also want to clean the guests in only one run using
+``--id`` or ``--last`` options. This serves as an alternative
+to ``tmt run --last finish``::
+
+    $ tmt clean guests -v --last
+    clean
+        guests
+            Stopping guests in run '/var/tmp/tmt/run-003' plan '/advanced'.
+            Stopping guests in run '/var/tmp/tmt/run-003' plan '/base'.
+
+The type of provision to be cleaned can be changed using
+``--how`` option::
+
+    $ tmt run provision -h container
+    /var/tmp/tmt/run-001
+    ...
+
+    $ tmt run provision -h virtual
+    /var/tmp/tmt/run-002
+    ...
+
+    $ tmt clean guests --how container
+    clean
+        guests
+            Stopping guests in run '/var/tmp/tmt/run-001' plan '/advanced'.
+            Stopping guests in run '/var/tmp/tmt/run-001' plan '/base'.
+
+    $ tmt clean guests --how virtual
+    clean
+        guests
+            Stopping guests in run '/var/tmp/tmt/run-002' plan '/advanced'.
+            Stopping guests in run '/var/tmp/tmt/run-002' plan '/base'.
+
+
+Clean workdirs
+------------------------------------------------------------------
+
+The goal of ``clean runs`` is to remove workdirs of past runs.
+Similarly to above, ``/var/tmp/tmt`` is used by default as run
+location and this can be changed using an argument::
+
+    $ tmt clean runs /tmp/run
+    clean
+        runs
+            Removing workdir '/tmp/run/001'.
+
+Only one specific run can also be removed using ``--id`` or
+``--last`` options, similarly to ``clean guests``::
+
+    $ tmt clean runs -v -i /var/tmp/tmt/run-001
+    clean
+        runs
+            Removing workdir '/var/tmp/tmt/run-001'.
+
+You may also want to remove only old runs. This can be achieved
+using ``--keep`` option which allows you to specify the number
+of latest runs to keep::
+
+    $ for i in $(seq 1 10); do tmt run; done
+    ...
+
+    $ tmt clean runs --dry -v --keep 5
+    clean
+        runs
+            Would remove workdir '/var/tmp/tmt/run-005'.
+            Would remove workdir '/var/tmp/tmt/run-004'.
+            Would remove workdir '/var/tmp/tmt/run-003'.
+            Would remove workdir '/var/tmp/tmt/run-002'.
+            Would remove workdir '/var/tmp/tmt/run-001'.
+
+
+Clean images
+------------------------------------------------------------------
+
+The subcommand ``clean images`` removes images of all provision
+methods that support it. Currently, only testcloud provision
+supports this option, the images are removed from
+``/var/tmp/tmt/testcloud/images``::
+
+    $ tmt clean images
+    clean
+        images
+            testcloud
+                Removing '/var/tmp/tmt/testcloud/images/Fedora-Cloud-Base-34_Beta-1.3.x86_64.qcow2'.
+

--- a/tests/clean/guests/main.fmf
+++ b/tests/clean/guests/main.fmf
@@ -1,0 +1,1 @@
+summary: Checks whether tmt clean guests works correctly

--- a/tests/clean/guests/test.sh
+++ b/tests/clean/guests/test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "tmt init"
+        rlRun "tmt plan create -t mini plan1"
+        rlRun "tmt run --until provision provision -h container | tee run-output"
+        rlRun "runid=\$(head -n 1 run-output)" 0 "Get the run ID"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Dry mode"
+        rlRun "tmt status -vv | tee output"
+        rlAssertGrep "(done\s+){2}(todo\s+){4}$runid\s+/plan1" "output" -E
+        rlRun "tmt clean guests --dry -v | tee output"
+        rlAssertGrep "Would stop guests in run '$runid'" "output"
+        rlRun "tmt status -vv | tee output"
+        rlAssertGrep "(done\s+){2}(todo\s+){4}$runid\s+/plan1" "output" -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Specify ID"
+        rlRun "tmt clean guests --dry -v -l | tee output"
+        rlAssertGrep "Would stop guests in run '$runid'" "output"
+
+        rlRun "tmt clean guests --dry -v -i $runid | tee output"
+        rlAssertGrep "Would stop guests in run '$runid'" "output"
+
+        rlRun "tmt status -vv | tee output"
+        rlAssertGrep "(done\s+){2}(todo\s+){4}$runid\s+/plan1" "output" -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Filter by how"
+        rlRun "tmt clean guests --dry -v --how container | tee output"
+        rlAssertGrep "Would stop guests in run '$runid'" "output"
+
+        rlRun "tmt clean guests --dry -v --how virtual | tee output"
+        rlAssertNotGrep "Would stop guests in run '$runid'" "output"
+
+        rlRun "tmt status -vv | tee output"
+        rlAssertGrep "(done\s+){2}(todo\s+){4}$runid\s+/plan1" "output" -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Stop the guest"
+        rlRun "tmt clean guests -v -i $runid | tee output"
+        rlAssertGrep "Stopping guests in run '$runid'" "output"
+        rlRun "tmt status -vv | tee output"
+        rlAssertGrep "(done\s+){2}(todo\s+){3}done\s+$runid\s+/plan1" "output" -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Different root"
+        rlRun "tmprun=\$(mktemp -d)" 0 "Create a temporary directory for runs"
+        rlRun "tmt run -i $tmprun/run1 --until provision provision -h local | tee run-output"
+        rlRun "tmt run -i $tmprun/run2 --until provision provision -h local | tee run-output"
+        rlRun "tmt clean guests $tmprun"
+        rlRun "tmt status $tmprun -vv | tee output"
+        rlAssertGrep "(done\s+){2}(todo\s+){3}done\s+$tmprun/run1" "output" -E
+        rlAssertGrep "(done\s+){2}(todo\s+){3}done\s+$tmprun/run2" "output" -E
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+        rlRun "rm -r $tmprun" 0 "Remove a temporary directory for runs"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/clean/runs/main.fmf
+++ b/tests/clean/runs/main.fmf
@@ -1,0 +1,1 @@
+summary: Checks whether tmt clean runs works correctly

--- a/tests/clean/runs/test.sh
+++ b/tests/clean/runs/test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "tmt init"
+        rlRun "tmt plan create -t mini plan1"
+        rlRun "tmprun=\$(mktemp -d)" 0 "Create a temporary directory for runs"
+
+        rlRun "run1=$tmprun/1"
+        rlRun "tmt run -i $run1 discover"
+
+        rlRun "run2=$tmprun/2"
+        rlRun "tmt run -i $run2 discover"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Dry mode"
+        rlRun "tmt clean runs --dry -v $tmprun | tee output"
+        rlAssertGrep "Would remove workdir '$run1'" "output"
+        rlAssertGrep "Would remove workdir '$run2'" "output"
+        rlRun "tmt status $tmprun -vv | tee output"
+        rlAssertGrep "(done\s+){1}(todo\s+){5}$run1\s+/plan1" "output" -E
+        rlAssertGrep "(done\s+){1}(todo\s+){5}$run2\s+/plan1" "output" -E
+    rlPhaseEnd
+
+    rlPhaseStartTest "Specify ID"
+        rlRun "tmt clean runs -v -i $run1 | tee output"
+        rlAssertGrep "Removing workdir '$run1'" "output"
+        rlRun "tmt status $tmprun -vv | tee output"
+        rlAssertNotGrep "(done\s+){1}(todo\s+){5}$run1\s+/plan1" "output" -E
+        rlAssertGrep "(done\s+){1}(todo\s+){5}$run2\s+/plan1" "output" -E
+
+        rlRun "tmt clean runs -v -l | tee output"
+        rlAssertGrep "Removing workdir '$run2'" "output"
+        rlRun "tmt status $tmprun -vv | tee output"
+        rlAssertNotGrep "(done\s+){1}(todo\s+){5}$run2\s+/plan1" "output" -E
+
+        rlRun "wc -l output | tee lines" 0 "Get the number of lines"
+        rlLog "The status should only contain the heading"
+        rlAssertGrep "1" "lines"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Keep N"
+        for i in $(seq 1 10); do
+            rlRun "tmt run -i $tmprun/$i discover"
+        done
+        rlRun "tmt clean runs -v --keep 10 $tmprun"
+        rlRun "tmt status $tmprun -vv | tee output"
+        rlLog "The runs should remain intact"
+        for i in $(seq 1 10); do
+            rlAssertGrep "$tmprun/$i\s+/plan1" "output" -E
+        done
+
+        rlRun "tmt clean runs -v --keep 2 $tmprun"
+        rlRun "tmt status $tmprun -vv | tee output"
+        rlAssertGrep "$tmprun/9" "output"
+        rlAssertGrep "$tmprun/10" "output"
+
+        for i in $(seq 1 8); do
+            rlAssertNotGrep "$tmprun/$i\s+/plan1" "output" -E
+        done
+
+        rlRun "tmt clean runs -v --keep 1 $tmprun"
+        rlRun "tmt status $tmprun -vv | tee output"
+        rlAssertNotGrep "$tmprun/9" "output"
+        rlAssertGrep "$tmprun/10" "output"
+
+        rlRun "tmt clean runs -v --keep 0 $tmprun"
+        rlRun "tmt status $tmprun -vv | tee output"
+        rlAssertNotGrep "$tmprun/10" "output"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Remove everything"
+        for i in $(seq 1 10); do
+            rlRun "tmt run -i $tmprun/$i discover"
+        done
+        rlRun "tmt clean runs -v $tmprun"
+        rlRun "tmt status -vv $tmprun | tee output"
+        rlRun "wc -l output | tee lines" 0 "Get the number of lines"
+        rlLog "The status should only contain the heading"
+        rlAssertGrep "1" "lines"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+        rlRun "rm -r $tmprun" 0 "Remove a temporary directory for runs"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/__init__.py
+++ b/tmt/__init__.py
@@ -3,7 +3,8 @@
 # Version is replaced before building the package
 __version__ = 'running from the source'
 
-__all__ = ['Tree', 'Test', 'Plan', 'Story', 'Run', 'Guest', 'Result', 'Status']
+__all__ = ['Tree', 'Test', 'Plan', 'Story', 'Run', 'Guest', 'Result',
+           'Status', 'Clean']
 
-from tmt.base import Tree, Test, Plan, Story, Run, Result, Status
+from tmt.base import Tree, Test, Plan, Story, Run, Result, Status, Clean
 from tmt.steps.provision import Guest

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -170,6 +170,10 @@ class ProvisionPlugin(tmt.steps.Plugin):
         """ List of required packages needed for workdir sync """
         return Guest.requires()
 
+    @classmethod
+    def clean_images(cls, clean, dry):
+        """ Remove the images of one particular plugin """
+
 
 class Guest(tmt.utils.Common):
     """

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -237,6 +237,22 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
         """ Return the provisioned guest """
         return self._guest
 
+    @classmethod
+    def clean_images(cls, clean, dry):
+        """ Remove the testcloud images """
+        clean.info('testcloud', shift=1, color='green')
+        if not os.path.exists(TESTCLOUD_IMAGES):
+            clean.warn(
+                f"Directory '{TESTCLOUD_IMAGES}' does not exist.", shift=2)
+            return
+        for image in os.listdir(TESTCLOUD_IMAGES):
+            image = os.path.join(TESTCLOUD_IMAGES, image)
+            if dry:
+                clean.verbose(f"Would remove '{image}'.", shift=2)
+            else:
+                clean.verbose(f"Removing '{image}'.", shift=2)
+                os.remove(image)
+
 
 class GuestTestcloud(tmt.Guest):
     """


### PR DESCRIPTION
Just an initial draft for command-line interface putting together everything that was mentioned in https://github.com/psss/tmt/issues/436 to give some space for feedback/discussion. @psss @thrix does this look reasonable to you or is there anything missing or something could be improved? I will slowly start working on the implementation so we should hopefully have something working soon :)

I thought about `tmt clean images` and for now it only make sense for testcloud provision but perhaps in the future, there may be more.

Resolves: #436 