### PR TITLE
Fix lint and use it on tmt repo

### DIFF
--- a/plans/sanity/lint.fmf
+++ b/plans/sanity/lint.fmf
@@ -1,0 +1,8 @@
+summary: Metadata used by tmt itself are valid
+discover:
+    how: shell
+    tests:
+      - name: /lint/tests
+        test: tmt tests lint
+      - name: /lint/plans
+        test: tmt plans lint

--- a/tests/core/docs/main.fmf
+++ b/tests/core/docs/main.fmf
@@ -1,3 +1,4 @@
 summary: Check that essential documentation is working
-coverage: /stories/docs
+link:
+  - verifies: /stories/docs
 tag-: [container] # docs are not installed in containers

--- a/tests/test/lint/data/coverage.fmf
+++ b/tests/test/lint/data/coverage.fmf
@@ -1,0 +1,2 @@
+test: /bin/true
+coverage: /story/doc

--- a/tests/test/lint/test.sh
+++ b/tests/test/lint/test.sh
@@ -42,6 +42,8 @@ rlJournalStart
         done
         rlRun "tmt test lint bad-attribute | tee output" 1
         rlAssertGrep "fail unknown attribute 'requires' is used" output
+        rlRun "tmt test lint coverage | tee output" 1
+        rlAssertGrep "fail coverage has been obsoleted by link" output
     rlPhaseEnd
 
     rlPhaseStartTest "Fix"

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -35,9 +35,12 @@ DEFAULT_TEST_DURATION_L2 = '1h'
 # How many already existing lines should tmt run --follow show
 FOLLOW_LINES = 10
 
+# Obsoleted test keys
+OBSOLETED_TEST_KEYS = "relevancy coverage".split()
+
 # Unofficial temporary test keys
 EXTRA_TEST_KEYS = (
-    "relevancy extra-nitrate extra-hardware extra-pepa "
+    "extra-nitrate extra-hardware extra-pepa "
     "extra-summary extra-task".split())
 
 
@@ -50,7 +53,7 @@ class Node(tmt.utils.Common):
     """
 
     # Core attributes (supported across all levels)
-    _keys = ['summary', 'description', 'enabled', 'link']
+    _keys = ['summary', 'description', 'enabled', 'link', 'adjust']
 
     def __init__(self, node, parent=None):
         """ Initialize the node """
@@ -398,9 +401,15 @@ class Test(Node):
                 valid = verdict(
                     False, 'relevancy has been obsoleted by adjust')
 
+        # Check for possible coverage attribute
+        coverage = metadata.pop('coverage', None)
+        if coverage:
+            valid = verdict(False, 'coverage has been obsoleted by link')
         # Check for unknown attributes
         # FIXME - Make additional attributes configurable
-        invalid_keys = self.lint_keys(EXTRA_TEST_KEYS)
+        # We don't want adjust in show/export so it is not yet in Test._keys
+        invalid_keys = self.lint_keys(
+            EXTRA_TEST_KEYS + OBSOLETED_TEST_KEYS + ['adjust'])
         if invalid_keys:
             valid = False
             for key in invalid_keys:


### PR DESCRIPTION
Recognize adjust as a valid Test's key
Convert deprecated coverage attribute in the test
Use lint in the CI

Resolves #718