### PR TITLE
Export text fields of a case to nitrate should be checked by lint

### DIFF
--- a/tests/test/lint/data/manual_test_failed/test.md
+++ b/tests/test/lint/data/manual_test_failed/test.md
@@ -1,0 +1,91 @@
+### Unknown heading begin
+
+# Setup
+
+Something in Setup 1
+
+## Step
+Step is outside test section
+
+# Test
+## Step
+Verify tmt shows help page
+```bash
+tmt --help
+```
+
+
+## Expect
+Text similar to the one bellow is displayed
+```
+Usage: tmt [OPTIONS] COMMAND [ARGS]...
+
+  Test Management Tool
+
+Options:
+...
+```
+## Test Step
+Check that error about missing metadata is sane
+```bash
+tmt tests ls
+```
+## Result
+
+## Test
+
+```
+ERROR  No metadata found in the '.' directory. Use 'tmt init' to get started.
+```
+## Step
+Initialize metadata structure
+
+#
+```bash
+tmt init
+```
+## Expected Result
+1. Metadata structure was created
+```bash
+$ cat .fmf/version
+1
+```
+2. Tool prints advice about next steps
+
+# Setup
+# Cleanup
+```
+To populate it with example content, use --template with mini, base or full.
+```
+
+# Test one
+## Test Step
+description for step 1-1
+
+## Result
+description for result 1-1
+
+## Step
+description for step 1-2
+
+## Expected Result
+description for Expected Result 1-2
+
+# Test two
+## Step
+description for step 2-1
+
+# Cleanup
+
+## Result
+description for result 2-1
+
+## Step
+description for step 2-2
+
+# Cleanup
+Optionally remove temporary directory created in the first step
+2 line of cleanup
+3 line of cleanup
+
+## Unknown heading end

--- a/tests/test/lint/data/manual_test_failed_2/test.md
+++ b/tests/test/lint/data/manual_test_failed_2/test.md
@@ -1,0 +1,80 @@
+# Setup
+
+Something in Setup 1
+
+## Step
+Step is outside test section
+
+## Step
+Verify tmt shows help page
+```bash
+tmt --help
+```
+
+
+## Expect
+Text similar to the one bellow is displayed
+```
+Usage: tmt [OPTIONS] COMMAND [ARGS]...
+
+  Test Management Tool
+
+Options:
+...
+```
+## Test Step
+Check that error about missing metadata is sane
+```bash
+tmt tests ls
+```
+## Result
+
+```
+ERROR  No metadata found in the '.' directory. Use 'tmt init' to get started.
+```
+## Step
+Initialize metadata structure
+
+#
+```bash
+tmt init
+```
+## Expected Result
+1. Metadata structure was created
+```bash
+$ cat .fmf/version
+1
+```
+2. Tool prints advice about next steps
+
+```
+To populate it with example content, use --template with mini, base or full.
+```
+
+
+## Test Step
+description for step 1-1
+
+## Result
+description for result 1-1
+
+## Step
+description for step 1-2
+
+## Expected Result
+description for Expected Result 1-2
+
+
+## Step
+description for step 2-1
+
+## Result
+description for result 2-1
+
+## Step
+description for step 2-2
+
+# Cleanup
+Optionally remove temporary directory created in the first step
+2 line of cleanup
+3 line of cleanup

--- a/tests/test/lint/data/manual_test_passed/random_name.md
+++ b/tests/test/lint/data/manual_test_passed/random_name.md
@@ -1,0 +1,71 @@
+# Test
+## Step
+Verify tmt shows help page
+```bash
+tmt --help
+```
+## Expect
+Text similar to the one bellow is displayed
+```
+Usage: tmt [OPTIONS] COMMAND [ARGS]...
+
+  Test Management Tool
+
+Options:
+...
+```
+## Test Step
+Check that error about missing metadata is sane
+```bash
+tmt tests ls
+```
+## Result
+```
+ERROR  No metadata found in the '.' directory. Use 'tmt init' to get started.
+```
+## Step
+Initialize metadata structure
+```bash
+tmt init
+```
+## Expected Result
+1. Metadata structure was created
+```bash
+$ cat .fmf/version
+1
+```
+2. Tool prints advice about next steps
+```
+To populate it with example content, use --template with mini, base or full.
+```
+
+# Test one
+## Test Step
+description for step 1-1
+
+## Result
+description for result 1-1
+
+## Step
+description for step 1-2
+
+## Expected Result
+description for Expected Result 1-2
+
+# Test two
+## Step
+description for step 2-1
+
+## Result
+description for result 2-1
+
+## Step
+description for step 2-2
+
+## Expect
+description for Expected Result 2-2
+
+# Cleanup
+Optionally remove temporary directory created in the first step
+2 line of cleanup
+3 line of cleanup

--- a/tests/test/lint/data/two_or_more_manual_test/test.md
+++ b/tests/test/lint/data/two_or_more_manual_test/test.md
@@ -1,0 +1,71 @@
+# Test
+## Step
+Verify tmt shows help page
+```bash
+tmt --help
+```
+## Expect
+Text similar to the one bellow is displayed
+```
+Usage: tmt [OPTIONS] COMMAND [ARGS]...
+
+  Test Management Tool
+
+Options:
+...
+```
+## Test Step
+Check that error about missing metadata is sane
+```bash
+tmt tests ls
+```
+## Result
+```
+ERROR  No metadata found in the '.' directory. Use 'tmt init' to get started.
+```
+## Step
+Initialize metadata structure
+```bash
+tmt init
+```
+## Expected Result
+1. Metadata structure was created
+```bash
+$ cat .fmf/version
+1
+```
+2. Tool prints advice about next steps
+```
+To populate it with example content, use --template with mini, base or full.
+```
+
+# Test one
+## Test Step
+description for step 1-1
+
+## Result
+description for result 1-1
+
+## Step
+description for step 1-2
+
+## Expected Result
+description for Expected Result 1-2
+
+# Test two
+## Step
+description for step 2-1
+
+## Result
+description for result 2-1
+
+## Step
+description for step 2-2
+
+## Expect
+description for Expected Result 2-2
+
+# Cleanup
+Optionally remove temporary directory created in the first step
+2 line of cleanup
+3 line of cleanup

--- a/tests/test/lint/data/two_or_more_manual_test/test2.md
+++ b/tests/test/lint/data/two_or_more_manual_test/test2.md
@@ -1,0 +1,71 @@
+# Test
+## Step
+Verify tmt shows help page
+```bash
+tmt --help
+```
+## Expect
+Text similar to the one bellow is displayed
+```
+Usage: tmt [OPTIONS] COMMAND [ARGS]...
+
+  Test Management Tool
+
+Options:
+...
+```
+## Test Step
+Check that error about missing metadata is sane
+```bash
+tmt tests ls
+```
+## Result
+```
+ERROR  No metadata found in the '.' directory. Use 'tmt init' to get started.
+```
+## Step
+Initialize metadata structure
+```bash
+tmt init
+```
+## Expected Result
+1. Metadata structure was created
+```bash
+$ cat .fmf/version
+1
+```
+2. Tool prints advice about next steps
+```
+To populate it with example content, use --template with mini, base or full.
+```
+
+# Test one
+## Test Step
+description for step 1-1
+
+## Result
+description for result 1-1
+
+## Step
+description for step 1-2
+
+## Expected Result
+description for Expected Result 1-2
+
+# Test two
+## Step
+description for step 2-1
+
+## Result
+description for result 2-1
+
+## Step
+description for step 2-2
+
+## Expect
+description for Expected Result 2-2
+
+# Cleanup
+Optionally remove temporary directory created in the first step
+2 line of cleanup
+3 line of cleanup

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -43,6 +43,18 @@ EXTRA_TEST_KEYS = (
     "extra-nitrate extra-hardware extra-pepa "
     "extra-summary extra-task".split())
 
+SECTIONS_HEADINGS = {
+    'Setup': ['<h1>Setup</h1>'],
+    'Test': ['<h1>Test</h1>',
+             '<h1>Test .*</h1>'],
+    'Step': ['<h2>Step</h2>',
+             '<h2>Test Step</h2>'],
+    'Expect': ['<h2>Expect</h2>',
+               '<h2>Result</h2>',
+               '<h2>Expected Result</h2>'],
+    'Cleanup': ['<h1>Cleanup</h1>']
+    }
+
 
 class Core(tmt.utils.Common):
     """
@@ -429,6 +441,18 @@ class Test(Core):
                 verdict(False, f"unknown attribute '{key}' is used")
         else:
             verdict(True, "correct attributes are used")
+
+        # Check if the format of Markdown file respects the specification
+        # https://tmt.readthedocs.io/en/latest/spec/tests.html#manual
+        md_path = tmt.export.return_markdown_file()
+        if os.path.exists(md_path):
+            invalid_md_file = tmt.export.check_md_file_respects_spec(md_path)
+            if invalid_md_file:
+                for i in invalid_md_file:
+                    verdict(False, i)
+            else:
+                verdict(True, "correct headings are used in the Markdown file")
+
         return valid
 
     def export(self, format_='yaml', keys=None):


### PR DESCRIPTION
#692

1. Fix a bug that user should always use only `test.md` file during export of manual test instructions to nitrate. 
User should be able to use "any filename".md to export manual test instructions to nitrate instead of `test.md`
If there are more than one .md file we will print a warning.

2. `tmt test lint` part will be done within this PR next