### PR TITLE
Use `count=True` for multiple flag options

### DIFF
--- a/tmt/options.py
+++ b/tmt/options.py
@@ -9,10 +9,10 @@ import click
 # Verbose, debug and quiet output
 verbose_debug_quiet = [
     click.option(
-        '-v', '--verbose', is_flag=True, multiple=True, default=[],
+        '-v', '--verbose', count=True, default=0,
         help='Show more details. Use multiple times to raise verbosity.'),
     click.option(
-        '-d', '--debug', is_flag=True, multiple=True, default=[],
+        '-d', '--debug', count=True, default=0,
         help='Provide debugging information. Repeat to see more details.'),
     click.option(
         '-q', '--quiet', is_flag=True,

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -189,9 +189,6 @@ class Common(object):
         # parent if it was defined)
         elif option in ['debug', 'verbose']:
             winner = local if local else parent
-            # Convert tuple of booleans into debug/verbose level (int)
-            if isinstance(winner, tuple):
-                winner = len(winner)
             if winner is None:
                 winner = 0
             return winner


### PR DESCRIPTION
Seems that 'multiple=True, is_flag=True' is better to replace with
'count=True'.