### PR TITLE
Code-style improvements according to PEP8

### DIFF
--- a/tests/unit/test_adjust.py
+++ b/tests/unit/test_adjust.py
@@ -9,6 +9,7 @@ def mini():
     """ Minimal example """
     return relevancy_to_adjust("distro = fedora: False")
 
+
 @pytest.fixture
 def full():
     """ Full example """
@@ -25,6 +26,7 @@ def full():
     collection contains httpd24 && fips defined: False
     """.replace('    ', ''))
 
+
 def check(condition, expected):
     """ Check condition against expected """
     adjusted = relevancy_to_adjust(f"{condition}: False")[0]['when']
@@ -37,11 +39,13 @@ def test_empty():
     """ Empty relevancy """
     assert relevancy_to_adjust('') == list()
 
+
 def test_comments(full):
     """ Extract comments """
     assert full[0]['because'] == 'feature has been added in Fedora 33'
     assert full[1]['because'] == 'using logical operators'
     assert full[2]['because'] == 'modify environment'
+
 
 def test_disable(mini, full):
     """ Disable test """
@@ -49,13 +53,16 @@ def test_disable(mini, full):
     assert full[0]['enabled'] == False
     assert full[1]['enabled'] == False
 
+
 def test_environment(full):
     """ Modify environment """
     assert full[2]['environment'] == {'PHASES': 'novalgrind'}
 
+
 def test_continue(mini):
     """ Explicit continue """
     assert mini[0]['continue'] == False
+
 
 def test_condition(mini, full):
     """ Expressions conversion """
@@ -65,6 +72,7 @@ def test_condition(mini, full):
     assert full[2]['when'] == 'arch == s390x'
     assert full[3]['when'] == 'collection == httpd24 and fips is defined'
 
+
 def test_operators_basic():
     """ Basic operators unchanged """
     check('component = python', 'component == python')
@@ -72,11 +80,13 @@ def test_operators_basic():
     check('arch == s390x', 'arch == s390x')
     check('arch != s390x', 'arch != s390x')
 
+
 def test_operators_distro_name():
     """ Check distro name """
     check('distro = fedora', 'distro == fedora')
     check('distro == fedora', 'distro == fedora')
     check('distro != fedora', 'distro != fedora')
+
 
 def test_operators_distro_major():
     """ Check distro major version """
@@ -84,6 +94,7 @@ def test_operators_distro_major():
     check('distro > fedora-33', 'distro > fedora-33')
     check('distro <= fedora-33', 'distro <= fedora-33')
     check('distro >= fedora-33', 'distro >= fedora-33')
+
 
 def test_operators_distro_minor():
     """ Check distro minor version """
@@ -94,6 +105,7 @@ def test_operators_distro_minor():
     check('distro > centos-8.3', 'distro ~> centos-8.3')
     check('distro <= centos-8.3', 'distro ~<= centos-8.3')
     check('distro >= centos-8.3', 'distro ~>= centos-8.3')
+
 
 def test_operators_product():
     """ Special handling for product """
@@ -111,6 +123,7 @@ def test_operators_product():
     check('product > rhscl-3.3', 'product ~> rhscl-3.3')
     check('product <= rhscl-3.3', 'product ~<= rhscl-3.3')
     check('product >= rhscl-3.3', 'product ~>= rhscl-3.3')
+
 
 def test_operators_special():
     """ Check 'defined' and 'contains' """
@@ -132,15 +145,18 @@ def test_invalid_rule():
     with pytest.raises(ConvertError, match='Invalid.*rule'):
         relevancy_to_adjust("weird")
 
+
 def test_invalid_decision():
     """ Invalid relevancy decision """
     with pytest.raises(ConvertError, match='Invalid.*decision'):
         relevancy_to_adjust("distro < fedora-33: weird")
 
+
 def test_invalid_expression():
     """ Invalid relevancy expression """
     with pytest.raises(ConvertError, match='Invalid.*expression'):
         relevancy_to_adjust("distro * fedora-33: False")
+
 
 def test_invalid_operator():
     """ Invalid relevancy operator """

--- a/tests/unit/test_adjust.py
+++ b/tests/unit/test_adjust.py
@@ -1,8 +1,7 @@
 import pytest
 
-import tmt
-from tmt.utils import ConvertError
 from tmt.convert import relevancy_to_adjust
+from tmt.utils import ConvertError
 
 
 @pytest.fixture

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -14,6 +14,7 @@ from tmt.utils import SpecificationError
 
 runner = click.testing.CliRunner()
 
+
 def test_invalid_yaml_syntax():
     """ Invalid yaml syntax """
     tmp = tempfile.mkdtemp()
@@ -28,6 +29,7 @@ def test_invalid_yaml_syntax():
     os.chdir(original_directory)
     shutil.rmtree(tmp)
 
+
 def test_test_defaults():
     """ Test default test attributes """
     test = tmt.Test(dict(test='./test.sh'), name='/smoke')
@@ -41,6 +43,7 @@ def test_test_defaults():
     assert test.enabled == True
     assert test.result == 'respect'
     assert test.tag == list()
+
 
 def test_test_invalid():
     """ Test invalid test """
@@ -59,6 +62,7 @@ def test_test_invalid():
     # Listify attributes
     assert tmt.Test({'tag': 'a'}, name='/smoke').tag == ['a']
     assert tmt.Test({'tag': ['a', 'b']}, name='/smoke').tag == ['a', 'b']
+
 
 def test_link():
     """ Test the link attribute parsing """

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,10 +1,11 @@
 # coding: utf-8
 
 import os
-import pytest
 import shutil
 import tempfile
+
 import click.testing
+import pytest
 
 import tmt
 import tmt.cli

--- a/tests/unit/test_beakerlib.py
+++ b/tests/unit/test_beakerlib.py
@@ -1,5 +1,6 @@
-import pytest
 import shutil
+
+import pytest
 
 import tmt
 import tmt.beakerlib

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,10 +2,11 @@
 
 import os
 import shutil
-import tmt.cli
 import tempfile
 
 from click.testing import CliRunner
+
+import tmt.cli
 
 # Prepare path to examples
 PATH = os.path.dirname(os.path.realpath(__file__))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,11 +11,14 @@ import tmt.cli
 # Prepare path to examples
 PATH = os.path.dirname(os.path.realpath(__file__))
 
+
 def example(name):
     """ Return path to given example """
     return os.path.join(PATH, "../../examples/", name)
 
+
 runner = CliRunner()
+
 
 def test_mini():
     """ Minimal smoke test """
@@ -25,6 +28,7 @@ def test_mini():
     assert 'Found 1 plan.' in result.output
     assert '1 test selected' in result.output
     assert '/ci' in result.output
+
 
 def test_init():
     """ Tree initialization """
@@ -53,6 +57,7 @@ def test_init():
     os.chdir(original_directory)
     shutil.rmtree(tmp)
 
+
 def test_create():
     """ Test, plan and story creation """
     # Create a test directory
@@ -77,6 +82,7 @@ def test_create():
     os.chdir(original_directory)
     shutil.rmtree(tmp)
 
+
 def test_step():
     """ Select desired step"""
     for step in ['discover', 'provision', 'prepare']:
@@ -85,6 +91,7 @@ def test_step():
         assert result.exit_code == 0
         assert step in result.output
         assert 'finish' not in result.output
+
 
 def test_step_execute():
     """ Test execute step"""
@@ -98,6 +105,7 @@ def test_step_execute():
     assert isinstance(result.exception, tmt.utils.ExecuteError)
     assert step in result.output
     assert 'provision' not in result.output
+
 
 def test_systemd():
     """ Check systemd example """

--- a/tests/unit/test_export_to_nitrate.py
+++ b/tests/unit/test_export_to_nitrate.py
@@ -1,9 +1,10 @@
 import os
 import shutil
-from pathlib import Path
 import tempfile
-from tmt.export import convert_manual_to_nitrate
+from pathlib import Path
 from unittest import TestCase
+
+from tmt.export import convert_manual_to_nitrate
 
 TEST_DIR = Path(__file__).parent
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,11 +2,12 @@
 
 import re
 import tmt
-import pytest
 import unittest
 
-from tmt.utils import StructuredField, StructuredFieldError, public_git_url
-from tmt.utils import listify, duration_to_seconds
+import pytest
+
+from tmt.utils import (StructuredField, StructuredFieldError, public_git_url,
+                       listify, duration_to_seconds)
 
 def test_public_git_url():
     """ Verify url conversion """

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -9,6 +9,7 @@ import pytest
 from tmt.utils import (StructuredField, StructuredFieldError, public_git_url,
                        listify, duration_to_seconds)
 
+
 def test_public_git_url():
     """ Verify url conversion """
     examples = [
@@ -37,6 +38,7 @@ def test_public_git_url():
         ]
     for example in examples:
         assert public_git_url(example['original']) == example['expected']
+
 
 def test_listify():
     """ Check listify functionality """

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2,31 +2,29 @@
 """ Base Metadata Classes """
 
 import copy
+import functools
 import os
 import re
+import subprocess
 import time
+
+import click
 import fmf
 import yaml
-import click
-import pprint
-import subprocess
-import functools
+from fmf.utils import listed
+from click import echo, style
 
-import tmt.steps
-import tmt.utils
 import tmt.export
-import tmt.templates
-
+import tmt.steps
 import tmt.steps.discover
 import tmt.steps.provision
 import tmt.steps.prepare
 import tmt.steps.execute
 import tmt.steps.report
 import tmt.steps.finish
-
+import tmt.templates
+import tmt.utils
 from tmt.utils import verdict
-from fmf.utils import listed
-from click import echo, style
 
 # Default test duration is 5m for individual tests discovered from L1
 # metadata and 1h for scripts defined directly in plans (L2 metadata).

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -4,6 +4,7 @@ import re
 import os
 
 import fmf
+
 import tmt
 
 # Regular expressions for beakerlib libraries

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -2,21 +2,21 @@
 
 """ Command line interface for the Test Management Tool """
 
+import os
+
+import click
+import fmf
 from click import echo, style
 from fmf.utils import listed
 
-import click
-import os
-
-import fmf
 import tmt
-import tmt.utils
-import tmt.plugins
 import tmt.convert
 import tmt.export
+import tmt.options
+import tmt.plugins
 import tmt.steps
 import tmt.templates
-import tmt.options
+import tmt.utils
 
 # Explore available plugins (need to detect all supported methods first)
 tmt.plugins.explore()

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -21,6 +21,7 @@ import tmt.utils
 # Explore available plugins (need to detect all supported methods first)
 tmt.plugins.explore()
 
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Custom Group
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -49,6 +50,7 @@ class CustomGroup(click.Group):
             return click.Group.get_command(self, context, matches[0])
         context.fail('Did you mean {}?'.format(
             listed(sorted(matches), join='or')))
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Common Options
@@ -293,6 +295,7 @@ def finito(click_context, commands, *args, **kwargs):
     """ Run tests if run defined """
     if hasattr(click_context.obj, 'run'):
         click_context.obj.run.go()
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Test
@@ -618,6 +621,7 @@ def create(context, name, template, force, **kwargs):
     """ Create a new plan based on given template. """
     tmt.Plan._save_context(context)
     tmt.Plan.create(name, template, context.obj.tree.root, force)
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Story

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -54,6 +54,7 @@ except AttributeError:
         return dumper.orig_represent_str(data)
     yaml.add_representer(str, repr_str, Dumper=yaml.SafeDumper)
 
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Convert
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -2,18 +2,19 @@
 
 """ Convert metadata into the new format """
 
+import copy
+import os
+import pprint
+import re
+import subprocess
 from io import open
-from click import echo, style
-from tmt.utils import ConvertError, StructuredFieldError
 
 import fmf.utils
-import tmt.utils
-import subprocess
-import pprint
-import copy
 import yaml
-import re
-import os
+from click import echo, style
+
+import tmt.utils
+from tmt.utils import ConvertError
 
 log = fmf.utils.Logging('tmt').logger
 

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -2,14 +2,15 @@
 
 """ Export metadata into nitrate """
 
-from click import echo, style
 
-import tmt.utils
 import email
-import fmf
 import os
 import re
 
+import fmf
+from click import echo, style
+
+import tmt.utils
 from tmt.utils import ConvertError, markdown_to_html
 
 log = fmf.utils.Logging('tmt').logger

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -3,6 +3,7 @@
 """ Common options and the MethodCommand class """
 
 import re
+
 import click
 
 # Verbose, debug and quiet output

--- a/tmt/plugins.py
+++ b/tmt/plugins.py
@@ -2,12 +2,13 @@
 
 """ Handle Steps Plugins """
 
-import fmf
-import os
 import importlib
+import os
 import pkgutil
-import tmt
 import sys
+import tmt
+
+import fmf
 
 log = fmf.utils.Logging('tmt').logger
 

--- a/tmt/plugins.py
+++ b/tmt/plugins.py
@@ -12,6 +12,7 @@ import fmf
 
 log = fmf.utils.Logging('tmt').logger
 
+
 def explore():
     """ Explore all available plugins """
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -3,12 +3,11 @@
 
 import os
 import re
-import fmf
-import click
-import pprint
-import tmt.utils
 
-from click import echo, style
+import click
+from click import echo
+
+import tmt.utils
 from tmt.utils import GeneralError
 
 STEPS = ['discover', 'provision', 'prepare', 'execute', 'report', 'finish']

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -1,6 +1,7 @@
 import click
-import tmt
 from fmf.utils import listed
+
+import tmt
 
 class Discover(tmt.steps.Step):
     """ Gather information about test cases to be executed. """

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -3,6 +3,7 @@ from fmf.utils import listed
 
 import tmt
 
+
 class Discover(tmt.steps.Step):
     """ Gather information about test cases to be executed. """
 

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -1,9 +1,10 @@
 import os
-import click
-import shutil
 import re
+import shutil
 
+import click
 import fmf
+
 import tmt
 import tmt.beakerlib
 import tmt.steps.discover

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -8,6 +8,7 @@ import fmf
 
 import tmt.steps.discover
 
+
 class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
     """
     Use provided list of shell script tests

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -1,9 +1,11 @@
-import os
-import fmf
-import tmt
 import copy
-import click
+import os
 import shutil
+import tmt
+
+import click
+import fmf
+
 import tmt.steps.discover
 
 class DiscoverShell(tmt.steps.discover.DiscoverPlugin):

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1,9 +1,11 @@
 import os
 import re
 import time
-import fmf
-import tmt
+
 import click
+import fmf
+
+import tmt
 
 # Test data directory name
 TEST_DATA = 'data'

--- a/tmt/steps/execute/detach.py
+++ b/tmt/steps/execute/detach.py
@@ -1,8 +1,10 @@
 import os
-import time
-import tmt
 import shutil
+import time
+
 import click
+
+import tmt
 
 # Simple runner script name
 RUNNER = 'run.sh'

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -1,7 +1,8 @@
 import os
-import time
-import click
 import sys
+import time
+
+import click
 
 import tmt
 from tmt.steps.execute import TEST_OUTPUT_FILENAME

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -1,7 +1,9 @@
 import re
+
 import fmf
-import tmt
 import click
+
+import tmt
 
 
 class Finish(tmt.steps.Step):

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -1,6 +1,7 @@
 import fmf
-import tmt
 import click
+
+import tmt
 
 
 class FinishShell(tmt.steps.finish.FinishPlugin):

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -1,7 +1,9 @@
 import re
+
 import fmf
-import tmt
 import click
+
+import tmt
 
 
 class Prepare(tmt.steps.Step):

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -1,5 +1,7 @@
-import tmt
 import click
+
+import tmt
+
 
 class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
     """

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -9,6 +9,7 @@ import tmt
 
 COPR_URL = 'https://copr.fedorainfracloud.org/coprs'
 
+
 class PrepareInstall(tmt.steps.prepare.PreparePlugin):
     """
     Install packages on the guest

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -1,9 +1,11 @@
 import os
 import re
-import fmf
-import tmt
-import click
 import shutil
+
+import click
+import fmf
+
+import tmt
 
 COPR_URL = 'https://copr.fedorainfracloud.org/coprs'
 

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -1,6 +1,8 @@
 import fmf
-import tmt
 import click
+
+import tmt
+
 
 class PrepareShell(tmt.steps.prepare.PreparePlugin):
     """

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1,10 +1,11 @@
 import os
-import re
-import click
 import random
+import re
 import string
 
+import click
 import fmf
+
 import tmt
 
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -436,7 +436,6 @@ class Guest(tmt.utils.Common):
             f'rsync {options} -e "{self._ssh_command(join=True)}" '
             f'{self._ssh_guest()}:{source} {destination}')
 
-
     def stop(self):
         """
         Stop the guest

--- a/tmt/steps/provision/base.py
+++ b/tmt/steps/provision/base.py
@@ -1,9 +1,9 @@
-import tmt
 import os
 import random
 import string
 
-from click import echo
+import tmt
+
 
 class ProvisionBase(tmt.utils.Common):
     def __init__(self, data, step, instance_name=None):

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -1,5 +1,7 @@
-import tmt
 import click
+
+import tmt
+
 
 class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
     """

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -1,5 +1,6 @@
 import tmt
 
+
 class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
     """
     Use local host for test execution

--- a/tmt/steps/provision/minute.py
+++ b/tmt/steps/provision/minute.py
@@ -1,12 +1,13 @@
 import base64
-import click
 import datetime
 import getpass
 import json
 import os
 import re
-import requests
 import time
+
+import click
+import requests
 import urllib3.exceptions
 
 import tmt

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -1,6 +1,8 @@
 import os
-import tmt
+
 import click
+
+import tmt
 
 
 class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -11,6 +11,7 @@ import requests
 import tmt
 from tmt.utils import ProvisionError, WORKDIR_ROOT, retry_session
 
+
 def import_testcloud():
     """
     Import testcloud module only when needed

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1,11 +1,11 @@
 # coding: utf-8
 
-import re
 import os
+import re
 import time
 
-import fmf
 import click
+import fmf
 import requests
 
 import tmt

--- a/tmt/steps/provision/vagrant.py
+++ b/tmt/steps/provision/vagrant.py
@@ -2,18 +2,14 @@
 
 """ Provision Step Vagrnat Class """
 
-import tmt
-import subprocess
 import os
 import re
 import shutil
 from time import sleep
+from urllib.parse import urlparse
 
 from tmt.steps.provision.base import ProvisionBase
-from tmt.utils import ConvertError, SpecificationError, GeneralError, quote
-
-from click import echo
-from urllib.parse import urlparse
+from tmt.utils import SpecificationError, GeneralError, quote
 
 
 # DATA[*]:

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -1,7 +1,8 @@
 import re
-import fmf
-import tmt
+
 import click
+
+import tmt
 
 
 class Report(tmt.steps.Step):

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -3,6 +3,7 @@ import os
 import tmt
 from tmt.steps.execute import TEST_OUTPUT_FILENAME
 
+
 class ReportDisplay(tmt.steps.report.ReportPlugin):
     """
     Show test results on the terminal

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -1,8 +1,8 @@
 import os
 import os.path
+import webbrowser
 
 import click
-import webbrowser
 
 import tmt
 

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -130,6 +130,7 @@ HTML_TEMPLATE = """
 </html>
 """.strip()
 
+
 def import_jinja2():
     """
     Import jinja2 module only when needed
@@ -142,6 +143,7 @@ def import_jinja2():
     except ImportError:
         raise tmt.utils.ReportError(
             "Missing 'jinja2', fixable by 'pip install tmt[report-html]'")
+
 
 class ReportHtml(tmt.steps.report.ReportPlugin):
     """ Format test results into an html report """

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1,23 +1,24 @@
 
 """ Test Metadata Utilities """
 
-from click import style, echo, wrap_text
 
-from collections import OrderedDict
-from threading import Timer
-import unicodedata
-import subprocess
-import fmf
-import pprint
-import shlex
-import select
-import shutil
-import yaml
-import re
+import fcntl
 import io
 import os
-import fcntl
+import pprint
+import re
+import select
+import shlex
+import shutil
+import subprocess
+import unicodedata
+from collections import OrderedDict
+from threading import Timer
+
+import fmf
 import requests
+import yaml
+from click import style, echo, wrap_text
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1,7 +1,6 @@
 
 """ Test Metadata Utilities """
 
-
 import fcntl
 import io
 import os
@@ -53,6 +52,7 @@ PROCESS_TIMEOUT = 124
 
 # Default select.select(timeout) in seconds
 DEFAULT_SELECT_TIMEOUT = 5
+
 
 class Config(object):
     """ User configuration """
@@ -519,6 +519,7 @@ class Common(object):
             create_directory(self._workdir, 'workdir', quiet=True)
         return self._workdir
 
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Exceptions
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -529,8 +530,10 @@ class GeneralError(Exception):
         # Store the original exception for future use
         self.original = kwargs.get('original')
 
+
 class FileError(GeneralError):
     """ File operation error """
+
 
 class RunError(GeneralError):
     """ Command execution error """
@@ -544,37 +547,48 @@ class RunError(GeneralError):
         self.stdout = stdout
         self.stderr = stderr
 
+
 class MetadataError(GeneralError):
     """ General metadata error """
+
 
 class SpecificationError(MetadataError):
     """ Metadata specification error """
 
+
 class ConvertError(MetadataError):
     """ Metadata conversion error """
 
+
 class StructuredFieldError(GeneralError):
     """ StructuredField parsing error """
+
 
 # Step exceptions
 
 class DiscoverError(GeneralError):
     """ Discover step error """
 
+
 class ProvisionError(GeneralError):
     """ Provision step error """
+
 
 class PrepareError(GeneralError):
     """ Prepare step error """
 
+
 class ExecuteError(GeneralError):
     """ Execute step error """
+
 
 class ReportError(GeneralError):
     """ Report step error """
 
+
 class FinishError(GeneralError):
     """ Finish step error """
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Utilities


### PR DESCRIPTION
While replacing PyYAML with ruamel.yaml, I noticed that some parts our code don't comply with PEP8, mainly import order and blank lines around classes/functions. We embrace PEP8 compliance in our contribution guide, so lets try to follow it ourselves :)

This PR fixes:
 - group imports into 3 categories (standard libraries, third party libraries, local imports) as described in https://www.python.org/dev/peps/pep-0008/#imports (also remove unused imports)
 - surround top-level classes and functions with 2 blank lines as described in https://www.python.org/dev/peps/pep-0008/#blank-lines