### PR TITLE
Migrate from PyYAML to ruamel.yaml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ install_requires = [
     'fmf>=0.16.0',
     'click',
     'requests',
+    'ruamel.yaml'
 ]
 extras_require = {
     'docs': ['sphinx', 'sphinx_rtd_theme', 'mock'],

--- a/tests/integration/test_nitrate.py
+++ b/tests/integration/test_nitrate.py
@@ -3,10 +3,10 @@ import shutil
 import tempfile
 from pathlib import Path
 
-import yaml
 from click.testing import CliRunner
 from fmf import Tree
 from requre import RequreTestCase
+from ruamel.yaml import YAML
 
 import tmt.base
 import tmt.cli
@@ -94,7 +94,8 @@ class NitrateImport(Base):
         self.assertIn("/Manual/Imported_Test_Case/main.fmf", filename)
         self.assertTrue(Path(filename).exists())
         with open(Path(filename)) as file:
-            out = yaml.safe_load(file)
+            yaml = YAML(typ='safe')
+            out = yaml.load(file)
             self.assertIn("Tier1", out["tag"])
             self.assertIn("tmt_test_component", out["component"])
 
@@ -186,6 +187,7 @@ extra-task: /tmt/integration
             self.assertIn(self.test_md_content, file.read())
         self.assertIn("main.fmf", files)
         with open("main.fmf") as file:
-            generated = yaml.safe_load(file)
-            referenced = yaml.safe_load(self.main_fmf_content)
+            yaml = YAML(typ='safe')
+            generated = yaml.load(file)
+            referenced = yaml.load(self.main_fmf_content)
             self.assertEqual(generated, referenced)

--- a/tests/test/lint/data/old-yaml.fmf
+++ b/tests/test/lint/data/old-yaml.fmf
@@ -1,0 +1,3 @@
+test: /bin/true
+extra-summary: "Some extra summary"
+enabled: yes

--- a/tests/test/lint/data/relevancy-list.fmf
+++ b/tests/test/lint/data/relevancy-list.fmf
@@ -1,3 +1,4 @@
 test: /bin/true
+#comment
 relevancy:
   - 'distro = rhel: False'

--- a/tests/test/lint/data/relevancy-text.fmf
+++ b/tests/test/lint/data/relevancy-text.fmf
@@ -1,3 +1,4 @@
 test: /bin/true
+#comment
 relevancy: |
     distro = rhel: False

--- a/tests/test/lint/test.sh
+++ b/tests/test/lint/test.sh
@@ -25,6 +25,11 @@ rlJournalStart
         rlAssertNotGrep 'fail' output
     rlPhaseEnd
 
+    rlPhaseStartTest "Old yaml"
+        rlRun "tmt test lint old-yaml | tee output"
+        rlAssertGrep 'warn seems to use YAML 1.1' output
+    rlPhaseEnd
+
     rlPhaseStartTest "Bad"
         rlRun "tmt test lint bad | tee output" 1
         rlAssertGrep 'fail test script must be defined' output
@@ -52,6 +57,7 @@ rlJournalStart
         rlAssertGrep 'relevancy converted into adjust' output
         for format in list text; do
             rlAssertNotGrep 'relevancy' "relevancy-$format.fmf"
+            rlIsFedora && rlAssertGrep '#comment' "relevancy-$format.fmf"
             rlAssertGrep 'adjust:' "relevancy-$format.fmf"
             rlAssertGrep 'when: distro == rhel' "relevancy-$format.fmf"
         done

--- a/tmt.spec
+++ b/tmt.spec
@@ -49,11 +49,12 @@ BuildRequires: python%{python3_pkgversion}-requests
 BuildRequires: python%{python3_pkgversion}-testcloud
 BuildRequires: python%{python3_pkgversion}-markdown
 BuildRequires: python%{python3_pkgversion}-junit_xml
+BuildRequires: python%{python3_pkgversion}-ruamel-yaml
 # Required for tests
 BuildRequires: rsync
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
 %if %{with oldreqs}
-Requires:       python%{python3_pkgversion}-PyYAML
+Requires:       python%{python3_pkgversion}-ruamel-yaml
 %endif
 
 %description -n python%{python3_pkgversion}-%{name}

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -10,7 +10,6 @@ import subprocess
 from io import open
 
 import fmf.utils
-import yaml
 from click import echo, style
 
 import tmt.utils
@@ -27,36 +26,6 @@ RELEVANCY_EXPRESSION = (
 
 # Bug url prefix
 BUGZILLA_URL = 'https://bugzilla.redhat.com/show_bug.cgi?id='
-
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#  YAML
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-# Special hack to store multiline text with the '|' style
-# See https://stackoverflow.com/questions/45004464/
-# Python 2 version
-try:
-    yaml.SafeDumper.orig_represent_unicode = yaml.SafeDumper.represent_unicode
-
-    def repr_unicode(dumper, data):
-        if '\n' in data:
-            return dumper.represent_scalar(
-                u'tag:yaml.org,2002:str', data, style='|')
-        return dumper.orig_represent_unicode(data)
-
-    yaml.add_representer(unicode, repr_unicode, Dumper=yaml.SafeDumper)
-# Python 3 version
-except AttributeError:
-    yaml.SafeDumper.orig_represent_str = yaml.SafeDumper.represent_str
-
-    def repr_str(dumper, data):
-        if '\n' in data:
-            return dumper.represent_scalar(
-                u'tag:yaml.org,2002:str', data, style='|')
-        return dumper.orig_represent_str(data)
-
-    yaml.add_representer(str, repr_str, Dumper=yaml.SafeDumper)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -16,7 +16,7 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
             how: container
             image: fedora:latest
 
-    In order to always pull the fresh container image use 'pull: yes'.
+    In order to always pull the fresh container image use 'pull: true'.
     """
 
     # Guest instance


### PR DESCRIPTION
As agreed at the hacking session, lets move to `ruamel.yaml` for more flexibility and also comment preserving. This PR:
 - adds `ruamel.yaml` as a dependency
 - replaces `yaml` completely with `ruamel.yaml` (which also removes the need for some hack-arounds)
 - improves formatting of output YAML files as described in https://github.com/psss/tmt/issues/695 (comments are also kept)
 - only YAML 1.2 is now supported

Resolves: https://github.com/psss/tmt/issues/695