### PR TITLE
Make sure pip is available for integration testing

### DIFF
--- a/plans/integration/main.fmf
+++ b/plans/integration/main.fmf
@@ -6,6 +6,9 @@ discover:
     how: fmf
     filter: 'tag: integration'
 prepare:
+  - name: Install pip
+    how: install
+    package: python3-pip
   - name: Install Requre
     script: pip3 install requre
   - name: Create default nitrate config


### PR DESCRIPTION
The latest rawhide does not include pip by default.