### PR TITLE
Cleanup workdirs during tests

### DIFF
--- a/tests/clean/guests/test.sh
+++ b/tests/clean/guests/test.sh
@@ -63,6 +63,7 @@ rlJournalStart
 
     rlPhaseStartCleanup
         rlRun "popd"
+        rlRun "rm -r $runid" 0 "Remove initial run"
         rlRun "rm -r $tmp" 0 "Remove tmp directory"
         rlRun "rm -r $tmprun" 0 "Remove a temporary directory for runs"
     rlPhaseEnd

--- a/tests/core/dry/test.sh
+++ b/tests/core/dry/test.sh
@@ -3,9 +3,9 @@
 
 rlJournalStart
     rlPhaseStartTest
-        rlRun "tmt run --dry"
-        rlRun "tmt run --dry -dv"
-        rlRun "tmt run --dry -ddvv"
-        rlRun "tmt run --dry -dddvvv"
+        rlRun "tmt run --dry -r"
+        rlRun "tmt run --dry -dvr"
+        rlRun "tmt run --dry -ddvvr"
+        rlRun "tmt run --dry -dddvvvr"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/core/env/test.sh
+++ b/tests/core/env/test.sh
@@ -16,7 +16,7 @@ rlJournalStart
     rlPhaseEnd
 
     for execute in 'shell.detach' 'shell.tmt'; do
-        tmt="tmt run -avvv execute --how $execute"
+        tmt="tmt run -avvvr execute --how $execute"
 
         rlPhaseStartTest "Variable in L1 ($execute)"
             rlRun "$tmt plan --name no test --name yes | tee output"
@@ -33,7 +33,7 @@ rlJournalStart
         rlPhaseStartTest "Variable in option ($execute)"
             for plan in yes no; do
                 for test in yes no; do
-                    rlRun "tmt run -avvv -e STR=O -e INT=0 \
+                    rlRun "tmt run -avvvr -e STR=O -e INT=0 \
                         execute --how $execute \
                         plan --name $plan \
                         test --name $test | tee output"
@@ -47,7 +47,7 @@ rlJournalStart
         rlPhaseStartTest "Variable in YAML file ($execute)"
             for plan in yes no; do
                 for test in yes no; do
-                    rlRun "tmt run -avvv -e @vars.yaml \
+                    rlRun "tmt run -avvvr -e @vars.yaml \
                         execute --how $execute \
                         plan --name $plan \
                         test --name $test | tee output"

--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -11,7 +11,7 @@ rlJournalStart
     rlPhaseStartTest "Filter by test name"
         plan='plan --name fmf/nourl/noref/nopath'
         discover='discover --how fmf --test discover1'
-        rlRun 'tmt run -dv $discover $plan | tee output'
+        rlRun 'tmt run -dvr $discover $plan finish | tee output'
         rlAssertGrep '1 test selected' output
         rlAssertGrep '/tests/discover1' output
         rlAssertNotGrep '/tests/discover2' output
@@ -21,7 +21,7 @@ rlJournalStart
     rlPhaseStartTest "Filter by advanced filter"
         plan='plan --name fmf/nourl/noref/nopath'
         discover='discover --how fmf --filter tier:1,2'
-        rlRun 'tmt run -dv $discover $plan | tee output'
+        rlRun 'tmt run -dvr $discover $plan finish | tee output'
         rlAssertGrep '2 tests selected' output
         rlAssertGrep '/tests/discover1' output
         rlAssertGrep '/tests/discover2' output

--- a/tests/discover/references.sh
+++ b/tests/discover/references.sh
@@ -4,13 +4,14 @@
 
 rlJournalStart
     rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory for failed run"
         rlRun 'pushd data'
         rlRun 'set -o pipefail'
     rlPhaseEnd
 
     plan=fmf/nourl/noref/nopath
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dv discover plan --name $plan | tee output'
+        rlRun 'tmt run -dvr discover plan --name $plan finish | tee output'
         rlAssertNotGrep 'Cloning into' output
         rlAssertNotGrep 'Checkout ref' output
         rlAssertGrep '3 tests selected' output
@@ -22,8 +23,8 @@ rlJournalStart
     plan=fmf/nourl/noref/path
     path=$(realpath .)
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dv discover --how fmf --path $path plan --name $plan \
-            | tee output'
+        rlRun 'tmt run -dvr discover --how fmf --path $path plan --name $plan \
+            finish | tee output'
         rlAssertNotGrep 'Cloning into' output
         rlAssertNotGrep 'Checkout ref' output
         rlAssertGrep '3 tests selected' output
@@ -34,7 +35,7 @@ rlJournalStart
 
     plan=fmf/nourl/ref/nopath
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dv discover plan --name $plan | tee output'
+        rlRun 'tmt run -dvr discover plan --name $plan finish | tee output'
         rlAssertNotGrep 'Cloning into' output
         rlAssertGrep 'Checkout ref.*5407fe5' output
         rlAssertGrep /tests/docs output
@@ -46,8 +47,8 @@ rlJournalStart
     path=$(realpath ../../../examples/together)
     echo $path
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dddv discover --how fmf --path $path \
-            plan --name $plan | tee output'
+        rlRun 'tmt run -dddvr discover --how fmf --path $path \
+            plan --name $plan finish | tee output'
         rlAssertNotGrep 'Cloning into' output
         rlAssertGrep 'Checkout ref.*eae4d52' output
         rlAssertGrep '2 tests selected' output
@@ -57,7 +58,7 @@ rlJournalStart
 
     plan=fmf/url/noref/nopath
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dddv discover plan --name $plan | tee output'
+        rlRun 'tmt run -dddvr discover plan --name $plan finish | tee output'
         rlAssertGrep 'Cloning into' output
         rlAssertNotGrep 'Checkout ref.*master' output
         rlAssertGrep /tests/core/docs output
@@ -67,7 +68,7 @@ rlJournalStart
 
     plan=fmf/url/noref/path
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dddv discover plan --name $plan | tee output'
+        rlRun 'tmt run -dddvr discover plan --name $plan finish | tee output'
         rlAssertGrep 'Cloning into' output
         rlAssertNotGrep 'Checkout ref.*master' output
         rlAssertGrep '2 tests selected' output
@@ -77,7 +78,7 @@ rlJournalStart
 
     plan=fmf/url/ref/nopath
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dddv discover plan --name $plan | tee output'
+        rlRun 'tmt run -dddvr discover plan --name $plan finish | tee output'
         rlAssertGrep 'Cloning into' output
         rlAssertGrep 'Checkout ref.*5407fe5' output
         rlAssertGrep 'hash.*5407fe5' output
@@ -89,7 +90,7 @@ rlJournalStart
 
     plan=fmf/url/ref/path
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dddv discover plan --name $plan | tee output'
+        rlRun 'tmt run -dddvr discover plan --name $plan finish | tee output'
         rlAssertGrep 'Cloning into' output
         rlAssertGrep 'Checkout ref.*eae4d52' output
         rlAssertGrep 'hash.*eae4d52' output
@@ -97,12 +98,13 @@ rlJournalStart
         rlAssertGrep /tests/full output
         rlAssertGrep /tests/smoke output
         # Before the change was committed
-        rlRun 'tmt run -d discover --how fmf --ref eae4d52^ plan --name $plan \
-            2>&1 | tee output' 2
+        rlRun "tmt run -i $tmp -d discover --how fmf --ref eae4d52^ plan \
+            --name $plan 2>&1 | tee output" 2
         rlAssertGrep 'Metadata tree path .* not found.' output
     rlPhaseEnd
 
     rlPhaseStartCleanup
+        rlRun "rm -r $tmp" 0 "Removing tmp directory"
         rlRun 'rm -f output' 0 'Removing tmp file'
         rlRun 'popd'
     rlPhaseEnd

--- a/tests/discover/scripts.sh
+++ b/tests/discover/scripts.sh
@@ -11,19 +11,19 @@ rlJournalStart
     plan='plan --name /smoke'
 
     rlPhaseStartTest 'Discover only'
-        rlRun "tmt run discover $plan | tee output"
+        rlRun "tmt run -r discover finish $plan | tee output"
         rlAssertGrep '1 test selected' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'Selected steps'
-        rlRun "tmt run discover provision execute $plan | tee output"
+        rlRun "tmt run -r discover provision execute finish $plan | tee output"
         rlAssertGrep '1 test selected' 'output'
         rlAssertGrep 'discover' 'output'
         rlAssertGrep 'provision' 'output'
         rlAssertGrep 'execute' 'output'
+        rlAssertGrep 'finish' 'output'
         rlAssertNotGrep 'prepare' 'output'
         rlAssertNotGrep 'report' 'output'
-        rlAssertNotGrep 'finish' 'output'
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/execute/codes/test.sh
+++ b/tests/execute/codes/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        tmt="tmt run -a provision -h local"
+        tmt="tmt run -ar provision -h local"
         rlRun "$tmt execute -h shell -s true" 0 "Good test"
         rlRun "$tmt execute -h shell -s false" 1 "Bad test"
         rlRun "$tmt execute -h shell -s fooo" 2 "Weird test"

--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -4,7 +4,7 @@
 rlJournalStart
     rlPhaseStartSetup
         rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
-        rlRun "tmt='tmt run -a provision -h local'"
+        rlRun "tmt='tmt run -ar provision -h local'"
         rlRun "pushd $tmp"
         rlRun "set -o pipefail"
         rlRun "tmt init -t mini"
@@ -33,8 +33,8 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Last run"
-        rlRun "$tmt"
-        rlRun "tmt run -l login -c true | tee output"
+        rlRun "tmt run -a provision -h local"
+        rlRun "tmt run -rl login -c true | tee output"
         rlAssertGrep "interactive" "output"
     rlPhaseEnd
 

--- a/tests/login/when.sh
+++ b/tests/login/when.sh
@@ -4,7 +4,7 @@
 rlJournalStart
     rlPhaseStartSetup
         rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
-        rlRun "tmt='tmt run -a provision -h local execute -h shell -s '"
+        rlRun "tmt='tmt run -ar provision -h local execute -h shell -s '"
         rlRun "pushd $tmp"
         rlRun "set -o pipefail"
         rlRun "tmt init -t mini"

--- a/tests/plan/select/test.sh
+++ b/tests/plan/select/test.sh
@@ -3,6 +3,7 @@
 
 rlJournalStart
     rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create temporary run workdir"
         rlRun "output=\$(mktemp)" 0 "Create output file"
         rlRun "set -o pipefail"
     rlPhaseEnd
@@ -34,7 +35,7 @@ rlJournalStart
 
     for name in '-n' '--name'; do
         rlPhaseStartTest "tmt run plan $name <name>"
-            tmt='tmt run -r discover'
+            tmt='tmt run -i $tmp discover'
             rlRun "$tmt plan $name core | tee $output"
             rlAssertGrep "^/plans/features/core" $output
             rlAssertNotGrep "^/plans/features/basic" $output
@@ -44,6 +45,7 @@ rlJournalStart
     done
 
     rlPhaseStartCleanup
+        rlRun "rm -r $tmp" 0 "Remove temporary run workdir"
         rlRun "rm $output" 0 "Remove output file"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/prepare/basic/test.sh
+++ b/tests/prepare/basic/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "tmt run -dddvvv | tee output"
+        rlRun "tmt run -dddvvvr | tee output"
         rlAssertGrep "Test Management Tool" "output"
     rlPhaseEnd
 

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -7,19 +7,19 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Just enable copr"
-        rlRun "tmt run -adddvvv plan --name copr"
+        rlRun "tmt run -adddvvvr plan --name copr"
     rlPhaseEnd
 
     rlPhaseStartTest "Escape package names"
-        rlRun "tmt run -adddvvv plan --name escape"
+        rlRun "tmt run -adddvvvr plan --name escape"
     rlPhaseEnd
 
     rlPhaseStartTest "Exclude selected packages"
-        rlRun "tmt run -adddvvv plan --name exclude"
+        rlRun "tmt run -adddvvvr plan --name exclude"
     rlPhaseEnd
 
     rlPhaseStartTest "Install from epel7 copr"
-        rlRun "tmt run -adddvvv plan --name epel7"
+        rlRun "tmt run -adddvvvr plan --name epel7"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/prepare/require/test.sh
+++ b/tests/prepare/require/test.sh
@@ -9,7 +9,7 @@ rlJournalStart
 
     for image in fedora centos:7 ; do
         # Prepare the tmt command and expected error message
-        tmt="tmt run -av provision -h container -i $image"
+        tmt="tmt run -avr provision -h container -i $image"
         if [[ $image == fedora ]]; then
             error='Unable to find a match: forest'
         else

--- a/tests/report/summary/test.sh
+++ b/tests/report/summary/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Check summary"
-        rlRun "tmt run | tee output" 2 "Run tests in concise mode"
+        rlRun "tmt run -r | tee output" 2 "Run tests in concise mode"
         rlAssertGrep "3 tests passed, 2 tests failed and 1 error" "output"
     rlPhaseEnd
 
@@ -25,7 +25,7 @@ rlJournalStart
     rlPhaseStartTest "Check the last run"
         rlRun "tmt run -l | tee output" 2 "Last run in concise mode "
         rlAssertGrep "3 tests passed, 2 tests failed and 1 error" "output"
-        rlRun "tmt run -lv | tee output" 2 "Last run in verbose mode "
+        rlRun "tmt run -lvr | tee output" 2 "Last run in verbose mode "
         rlAssertGrep "3 tests passed, 2 tests failed and 1 error" "output"
         rlAssertGrep "fail /test/bad/one" "output"
         rlAssertGrep "pass /test/good/one" "output"

--- a/tests/run/default/test.sh
+++ b/tests/run/default/test.sh
@@ -10,7 +10,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "No Metadata"
-        rlRun "tmt run $options execute -h shell -s 'touch $tmp/no-metadata'"
+        rlRun "tmt run -r $options execute -h shell -s 'touch $tmp/no-metadata'"
         rlAssertExists "$tmp/no-metadata"
     rlPhaseEnd
 
@@ -20,7 +20,7 @@ rlJournalStart
         rlRun "echo 'touch $tmp/no-plan' >> tests/smoke/test.sh"
         rlRun "tmt run $options"
         rlAssertExists "$tmp/no-plan"
-        rlRun "tmt run --last report -fv" 0 "Try --last report (verify #287)"
+        rlRun "tmt run -r --last report -fv finish -f" 0 "Try --last report (verify #287)"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/run/root/test.sh
+++ b/tests/run/root/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
         rlRun "tmt test create -t shell tests/test"
         rlRun "tmt plans create -t mini plans/test-plan"
         rlRun "tmt run --until report provision -h local"
-        rlRun "cd .. && tmt run -vvvddd --last --since report"
+        rlRun "cd .. && tmt run -vvvdddr --last --since report"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/test/select/test.sh
+++ b/tests/test/select/test.sh
@@ -32,7 +32,7 @@ rlJournalStart
 
     for name in '-n' '--name'; do
         rlPhaseStartTest "tmt run test $name <name>"
-            tmt='tmt run -rv discover'
+            tmt='tmt run -rv discover finish'
             # Existing
             rlRun "$tmt test $name enabled | tee $output"
             rlAssertGrep "/tests/enabled/default" $output
@@ -64,8 +64,8 @@ rlJournalStart
             rlAssertGrep '/tests/enabled/disabled' $output
         done
 
-        for tmt in 'tmt test ls' 'tmt run -rv discover test' \
-            'tmt run -rv plans --name /plans/filtered discover test'; do
+        for tmt in 'tmt test ls' 'tmt run -rv discover finish test' \
+            'tmt run -rv plans --name /plans/filtered discover finish test'; do
             # Tag
             rlRun "$tmt --filter tag:slow | tee $output"
             rlAssertNotGrep '/tests/tag/default' $output
@@ -107,7 +107,7 @@ rlJournalStart
         rlAssertNotGrep '/tests/enabled/defined' $output
         rlAssertGrep '/tests/enabled/disabled' $output
 
-        for tmt in 'tmt test ls' 'tmt run -rv discover test'; do
+        for tmt in 'tmt test ls' 'tmt run -rv discover finish test'; do
             # Tag
             rlRun "$tmt --condition '\"slow\" in tag' | tee $output"
             rlAssertNotGrep '/tests/tag/default' $output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -22,12 +22,15 @@ runner = CliRunner()
 
 def test_mini():
     """ Minimal smoke test """
+    tmp = tempfile.mkdtemp()
     result = runner.invoke(
-        tmt.cli.main, ['--root', example('mini'), 'run', '-dv', 'discover'])
+        tmt.cli.main,
+        ['--root', example('mini'), 'run', '-i', tmp, '-dv', 'discover'])
     assert result.exit_code == 0
     assert 'Found 1 plan.' in result.output
     assert '1 test selected' in result.output
     assert '/ci' in result.output
+    shutil.rmtree(tmp)
 
 
 def test_init():
@@ -86,25 +89,29 @@ def test_create():
 def test_step():
     """ Select desired step"""
     for step in ['discover', 'provision', 'prepare']:
+        tmp = tempfile.mkdtemp()
         result = runner.invoke(
-            tmt.cli.main, ['--root', example('local'), 'run', step])
+            tmt.cli.main, ['--root', example('local'), 'run', '-i', tmp, step])
         assert result.exit_code == 0
         assert step in result.output
         assert 'finish' not in result.output
+        shutil.rmtree(tmp)
 
 
 def test_step_execute():
     """ Test execute step"""
+    tmp = tempfile.mkdtemp()
     step = 'execute'
 
     result = runner.invoke(
-        tmt.cli.main, ['--root', example('local'), 'run', step])
+        tmt.cli.main, ['--root', example('local'), 'run', '-i', tmp, step])
 
     # Test execute empty with discover output missing
     assert result.exit_code != 0
     assert isinstance(result.exception, tmt.utils.ExecuteError)
     assert step in result.output
     assert 'provision' not in result.output
+    shutil.rmtree(tmp)
 
 
 def test_systemd():

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -121,10 +121,7 @@ class Common(object):
             self._context = context
 
         # Initialize the workdir if requested
-        if workdir is True:
-            self._workdir_init()
-        elif workdir is not None:
-            self._workdir_init(workdir)
+        self._workdir_load(workdir)
 
     def __str__(self):
         """ Name is the default string representation """
@@ -498,6 +495,17 @@ class Common(object):
             return None
         # Join parent name with self
         return os.path.join(self.parent.workdir, self.name.lstrip('/'))
+
+    def _workdir_load(self, workdir):
+        """
+        Create the given workdir if it is not None
+
+        If workdir=True, the directory name is automatically generated.
+        """
+        if workdir is True:
+            self._workdir_init()
+        elif workdir is not None:
+            self._workdir_init(workdir)
 
     def _workdir_cleanup(self, path=None):
         """ Clean up the work directory """


### PR DESCRIPTION
As agreed at the hacking session on Tuesday, we should use `--remove` in our tests (or remove manually if the option isn't suitable for the type of test) to save space when running tests locally. After this PR, running `tmt run plan -n '(basic|core)'` in the tmt repo produces only one run workdir (compared to over 70 before the changes).

I also noticed a small bug that running `tmt run discover --how fmf --help` or similar (requesting help for a method) creates a workdir with just log.txt. This is was fixed by a slight refactoring, workdir creation is postponed until options are completely processed.