### PR TITLE
Strip .git from github.com URL for libraries (any repo from github)

### DIFF
--- a/tests/discover/libraries/data/plan.fmf
+++ b/tests/discover/libraries/data/plan.fmf
@@ -17,6 +17,11 @@ execute:
     provision:
         how: virtual
 
+/strip_git_suffix:
+    summary: "Check libraries can end in '.git' suffix"
+    discover+:
+        test: strip_git_suffix
+
 /certificate:
     /rpm:
         summary: "Certificate test (rpm format)"

--- a/tests/discover/libraries/data/strip_git_suffix.fmf
+++ b/tests/discover/libraries/data/strip_git_suffix.fmf
@@ -1,0 +1,30 @@
+summary: Check libraries can end in '.git' suffix
+description:
+    User doesn't need to care/remember whether to use '.git'
+    suffix or not in the 'require' or 'recommend' section -
+    both are allowed.
+test: ./file.sh
+
+/test1:
+  recommend:
+    - url: https://github.com/beakerlib/database.git
+      name: /mysql
+    - library(database/postgresql)
+  require:
+    - library(database/mariadb)
+    - url: https://github.com/beakerlib/test
+      name: /very/deep/file
+/test2:
+  require:
+    - library(database/mariadb)
+    - url: https://github.com/beakerlib/squid.git
+      name: /squid
+  recommend:
+    - url: https://github.com/beakerlib/database.git
+      name: /postgresql
+    - library(database/postgresql)
+    - url: https://github.com/psss/fmf.git
+/test3:
+  recommend:
+    - url: https://github.com/beakerlib/database.git
+      name: /postgresql

--- a/tests/discover/libraries/data/strip_git_suffix.fmf
+++ b/tests/discover/libraries/data/strip_git_suffix.fmf
@@ -20,7 +20,7 @@ test: ./file.sh
     - url: https://github.com/beakerlib/squid.git
       name: /squid
   recommend:
-    - url: https://github.com/beakerlib/database.git
+    - url: https://github.com/beakerlib/database
       name: /postgresql
     - library(database/postgresql)
     - url: https://github.com/psss/fmf.git

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -52,6 +52,16 @@ rlJournalStart
         rlAssertGrep 'the library is stored deep.' $tmp/output
     rlPhaseEnd
 
+    rlPhaseStartTest "strip_git_suffix"
+        rlRun "$tmt strip_git_suffix 2>&1 | tee $tmp/output" 0
+        rlAssertGrep "summary: 3 tests selected" "$tmp/output"
+        rlAssertGrep "/strip_git_suffix/test2" "$tmp/output"
+        rlAssertGrep "Detected library '{'url': 'https://github.com/psss/fmf.git'}'."\
+                   "$tmp/output"
+        rlAssertNotGrep 'Library.*conflicts with already fetched library' \
+                   "$tmp/output"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $tmp" 0 "Removing tmp directory"

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -5,7 +5,7 @@
 rlJournalStart
     rlPhaseStartSetup
         rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
-        rlRun "tmt='tmt run -avvvddd plan --name'"
+        rlRun "tmt='tmt run -arvvvddd plan --name'"
         rlRun "pushd data"
         rlRun "set -o pipefail"
     rlPhaseEnd
@@ -52,14 +52,15 @@ rlJournalStart
         rlAssertGrep 'the library is stored deep.' $tmp/output
     rlPhaseEnd
 
-    rlPhaseStartTest "strip_git_suffix"
+    rlPhaseStartTest "Strip git suffix"
         rlRun "$tmt strip_git_suffix 2>&1 | tee $tmp/output" 0
         rlAssertGrep "summary: 3 tests selected" "$tmp/output"
         rlAssertGrep "/strip_git_suffix/test2" "$tmp/output"
-        rlAssertGrep "Detected library '{'url': 'https://github.com/psss/fmf.git'}'."\
-                   "$tmp/output"
+        rlAssertGrep \
+            "Detected library '{'url': 'https://github.com/psss/fmf.git'}'." \
+            "$tmp/output"
         rlAssertNotGrep 'Library.*conflicts with already fetched library' \
-                   "$tmp/output"
+            "$tmp/output"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -13,6 +13,13 @@ LIBRARY_REGEXP = re.compile(r'^library\(([^/]+)(/[^)]+)\)$')
 DEFAULT_REPOSITORY = 'https://github.com/beakerlib'
 DEFAULT_DESTINATION = 'libs'
 
+# List of git forges for which the .git suffix should be stripped
+STRIP_SUFFIX_FORGES = [
+    'https://github.com',
+    'https://gitlab.com',
+    'https://pagure.io',
+    ]
+
 
 class LibraryError(Exception):
     """ Used when library cannot be parsed from the identifier """
@@ -72,10 +79,8 @@ class Library(object):
             self.parent.debug(f"Detected library '{identifier}'.", level=3)
             self.format = 'fmf'
             self.url = identifier.get('url')
-            for i in ['https://github.com',
-                      'https://gitlab.com',
-                      'https://pagure.io']:
-                if self.url.startswith(i) and self.url.endswith('.git'):
+            for forge in STRIP_SUFFIX_FORGES:
+                if self.url.startswith(forge) and self.url.endswith('.git'):
                     self.url = self.url.rstrip('.git')
             self.ref = identifier.get('ref', None)
             self.dest = identifier.get(

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -72,6 +72,11 @@ class Library(object):
             self.parent.debug(f"Detected library '{identifier}'.", level=3)
             self.format = 'fmf'
             self.url = identifier.get('url')
+            for i in ['https://github.com',
+                      'https://gitlab.com',
+                      'https://pagure.io']:
+                if self.url.startswith(i) and self.url.endswith('.git'):
+                    self.url = self.url.rstrip('.git')
             self.ref = identifier.get('ref', None)
             self.dest = identifier.get(
                 'destination', DEFAULT_DESTINATION).lstrip('/')


### PR DESCRIPTION
#614
After this patch it's possible to have github.com repos with or without .git suffix in `require` and `recommend` sections together with `library` field.
```
tmt -dv run plan --name /plans/features/basic test --name references
/var/tmp/tmt/run-012

/plans/features/basic
        Report step always force mode enabled.
...
total: 1 test passed
```