### PR TITLE
Enable install plans for pull request testing

### DIFF
--- a/plans/install/main.fmf
+++ b/plans/install/main.fmf
@@ -5,4 +5,4 @@ provision:
 enabled: false
 adjust:
     enabled: true
-    when: how == full
+    when: how == full or trigger == commit


### PR DESCRIPTION
It makes sense to ensure for each pull request that the change
does not break docs building and the minimal/pip installation.