### PR TITLE
Various improvements to plugins

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -322,6 +322,21 @@ class Plugin(tmt.utils.Common, metaclass=PluginIndex):
             step.info(
                 'hint', "See 'tmt run provision --help' for all "
                 "available provision options.", color='blue')
+        elif step.name == 'report':
+            if data['how'] == 'html':
+                step.info(
+                    'hint', "Install 'tmt-report-html' to format results "
+                    "as a html report.", color='blue')
+            if data['how'] == 'junit':
+                step.info(
+                    'hint', "Install 'tmt-report-junit' to write results "
+                    "in JUnit format.", color='blue')
+            step.info(
+                'hint', "Use the 'display' method to show test results "
+                "on the terminal.", color='blue')
+            step.info(
+                'hint', "See 'tmt run report --help' for all "
+                "available report options.", color='blue')
 
         # Report invalid method
         raise tmt.utils.SpecificationError(

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -95,16 +95,21 @@ class Provision(tmt.steps.Step):
 
         # Provision guests
         self._guests = []
-        for plugin in self.plugins():
-            plugin.go()
-            if isinstance(plugin, ProvisionPlugin):
-                plugin.guest().details()
-                self._guests.append(plugin.guest())
+        try:
+            for plugin in self.plugins():
+                try:
+                    plugin.go()
+                    if isinstance(plugin, ProvisionPlugin):
+                        plugin.guest().details()
+                finally:
+                    if isinstance(plugin, ProvisionPlugin):
+                        self._guests.append(plugin.guest())
 
-        # Give a summary, update status and save
-        self.summary()
-        self.status('done')
-        self.save()
+            # Give a summary, update status and save
+            self.summary()
+            self.status('done')
+        finally:
+            self.save()
 
     def guests(self):
         """ Return the list of all provisioned guests """

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -486,9 +486,9 @@ class GuestTestcloud(tmt.Guest):
         self.info('progress', 'booting...', 'cyan')
         self.instance.ram = self.memory
         self.instance.disk_size = self.disk
-        self.instance.prepare()
-        self.instance.spawn_vm()
         try:
+            self.instance.prepare()
+            self.instance.spawn_vm()
             self.instance.start(DEFAULT_BOOT_TIMEOUT)
         except (testcloud.exceptions.TestcloudInstanceError,
                 libvirt.libvirtError) as error:

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -314,10 +314,14 @@ class Common(object):
                 return None if join else (None, None)
 
         # Create the process
-        process = subprocess.Popen(
-            command, cwd=cwd, shell=shell, env=environment,
-            stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT if join else subprocess.PIPE)
+        try:
+            process = subprocess.Popen(
+                command, cwd=cwd, shell=shell, env=environment,
+                stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT if join else subprocess.PIPE)
+        except FileNotFoundError as error:
+            raise RunError(
+                f"File '{error.filename}' not found.", command, 127)
         if join:
             descriptors = [process.stdout.fileno()]
         else:
@@ -430,6 +434,7 @@ class Common(object):
                 command, cwd, shell, env, log, join, interactive, timeout)
         except RunError as error:
             self.debug(error.message, level=3)
+            message += f" Reason: {error.message}"
             raise RunError(
                 message, error.command, error.returncode,
                 error.stdout, error.stderr)


### PR DESCRIPTION
This improves various things related to plugins:
 - Handling of FileNotFoundError (thrown e.g. when podman was not installed as in #822 )
 - Fixed catching of libvirt error ( #812 )
 - Added hints for unsupported report methods similarly to provision
 - Save guest details even on exception (e.g. KeyboardInterrupt)

Resolves: #812 
Resolves: #822
Resolves: #700 