### PR TITLE
install package dependencies separately than in command

### DIFF
--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -209,11 +209,12 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
                 self.info('package', summary + ' requested', 'green')
                 for package in sorted(repo_packages):
                     self.verbose(package, shift=1)
-            # Quote package names and prepare the rpm check
-            packages = ' '.join(
-                [tmt.utils.quote(package) for package in repo_packages])
-            check = f'rpm -q --whatprovides {packages}'
+            for item in repo_packages:
+                # avoid reinstall package if already installed from another repo
+                # Quote package names and prepare the rpm check
+                quoted = tmt.utils.quote(item)
+                check = f'rpm -q --whatprovides {quoted}'
             # Check and install (extra check for yum to workaround BZ#1920176)
-            guest.execute(
-                f'{check} || {command} install -y {packages}' +
-                (f' && {check}' if 'yum' in command else ''))
+                guest.execute(
+                    f'{check} || {command} install -y {quoted}' +
+                    (f' && {check}' if 'yum' in command else ''))


### PR DESCRIPTION
###Usecase
I have system with repaired version of beakerlib, with workaround I've used.
`dnf install` with name and there is different version than installed, will reinstall package from system repos

```
tmt run -a prepare -s "dnf -y install --repofrompath beakerlib,http://url... beakerlib"
```
what installs a new version of beakerlib package, but in next prepare steps, what installs dependency there is used `rpm -q --whatrequires` to all packages and in case some of them is missing it force to call install all packages, what caused downgrade of beakerlib package back to bad version.

So it should just install packages that are not already installed.

Theoretically someone may rely on this reinstallation, but my perspective is that a more common case is to not reinstall if dependency is already solved inside SUT.