### PR TITLE
Match by name prefix in discover.modified-only

### DIFF
--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -98,6 +98,8 @@ description: |
 
         modified-only
             Set to True if you want to filter modified tests only.
+            The test is modified if its name starts with the name
+            of any directory modified since modified-ref.
         modified-url
             Will be fetched as a "reference" remote in the test
             dir.

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -205,7 +205,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 ['git', 'log', '--format=', '--stat', '--name-only',
                 f"{modified_ref}..HEAD"], cwd=testdir, shell=False)[0]
             modified = set(
-                f"^/{re.escape(name)}$"
+                f"^/{re.escape(name)}"
                 for name in map(os.path.dirname, output.split('\n')) if name)
             self.debug(f"Limit to modified test dirs: {modified}", level=3)
             names.extend(modified)


### PR DESCRIPTION
Keeps current behaviour but makes it possible to match also virtual/children tests.

Thoughts? @psss @WOnder93 
Naming/help messages are difficult :)