### PR TITLE
Prevent duplicate content in generated docs

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -794,11 +794,12 @@ class Story(Node):
         if not self.node.children and not self.implemented:
             output += '\n.. note:: This is a draft, '
             output += 'the story is not implemented yet.\n'
-        if self.description:
+        if (self.description and
+                self.description != self.node.parent.get('description')):
             output += '\n{}\n'.format(self.description)
 
         # Examples
-        if self.example:
+        if self.example and self.example != self.node.parent.get('example'):
             output += '\nExamples::\n\n'
             output += tmt.utils.format(
                 '', self.example, wrap=False, indent=4,


### PR DESCRIPTION
Similarly as it is already done for `summary` and `story`, do not
export `description` and `example` when generating `rst` docs if
their content is inherited (identical with the parent).