### PR TITLE
Disable the white space test for container/virtual

### DIFF
--- a/tests/core/spaces/main.fmf
+++ b/tests/core/spaces/main.fmf
@@ -4,6 +4,7 @@ description:
     works as expected when file names and paths contain spaces.
 test: ./test.sh
 framework: beakerlib
+tag-: [container, virtual]
 
 environment:
     METHODS: local container


### PR DESCRIPTION
Needs a full virtualization when run with `--context how=full` and
thus fails when run under the `/plans/provision/*` plans during
the full release testing.