### PR TITLE
Login after last done step without --step option

### DIFF
--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -38,6 +38,12 @@ rlJournalStart
         rlAssertGrep "interactive" "output"
     rlPhaseEnd
 
+    rlPhaseStartTest "Last run failed"
+        rlRun "tmt run provision -h local prepare --how shell --script false" 2
+        rlRun "tmt run -rl login -c true | tee output" 2
+        rlAssertGrep "interactive" "output"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $tmp" 0 "Removing tmp directory"

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -798,6 +798,8 @@ class Plan(Core):
                 else:
                     step.warn(error)
 
+        # Set up login plugins for all steps
+        self.debug("login", color="blue", level=2)
         for step in self.steps(disabled=True):
             step.setup_login()
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -798,6 +798,9 @@ class Plan(Core):
                 else:
                     step.warn(error)
 
+        for step in self.steps(disabled=True):
+            step.setup_login()
+
         # Run enabled steps except 'finish'
         self.debug('go', color='cyan', shift=0, level=2)
         try:

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -149,10 +149,11 @@ class Step(tmt.utils.Common):
                 data['how'] = how
 
     def setup_login(self):
-        """Insert login plugins if requested on the command line"""
+        """ Insert login plugins if requested on the command line """
         for plugin in Login.plugins(step=self):
             self.debug(
-                f"Insert login plugin with order '{plugin.order}'.", level=2)
+                f"Insert a login plugin into the '{self}' step "
+                f"with order '{plugin.order}'.", level=2)
             self._plugins.append(plugin)
 
     def plugins(self, classes=None):
@@ -427,9 +428,10 @@ class Login(tmt.utils.Common):
             """
             Provide user with an interactive shell on the guest.
 
-            By default the shell si provided at the end of the last
-            enabled step. Use one or more --step options to select a
-            different step instead.
+            By default the shell is provided at the end of the last
+            enabled step. When used together with the --last option the
+            last completed step is selected. Use one or more --step
+            options to select a different step instead.
 
             Optional phase can be provided to specify the exact phase of
             the step when the shell should be provided. The following


### PR DESCRIPTION
Previously, login would be always done after the last enabled step. In
case of tmt run --skip finish and tmt run --last login, that would
always be report. However, if for example prepare step failed, tmt would
never get to login which made troubleshooting more difficult.

If no --step option is used and --last is used, login after the last
done enabled step to consider the possibility of a failure (the failed
step will be marked as todo). To achieve this, Login setup must be done
only once all step statuses have been loaded.

Resolves: #510 
Resolves: #508 (the issue doesn't mention a reproducer but as far as I understand the problem described, it should be solved. For example if I use `tmt run` and then I use `tmt run -l login` during execute step in another terminal, login to the machine happens after prepare which is expected).