### PR TITLE
Fix option handling for plugins with common prefix

### DIFF
--- a/tmt/options.py
+++ b/tmt/options.py
@@ -68,6 +68,7 @@ def create_method_class(methods):
                 for method in methods:
                     if method.startswith(how):
                         self._method = methods[method]
+                        break
 
         def parse_args(self, context, args):
             self._check_method(args)


### PR DESCRIPTION
Quit the loop once the first matching prefix has been found.
Otherwise the plugin with the highest order would be selected.

Resolves #785.