### PR TITLE
Add lint for plans to check invalid attributes

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -427,6 +427,25 @@ Options ``-f`` or ``--force`` can be used to overwrite existing
 files.
 
 
+Lint Plans
+------------------------------------------------------------------
+
+Use ``tmt plan lint`` to check defined plan metadata against the L2
+Metadata Specification::
+
+    $ tmt plan lint
+    /plans/smoke
+    pass correct attributes are used
+
+    /plans/features/advanced
+    pass correct attributes are used
+    pass fmf remote id in 'default' is valid
+
+    /plans/features/basic
+    pass correct attributes are used
+    pass fmf remote id in 'default' is valid
+
+
 Inherit Plans
 ------------------------------------------------------------------
 

--- a/tests/plan/lint/data/invalid_attr.fmf
+++ b/tests/plan/lint/data/invalid_attr.fmf
@@ -1,0 +1,9 @@
+summaryABCDEF: Basic smoke test
+environmen:
+        KOJI_TASK_ID: 42890031
+        RELEASE: f33
+execute:
+    script: tmt --help
+discove:
+  - name: a
+    how: fmf

--- a/tests/plan/lint/test.sh
+++ b/tests/plan/lint/test.sh
@@ -52,6 +52,12 @@ rlJournalStart
         rlAssertGrep "fail repo 'http://invalid-url' cannot be cloned" \
             $rlRun_LOG
         rlRun "rm $rlRun_LOG"
+
+        rlRun -s "tmt plan lint invalid_attr" 1
+        rlAssertGrep "fail unknown attribute 'discove' is used" $rlRun_LOG
+        rlAssertGrep "fail unknown attribute 'environmen' is used" $rlRun_LOG
+        rlAssertGrep "fail unknown attribute 'summaryABCDEF' is used" $rlRun_LOG
+        rlRun "rm $rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -463,6 +463,12 @@ class Test(Core):
 class Plan(Core):
     """ Plan object (L2 Metadata) """
 
+    extra_L2_keys = [
+        'context',
+        'environment',
+        'gate',
+        ]
+
     def __init__(self, node, run=None):
         """ Initialize the plan """
         super().__init__(node, parent=run)
@@ -725,10 +731,21 @@ class Plan(Core):
         # Explore all available plugins
         tmt.plugins.explore()
 
+        invalid_keys = self.lint_keys(
+            list(self.steps(enabled=True, disabled=True, names=True)) +
+            self.extra_L2_keys)
+
+        if invalid_keys:
+            for key in invalid_keys:
+                verdict(False, f"unknown attribute '{key}' is used")
+        else:
+            verdict(True, "correct attributes are used")
+
         return all([
             self._lint_summary(),
             self._lint_execute(),
-            self._lint_discover()])
+            self._lint_discover(),
+            len(invalid_keys) == 0])
 
     def go(self):
         """ Execute the plan """


### PR DESCRIPTION
Resolves issue #707.

Does not resolves a case, such as:

```
summary: Basic smoke test
execute:
    scriptHELLO: tmt --help
```
If I got it correctly, there are changes needed in steps, so lint implementation for steps would be necessary?  