### PR TITLE
Update default option values for verbose and debug

### DIFF
--- a/tmt/options.py
+++ b/tmt/options.py
@@ -9,10 +9,10 @@ import click
 # Verbose, debug and quiet output
 verbose_debug_quiet = [
     click.option(
-        '-v', '--verbose', is_flag=True, multiple=True,
+        '-v', '--verbose', is_flag=True, multiple=True, default=[],
         help='Show more details. Use multiple times to raise verbosity.'),
     click.option(
-        '-d', '--debug', is_flag=True, multiple=True,
+        '-d', '--debug', is_flag=True, multiple=True, default=[],
         help='Provide debugging information. Repeat to see more details.'),
     click.option(
         '-q', '--quiet', is_flag=True,


### PR DESCRIPTION
There has been a change introduced in click 8.0.0 which causes
handling of `verbose` and `debug` options to fail:

    TypeError is raised when parameter with multiple=True
    or nargs > 1 has non-iterable default.
    https://github.com/pallets/click/issues/1749

Provide the expected default values to fix the problem.