### PR TITLE
Require correct testcloud version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
 extras_require = {
     'docs': ['sphinx', 'sphinx_rtd_theme', 'mock'],
     'tests': ['pytest', 'python-coveralls', 'mock', 'requre', 'pre-commit'],
-    'provision': ['testcloud>=0.5.0'],
+    'provision': ['testcloud>=0.6.1'],
     'convert': ['nitrate', 'markdown'],
     'report-html': ['jinja2'],
     'report-junit': ['junit_xml'],

--- a/tmt.spec
+++ b/tmt.spec
@@ -74,7 +74,7 @@ Dependencies required to run tests in a container environment.
 Summary: Virtual machine provisioner for the Test Management Tool
 Obsoletes: tmt-testcloud < 0.17
 Requires: tmt == %{version}-%{release}
-Requires: python%{python3_pkgversion}-testcloud >= 0.6.0
+Requires: python%{python3_pkgversion}-testcloud >= 0.6.1
 Requires: ansible openssh-clients
 
 %description provision-virtual


### PR DESCRIPTION
https://github.com/psss/tmt/pull/827 only changed it inside specfile but not in setup.py which is useful for running the latest tmt version.