### PR TITLE
Beakerlib tests need at least beakerlib-1.28

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -311,7 +311,7 @@ class Test(Core):
         # able to detect if the test has explicitly set the framework.
         self._check('framework', expected=str, default=None)
         if self.framework == 'beakerlib':
-            self.require.append('beakerlib')
+            self.require.append('beakerlib >= 1.28')
 
         # Check that environment is a dictionary
         self._check('environment', expected=dict, default={})


### PR DESCRIPTION
TestResults state indicator was introduced in this version and it is
used to validate test result.