### PR TITLE
Correctly convert relevancy with the `!=` operator

### DIFF
--- a/tests/unit/test_adjust.py
+++ b/tests/unit/test_adjust.py
@@ -120,6 +120,11 @@ def test_operators_special():
     check('collection contains http24', 'collection == http24')
     check('collection !contains http24', 'collection != http24')
 
+def test_not_equal_comma_separated():
+    """ Special handling for comma-separated values with != """
+    check(
+        'distro != centos-7, centos-8',
+        'distro != centos-7 and distro != centos-8')
 
 # Invalid rules
 

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -746,6 +746,13 @@ def relevancy_to_adjust(relevancy):
                 except KeyError:
                     raise tmt.utils.ConvertError(
                         f"Invalid test case relevancy operator '{operator}'.")
+            # Special handling for the '!=' operator with comma-separated
+            # values (in relevancy this was treated as 'no value equals')
+            values = re.split(r'\s*,\s*', right)
+            if operator == '!=' and len(values) > 1:
+                for value in values:
+                    expressions.append(f"{left} != {value}")
+                continue
             # Join 'left operator right' with spaces
             expressions.append(
                 ' '.join([item for item in [left, operator, right] if item]))

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -266,7 +266,7 @@ class ExecutePlugin(tmt.steps.Plugin):
                 'TESTRESULT_RESULT_STRING=(.*)', results).group(1)
             # States are: started, incomplete and complete
             # FIXME In quotes until beakerlib/beakerlib/pull/92 is merged
-            state = re.search('TESTRESULT_STATE="?(\w+)"?', results).group(1)
+            state = re.search(r'TESTRESULT_STATE="?(\w+)"?', results).group(1)
         except AttributeError:
             self.debug(
                 f"No result or state found in '{beakerlib_results_file}'.",


### PR DESCRIPTION
Comma-separated values are treated by relevancy in a special way
if the operator `!=` is used. Make sure we convert the rules in a
way which will correctly work with the context adjust.

Fix also a minor unrelated warning about invalid escape sequence.