### PR TITLE
Use testcloud for image url guessing

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -74,7 +74,7 @@ Dependencies required to run tests in a container environment.
 Summary: Virtual machine provisioner for the Test Management Tool
 Obsoletes: tmt-testcloud < 0.17
 Requires: tmt == %{version}-%{release}
-Requires: python%{python3_pkgversion}-testcloud >= 0.5.0
+Requires: python%{python3_pkgversion}-testcloud >= 0.6.0
 Requires: ansible openssh-clients
 
 %description provision-virtual

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -151,6 +151,9 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
 
         https://kojipkgs.fedoraproject.org/compose/
 
+    Short names are also provided for 'centos', 'centos-stream',
+    'debian' and 'ubuntu' (e.g. 'centos-8' or 'c8').
+
     Use the full path for images stored on local disk, for example:
 
         /var/tmp/images/Fedora-Cloud-Base-31-1.9.x86_64.qcow2


### PR DESCRIPTION
Fixes https://github.com/psss/tmt/issues/514 ; uses testcloud to guess qcow2 url for short distro handles.

Needs latest testcloud git snapshot, available in  https://copr.fedorainfracloud.org/coprs/frantisekz/testcloud-wip/ .

Ubuntu and Debian support is not working, at least in m testing (url to qcow gets guessed correctly, vm boots up but ssh is not working, it is with plain testcloud).