### PR TITLE
Ignore the nitrate migration warning during import

### DIFF
--- a/tests/integration/test_data/test_nitrate/NitrateImportAutomated.test_basic.yaml
+++ b/tests/integration/test_data/test_nitrate/NitrateImportAutomated.test_basic.yaml
@@ -41,7 +41,13 @@ nitrate.xmlrpc_driver:
         extra_link: ''
         is_automated: 2
         is_automated_proposed: false
-        notes: '[structured-field-start]
+        notes: 'Test case has been migrated to git. Any changes made here might be
+          overwritten.
+
+          See: https://tmt.readthedocs.io/en/latest/questions.html#nitrate-migration
+
+
+          [structured-field-start]
 
           This is StructuredField version 1. Please, edit with care.
 
@@ -138,7 +144,12 @@ nitrate.xmlrpc_driver:
       extra_link: ''
       is_automated: 2
       is_automated_proposed: false
-      notes: '[structured-field-start]
+      notes: 'Test case has been migrated to git. Any changes made here might be overwritten.
+
+        See: https://tmt.readthedocs.io/en/latest/questions.html#nitrate-migration
+
+
+        [structured-field-start]
 
         This is StructuredField version 1. Please, edit with care.
 

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -587,8 +587,9 @@ def read_nitrate_case(testcase, makefile_data=None):
     for bug in testcase.bugs:
         add_bug(bug.bug, data)
 
-    # Header and footer from notes
-    data['description'] = field.header() + field.footer()
+    # Header and footer from notes (do not import the warning back)
+    data['description'] = re.sub(
+        tmt.export.WARNING, '', field.header() + field.footer())
 
     # Extras: [pepa] and [hardware]
     try:


### PR DESCRIPTION
Do not import back the migration warning which has been added to
the nitrate test case notes during export. We want to keep the git
metadata clean and concise.