### PR TITLE
Do not assert installed packages for recommend

### DIFF
--- a/tests/prepare/recommend/data/plan.fmf
+++ b/tests/prepare/recommend/data/plan.fmf
@@ -4,3 +4,13 @@ provision:
     how: container
 execute:
     how: tmt
+
+/mixed:
+    summary: One package found, one not available
+    discover+:
+        test: mixed
+
+/weird:
+    summary: No recommended package found
+    discover+:
+        test: weird

--- a/tests/prepare/recommend/data/test.fmf
+++ b/tests/prepare/recommend/data/test.fmf
@@ -1,2 +1,7 @@
-test: rpm -q tree
-recommend: [tree, forest]
+/mixed:
+    test: rpm -q tree
+    recommend: [tree, forest]
+
+/weird:
+    test: /bin/true
+    recommend: weird-package

--- a/tests/prepare/recommend/test.sh
+++ b/tests/prepare/recommend/test.sh
@@ -2,9 +2,17 @@
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 rlJournalStart
-    rlPhaseStartTest
+    rlPhaseStartSetup
         rlRun "pushd data"
-        rlRun "tmt run"
+    rlPhaseEnd
+
+    for image in centos:7 centos:8 fedora; do
+        rlPhaseStartTest "Test $image"
+            rlRun "tmt run -ar provision -h container -i $image"
+        rlPhaseEnd
+    done
+
+    rlPhaseStartCleanup
         rlRun "popd"
     rlPhaseEnd
 rlJournalEnd

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -229,7 +229,12 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
             packages = ' '.join(
                 [tmt.utils.quote(package) for package in repo_packages])
             check = f'rpm -q --whatprovides {packages}'
-            # Check and install (extra check for yum to workaround BZ#1920176)
+            # Extra ignore/check for yum to workaround BZ#1920176
+            if 'yum' in command:
+                yum_check = " || true" if skip else f" && {check}"
+            else:
+                yum_check = ""
+            # Check and install
             guest.execute(
-                f'{check} || {command} install {options} {packages}' +
-                (f' && {check}' if 'yum' in command else ''))
+                f"{check} || {command} install {options} "
+                f"{packages}{yum_check}")


### PR DESCRIPTION
Disable the extra check for yum when --skip-broken is used.
Extend the test coverage to run against centos 7/8 as well.

Resolves #734.