### PR TITLE
Do not use mutable objects as default arguments

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -548,7 +548,7 @@ class Plan(Node):
             path=plan_path, content=content,
             name='plan', dry=dry, force=force)
 
-    def steps(self, enabled=True, disabled=False, names=False, skip=[]):
+    def steps(self, enabled=True, disabled=False, names=False, skip=None):
         """
         Iterate over enabled / all steps
 
@@ -556,6 +556,7 @@ class Plan(Node):
         yield step names only and 'disabled=True' to iterate over all.
         Use 'skip' to pass the list of steps to be skipped.
         """
+        skip = skip or []
         for name in tmt.steps.STEPS:
             if name in skip:
                 continue
@@ -887,8 +888,13 @@ class Tree(tmt.utils.Common):
         """ Metadata root """
         return self.tree.root
 
-    def tests(self, keys=[], names=[], filters=[], conditions=[]):
+    def tests(self, keys=None, names=None, filters=None, conditions=None):
         """ Search available tests """
+        keys = (keys or [])[:]
+        names = (names or [])[:]
+        filters = (filters or [])[:]
+        conditions = (conditions or [])[:]
+
         # Apply possible command line options
         if Test._opt('names'):
             names.extend(Test._opt('names'))
@@ -902,8 +908,14 @@ class Tree(tmt.utils.Common):
             [Test(test) for test in self.tree.prune(keys=keys, names=names)],
             filters, conditions)
 
-    def plans(self, keys=[], names=[], filters=[], conditions=[], run=None):
+    def plans(self, keys=None, names=None, filters=None, conditions=None,
+              run=None):
         """ Search available plans """
+        keys = (keys or [])[:]
+        names = (names or [])[:]
+        filters = (filters or [])[:]
+        conditions = (conditions or [])[:]
+
         # Apply possible command line options
         if Plan._opt('names'):
             names.extend(Plan._opt('names'))
@@ -918,9 +930,14 @@ class Tree(tmt.utils.Common):
                 for plan in self.tree.prune(keys=keys, names=names)],
             filters, conditions)
 
-    def stories(
-            self, keys=[], names=[], filters=[], conditions=[], whole=False):
+    def stories(self, keys=None, names=None, filters=None, conditions=None,
+                whole=False):
         """ Search available stories """
+        keys = (keys or [])[:]
+        names = (names or [])[:]
+        filters = (filters or [])[:]
+        conditions = (conditions or [])[:]
+
         # Apply possible command line options
         if Story._opt('names'):
             names.extend(Story._opt('names'))

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -890,20 +890,13 @@ class Tree(tmt.utils.Common):
 
     def tests(self, keys=None, names=None, filters=None, conditions=None):
         """ Search available tests """
-        keys = (keys or [])[:]
-        names = (names or [])[:]
-        filters = (filters or [])[:]
-        conditions = (conditions or [])[:]
+        # Handle defaults, apply possible command line options
+        keys = (keys or []) + ['test']
+        names = (names or []) + list(Test._opt('names', []))
+        filters = (filters or []) + list(Test._opt('filters', []))
+        conditions = (conditions or []) + list(Test._opt('conditions', []))
 
-        # Apply possible command line options
-        if Test._opt('names'):
-            names.extend(Test._opt('names'))
-        if Test._opt('filters'):
-            filters.extend(Test._opt('filters'))
-        if Test._opt('conditions'):
-            conditions.extend(Test._opt('conditions'))
         # Build the list and convert to objects
-        keys = keys + ['test']
         return self._filters_conditions(
             [Test(test) for test in self.tree.prune(keys=keys, names=names)],
             filters, conditions)
@@ -911,20 +904,13 @@ class Tree(tmt.utils.Common):
     def plans(self, keys=None, names=None, filters=None, conditions=None,
               run=None):
         """ Search available plans """
-        keys = (keys or [])[:]
-        names = (names or [])[:]
-        filters = (filters or [])[:]
-        conditions = (conditions or [])[:]
+        # Handle defaults, apply possible command line options
+        keys = (keys or []) + ['execute']
+        names = (names or []) + list(Plan._opt('names', []))
+        filters = (filters or []) + list(Plan._opt('filters', []))
+        conditions = (conditions or []) + list(Plan._opt('conditions', []))
 
-        # Apply possible command line options
-        if Plan._opt('names'):
-            names.extend(Plan._opt('names'))
-        if Plan._opt('filters'):
-            filters.extend(Plan._opt('filters'))
-        if Plan._opt('conditions'):
-            conditions.extend(Plan._opt('conditions'))
         # Build the list and convert to objects
-        keys = keys + ['execute']
         return self._filters_conditions(
             [Plan(plan, run=run)
                 for plan in self.tree.prune(keys=keys, names=names)],
@@ -933,20 +919,13 @@ class Tree(tmt.utils.Common):
     def stories(self, keys=None, names=None, filters=None, conditions=None,
                 whole=False):
         """ Search available stories """
-        keys = (keys or [])[:]
-        names = (names or [])[:]
-        filters = (filters or [])[:]
-        conditions = (conditions or [])[:]
+        # Handle defaults, apply possible command line options
+        keys = (keys or []) + ['story']
+        names = (names or []) + list(Story._opt('names', []))
+        filters = (filters or []) + list(Story._opt('filters', []))
+        conditions = (conditions or []) + list(Story._opt('conditions', []))
 
-        # Apply possible command line options
-        if Story._opt('names'):
-            names.extend(Story._opt('names'))
-        if Story._opt('filters'):
-            filters.extend(Story._opt('filters'))
-        if Story._opt('conditions'):
-            conditions.extend(Story._opt('conditions'))
         # Build the list and convert to objects
-        keys = keys + ['story']
         return self._filters_conditions(
             [Story(story) for story in self.tree.prune(
                 keys=keys, names=names, whole=whole)],

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -26,12 +26,12 @@ class Step(tmt.utils.Common):
     # except for provision (virtual) and report (display)
     how = 'shell'
 
-    def __init__(self, data={}, plan=None, name=None):
+    def __init__(self, data=None, plan=None, name=None):
         """ Initialize and check the step data """
         super().__init__(name=name, parent=plan)
         # Initialize data
         self.plan = plan
-        self.data = data
+        self.data = data or {}
         self._status = None
         self._plugins = []
 

--- a/tmt/steps/execute/detach.py
+++ b/tmt/steps/execute/detach.py
@@ -76,9 +76,8 @@ class ExecuteDetach(tmt.steps.execute.ExecutePlugin):
             except tmt.utils.FileError:
                 pass
 
-    def remove_logs(self, logs=None):
+    def remove_logs(self):
         """ Clean up possible old logs """
-        logs = logs or []
         for log in LOGS:
             path = os.path.join(self.step.workdir, log)
             if os.path.exists(path):

--- a/tmt/steps/execute/detach.py
+++ b/tmt/steps/execute/detach.py
@@ -76,8 +76,9 @@ class ExecuteDetach(tmt.steps.execute.ExecutePlugin):
             except tmt.utils.FileError:
                 pass
 
-    def remove_logs(self, logs=[]):
+    def remove_logs(self, logs=None):
         """ Clean up possible old logs """
+        logs = logs or []
         for log in LOGS:
             path = os.path.join(self.step.workdir, log)
             if os.path.exists(path):

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -138,7 +138,7 @@ class Common(object):
     def _opt(cls, option, default=None):
         """ Get an option from the command line context (class version) """
         if cls._context is None:
-            return None
+            return default
         return cls._context.params.get(option, default)
 
     def _fmf_context(self):


### PR DESCRIPTION
Using lists/dicts as default arguments is a bad practice that can lead
to unexpected errors with subsequent calls to the method (the same
default instance is shared across all subsequent calls).

@lukaszachy could you check if this fixes the issue we discussed yesterday? I will also open a similar PR to fmf, there are a few instances of the same error