### PR TITLE
Human friendly names for VMs

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -195,9 +195,14 @@ class Guest(tmt.utils.Common):
         super().__init__(parent, name)
         self.load(data)
 
-    def _random_name(self):
+    def _random_name(self, prefix='', length=16):
         """ Generate a random name """
-        return ''.join(random.choices(string.ascii_letters, k=16))
+        # Append at least 5 random characters
+        min_random_part = max(5, length-len(prefix))
+        name = prefix + ''.join(
+            random.choices(string.ascii_letters, k=min_random_part))
+        # Return tail (containing random characters) of name
+        return name[-length:]
 
     def _ssh_guest(self):
         """ Return user@guest """

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -411,7 +411,8 @@ class GuestTestcloud(tmt.Guest):
                 f"directory permissions.", original=error)
 
         # Create instance
-        self.instance_name = self._random_name()
+        self.instance_name = self._random_name(
+            prefix="tmt-{0}-".format(self.parent.plan.my_run.workdir[-3:]))
         self.instance = testcloud.instance.Instance(
             name=self.instance_name, image=self.image,
             connection='qemu:///session')


### PR DESCRIPTION
Easier to spot VMs from tmt. Names are prefixed by tmt followed
by last three characters from run's workdir path.
Examples:
- tmt-039-bLQIFVQN
- tmt-asd-CDIjUHvU

Method Guest._random_name limits the maximal name length now.