### PR TITLE
Fix step selection for --before and --after

### DIFF
--- a/tests/steps/select/test.sh
+++ b/tests/steps/select/test.sh
@@ -44,7 +44,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Until"
-        rlRun "tmt run --until execute | tee output"
+        rlRun "tmt run --until execute discover -h shell | tee output"
         for step in discover provision prepare execute; do
             rlAssertGrep $step output
         done
@@ -55,7 +55,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Since"
-        rlRun "tmt run --last --since report | tee output"
+        rlRun "tmt run --last --since report finish -h shell | tee output"
         for step in discover provision prepare execute; do
             rlAssertNotGrep $step output
         done
@@ -66,7 +66,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Before"
-        rlRun "tmt run --before report | tee output"
+        rlRun "tmt run --before report discover -h shell | tee output"
         for step in discover provision prepare execute; do
             rlAssertGrep $step output
         done
@@ -77,7 +77,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "After"
-        rlRun "tmt run --last --after execute | tee output"
+        rlRun "tmt run --last --after execute finish -h shell | tee output"
         for step in discover provision prepare execute; do
             rlAssertNotGrep $step output
         done

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1125,7 +1125,7 @@ class Run(tmt.utils.Common):
         before = self.opt('before')
         skip = self.opt('skip')
 
-        if all_steps or since or until:
+        if any([all_steps, since, until, after, before]):
             # Detect index of the first and last enabled step
             if since:
                 first = tmt.steps.STEPS.index(since)

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -213,10 +213,10 @@ def main(click_contex, root, context, **kwargs):
     help='Enable given step and all following steps.')
 @click.option(
     '-A', '--after', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
-    help='Enable all steps before the given one.')
+    help='Enable all steps after the given one.')
 @click.option(
     '-B', '--before', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
-    help='Enable all steps after the given one.')
+    help='Enable all steps before the given one.')
 @click.option(
     '-S', '--skip', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
     help='Skip given step(s) during test run execution.', multiple=True)


### PR DESCRIPTION
All steps before/after the specified one must be enabled similarly to
--until and --since even if one of the steps is modified.

Also fix their swapped help messages.