### PR TITLE
Reserve multihost as Test attribute

### DIFF
--- a/tests/test/import/data/parent/child/Makefile
+++ b/tests/test/import/data/parent/child/Makefile
@@ -32,7 +32,7 @@ $(METADATA): Makefile
 	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
 	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
 	@echo "Description:     Simple smoke test" >> $(METADATA)
-	@echo "Type:            Sanity" >> $(METADATA)
+	@echo "Type:            Multihost" >> $(METADATA)
 	@echo "TestTime:        5m" >> $(METADATA)
 	@echo "RunFor:          tmt" >> $(METADATA)
 	@echo "Requires:        fmf" >> $(METADATA)

--- a/tests/test/import/test.sh
+++ b/tests/test/import/test.sh
@@ -53,6 +53,10 @@ rlJournalStart
         rlAssertGrep 'relates.*1234567' 'output'
     rlPhaseEnd
 
+    rlPhaseStartTest 'Multihost'
+        rlAssertGrep 'multihost:\s*{}' "main.fmf"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "rm -r $tmp" 0 "Removing tmp directory"
         rlRun 'popd'

--- a/tests/test/lint/test.sh
+++ b/tests/test/lint/test.sh
@@ -25,6 +25,11 @@ rlJournalStart
         rlAssertNotGrep 'fail' output
     rlPhaseEnd
 
+    rlPhaseStartTest "Warn"
+        rlRun "tmt test lint multihost | tee output"
+        rlAssertGrep 'warn multihost is not yet supported by tmt'  output
+    rlPhaseEnd
+
     rlPhaseStartTest "Bad"
         rlRun "tmt test lint bad | tee output" 1
         rlAssertGrep 'fail test script must be defined' output

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -39,7 +39,7 @@ FOLLOW_LINES = 10
 # Unofficial temporary test keys
 EXTRA_TEST_KEYS = (
     "relevancy extra-nitrate extra-hardware extra-pepa "
-    "extra-summary extra-task".split())
+    "extra-summary extra-task multihost".split())
 
 
 class Node(tmt.utils.Common):
@@ -398,6 +398,10 @@ class Test(Node):
             else:
                 valid = verdict(
                     False, 'relevancy has been obsoleted by adjust')
+
+        # Check for multihost and warn user
+        if 'multihost' in self.node.get():
+            verdict(None, 'multihost is not yet supported by tmt')
 
         # Check for unknown attributes
         # FIXME - Make additional attributes configurable

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -325,6 +325,16 @@ def read(path, makefile, nitrate, purpose, disabled):
             echo(
                 style('recommend: ', fg='green') + ' '.join(data['recommend']))
 
+        # Multihost (from Type)
+        try:
+            type = re.search(
+                r'^Type:\s*(.*)', testinfo, re.M).group(1)
+            if type == "Multihost":
+                # Attribute value is not yet defined
+                data['multihost'] = {}
+                echo(style('multihost: ', fg='green') + 'placeholder used')
+        except AttributeError:
+            pass
         # Add relevant bugs to the 'link' attribute
         for bug in re.findall(r'^Bug:\s*([0-9]+)', testinfo, re.M):
             add_bug(bug, data)
@@ -659,7 +669,7 @@ def write(path, data):
     extra_keys = [
         'adjust', 'extra-nitrate',
         'extra-summary', 'extra-task',
-        'extra-hardware', 'extra-pepa']
+        'extra-hardware', 'extra-pepa', 'multihost']
     sorted_data = dict()
     for key in tmt.base.Test._keys + extra_keys:
         try:


### PR DESCRIPTION
Cannot be used in tmt directly but other system might use it already.
Update linter to warn user about its usage.
Detect it from Makefile in the import