### PR TITLE
Hand over plan environment during local execution

### DIFF
--- a/tests/core/env/data/main.fmf
+++ b/tests/core/env/data/main.fmf
@@ -23,5 +23,9 @@
         environment:
             STR: L
             INT: 2
+        prepare:
+            script:
+              - declare -p STR
+              - declare -p INT
     /no:
         summary: This is a plan without variables

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -61,7 +61,12 @@ class GuestLocal(tmt.Guest):
 
     def execute(self, command, **kwargs):
         """ Execute command on localhost """
-        return self.run(command, **kwargs)
+        # Prepare the environment (plan/cli variables override)
+        environment = dict()
+        environment.update(kwargs.pop('env', dict()))
+        environment.update(self.parent.plan.environment)
+        # Run the command under the prepared environment
+        return self.run(command, env=environment, **kwargs)
 
     def push(self, source=None, destination=None, options=None):
         """ Nothing to be done to push workdir """


### PR DESCRIPTION
Make sure that L2 environment variables are correctly passed when
commands are executed on the localhost. Extend the test coverage.