### PR TITLE
Print better error when nitrate testcase not found.

### DIFF
--- a/tmt/export.py
+++ b/tmt/export.py
@@ -374,8 +374,8 @@ def create_nitrate_case(test):
     remote_dirname = re.sub('.git$', '', os.path.basename(test.fmf_id['url']))
     if not remote_dirname:
         raise ConvertError("Unable to find git remote url.")
-    summary = test.node.get('extra-summary', remote_dirname + test.name + ' - '
-                            + test.summary)
+    summary = test.node.get('extra-summary', (remote_dirname or "")
+                            + (test.name or "") + ' - ' + (test.summary or ""))
     category = nitrate.Category(name=category, product=DEFAULT_PRODUCT)
     testcase = nitrate.TestCase(summary=summary, category=category)
     echo(style(f"Test case '{testcase.identifier}' created.", fg='blue'))

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -6,6 +6,7 @@
 import email
 import os
 import re
+from functools import lru_cache
 
 import fmf
 from click import echo, style
@@ -188,7 +189,9 @@ def export_to_nitrate(test):
             # Newly created tmt tests have special format summary
             test._metadata['extra-summary'] = nitrate_case.summary
         else:
-            raise ConvertError("Nitrate test case id not found.")
+            raise ConvertError(f"Nitrate test case id not found for {test}"
+                               " (You can use --create option to enforce"
+                               " creating testcases)")
     except (nitrate.NitrateError, gssapi.raw.misc.GSSError) as error:
         raise ConvertError(error)
 
@@ -379,6 +382,8 @@ def create_nitrate_case(test):
     return testcase
 
 
+# avoid multiple searching for general plans (it is expensive)
+@lru_cache(maxsize=None)
 def find_general_plan(component):
     """ Return single General Test Plan or raise an error """
     # At first find by linked components


### PR DESCRIPTION
 - Better suggestion when raising error for missing testcase
 - Add performance optimalization for searching general plans.
 - Fix issue with `NoneType` when case not found - not sure root cause but would be better to use this to avoid `str + NoneType`