### PR TITLE
Use an empty worktree if no metadata tree found

### DIFF
--- a/tests/login/main.fmf
+++ b/tests/login/main.fmf
@@ -6,3 +6,6 @@
     summary: Check login result condition
     test: ./when.sh
 
+/reserve:
+    summary: Reserve a guest for experimenting
+    test: ./reserve.sh

--- a/tests/login/reserve.sh
+++ b/tests/login/reserve.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "pushd $tmp"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Single Command"
+        rlRun "tmt run -r provision -h container login -c 'echo hi' finish"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Multiple Commands"
+        rlRun "tmt run provision -h container"
+        for attempt in one two three; do
+            rlRun "tmt run -l login -c 'echo $attempt'"
+        done
+        rlRun "tmt run -rl finish"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Removing tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -487,10 +487,14 @@ class Plan(Node):
 
         self.worktree = os.path.join(self.workdir, 'tree')
         tree_root = self.my_run.tree.root
+
+        # Create an empty directory if there's no metadata tree
         if not tree_root:
-            self.debug('Skipping worktree init, no tree root present.')
+            self.debug('Create an empty worktree (no metadata tree).')
+            os.makedirs(self.worktree, exist_ok=True)
             return
 
+        # Sync metadata root to the worktree
         self.debug(f"Sync the worktree to '{self.worktree}'.")
         self.run(f'rsync -ar --exclude .git {tree_root}/ {self.worktree}')
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -413,7 +413,8 @@ class Common(object):
 
         # Fail nicely if the working directory does not exist
         if not os.path.exists(cwd):
-            raise GeneralError(f"The working directory '{cwd}' does not exist.")
+            raise GeneralError(
+                f"The working directory '{cwd}' does not exist.")
 
         try:
             return self._run(


### PR DESCRIPTION
If there's no metadata tree, for example when running against the
default plan, we need to create an empty worktree directory.
Simple test coverage reproducing the issue added as well.