### PR TITLE
Install `rsync` before guest.pull()

### DIFF
--- a/tests/execute/rsync/main.fmf
+++ b/tests/execute/rsync/main.fmf
@@ -1,0 +1,7 @@
+summary: Correctly handle rsync removed during test
+enabled: False
+
+adjust:
+  enabled: True
+  when: how == full
+  because: this can be run only with a full virtualization

--- a/tests/execute/rsync/main.fmf
+++ b/tests/execute/rsync/main.fmf
@@ -1,7 +1,7 @@
 summary: Correctly handle rsync removed during test
-enabled: False
+enabled: false
 
 adjust:
-  enabled: True
+  enabled: true
   when: how == full
   because: this can be run only with a full virtualization

--- a/tests/execute/rsync/test.sh
+++ b/tests/execute/rsync/test.sh
@@ -2,9 +2,20 @@
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+    rlPhaseEnd
+
     rlPhaseStartTest "Test with rsync removed during execute"
-        rlRun "tmt run -avvvddd \
+        rlRun "tmt run -arvvvddd \
             provision -h virtual \
             execute -h tmt -s 'rpm -e --nodeps rsync'"
     rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+
 rlJournalEnd

--- a/tests/execute/rsync/test.sh
+++ b/tests/execute/rsync/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartTest "Test with rsync removed during execute"
+        rlRun "tmt run -avvvddd \
+            provision -h virtual \
+            execute -h tmt -s 'rpm -e --nodeps rsync'"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -69,11 +69,7 @@ class Prepare(tmt.steps.Step):
             self.plan.provision.requires() +
             self.plan.execute.requires()
             )
-        try:
-            requires.remove('rsync')
-            rsync_required = True
-        except KeyError:
-            rsync_required = False
+
         if requires:
             data = dict(
                 how='install',
@@ -97,10 +93,6 @@ class Prepare(tmt.steps.Step):
 
         # Prepare guests (including workdir sync)
         for guest in self.plan.provision.guests():
-            # Make sure rsync is installed, push the workdir
-            if rsync_required:
-                self.debug('Ensure that rsync is installed on the guest.')
-                guest.execute('rpm -q rsync || yum install -y rsync')
             guest.push()
             # Create a guest copy and change its parent so that the
             # operations inside prepare plugins on the guest use the

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -455,6 +455,9 @@ class Guest(tmt.utils.Common):
             self.debug(f"Push workdir to guest '{self.guest}'.")
         else:
             self.debug(f"Copy '{source}' to '{destination}' on the guest.")
+        # Make sure rsync is present, note: tests can remove it
+        self.debug('Ensure that rsync is installed on the guest.', level=3)
+        self.install_rsync()
         # Run the rsync command
         try:
             self.run(
@@ -488,6 +491,9 @@ class Guest(tmt.utils.Common):
             self.debug(f"Pull workdir from guest '{self.guest}'.")
         else:
             self.debug(f"Copy '{source}' from the guest to '{destination}'.")
+        # Make sure rsync is present, note: tests can remove it
+        self.debug('Ensure that rsync is installed on the guest.', level=3)
+        self.install_rsync()
         # Run the rsync command
         self.run(
             ["rsync"] + options
@@ -545,7 +551,14 @@ class Guest(tmt.utils.Common):
         """
         self.debug(f"Doing nothing to remove guest '{self.guest}'.")
 
+    def install_rsync(self):
+        """
+        Install rsync on the guest. For now works only with RHEL based
+        distributions.
+        """
+        self.execute('rpm -q rsync || yum install -y rsync')
+
     @classmethod
     def requires(cls):
         """ Syncing workdir with the guest needs rsync installed """
-        return ['rsync']
+        return []

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -455,10 +455,8 @@ class Guest(tmt.utils.Common):
             self.debug(f"Push workdir to guest '{self.guest}'.")
         else:
             self.debug(f"Copy '{source}' to '{destination}' on the guest.")
-        # Make sure rsync is present, note: tests can remove it
-        self.debug('Ensure that rsync is installed on the guest.', level=3)
-        self.install_rsync()
-        # Run the rsync command
+        # Make sure rsync is present (tests can remove it) and sync
+        self._check_rsync()
         try:
             self.run(
                 ["rsync"] + options
@@ -491,10 +489,8 @@ class Guest(tmt.utils.Common):
             self.debug(f"Pull workdir from guest '{self.guest}'.")
         else:
             self.debug(f"Copy '{source}' from the guest to '{destination}'.")
-        # Make sure rsync is present, note: tests can remove it
-        self.debug('Ensure that rsync is installed on the guest.', level=3)
-        self.install_rsync()
-        # Run the rsync command
+        # Make sure rsync is present (tests can remove it) and sync
+        self._check_rsync()
         self.run(
             ["rsync"] + options
             + ["-e", self._ssh_command(join=True)]
@@ -551,14 +547,16 @@ class Guest(tmt.utils.Common):
         """
         self.debug(f"Doing nothing to remove guest '{self.guest}'.")
 
-    def install_rsync(self):
+    def _check_rsync(self):
         """
-        Install rsync on the guest. For now works only with RHEL based
-        distributions.
+        Make sure that rsync is installed on the guest
+
+        For now works only with RHEL based distributions.
         """
-        self.execute('rpm -q rsync || yum install -y rsync')
+        self.debug("Ensure that rsync is installed on the guest.", level=3)
+        self.execute("rpm -q rsync || yum install -y rsync")
 
     @classmethod
     def requires(cls):
-        """ Syncing workdir with the guest needs rsync installed """
+        """ No extra requires needed """
         return []


### PR DESCRIPTION
@mruprich reported that after running installability test the `tmt`
fails on missing rsync when pulling out artifacts.

After investiation, it turned out, installability for `rsync` removes
`rsync` from the test machine, but `tmt` still expects it to be around.

This tries to fix the problem and make sure `rsync` is still installed
on the machine before trying to pull out the artifacts.

Todo:
- [x] review comments
- [x] fix the issues with current tests
- [x] add a new test covering the problem

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>