### PR TITLE
Add timestamp to the tmt log file

### DIFF
--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2,6 +2,7 @@
 """ Test Metadata Utilities """
 
 import contextlib
+import datetime
 import fcntl
 import io
 import os
@@ -235,7 +236,8 @@ class Common(object):
             self.parent._log(message)
         else:
             with open(os.path.join(self.workdir, LOG_FILENAME), 'a') as log:
-                log.write(remove_color(message) + '\n')
+                log.write(datetime.datetime.utcnow().strftime('%H:%M:%S') + ' '
+                          + remove_color(message) + '\n')
 
     def print(self, key, value=None, color=None, shift=0, err=False):
         """ Print a message regardless the quiet mode """


### PR DESCRIPTION
Should resolve #821.

Log looks like this now:

```
...
/plans/features/basic
summary: Basic command line features
12:38:21 info
12:38:21     environment: {}
12:38:21     context: {}
12:38:21 wake
12:38:21     discover
12:38:21         Read file '/var/tmp/tmt/run-016/plans/features/basic/discover/step.yaml'.
12:38:21         Step data not found.
12:38:21         Read file '/var/tmp/tmt/run-016/plans/features/basic/discover/tests.yaml'.
12:38:21         Discovered tests not found.
12:38:21         Using the 'DiscoverFmf' plugin for the 'fmf' method.
12:38:21         status: todo
12:38:21         Write file '/var/tmp/tmt/run-016/plans/features/basic/discover/step.yaml'.
12:38:21         Write file '/var/tmp/tmt/run-016/plans/features/basic/discover/tests.yaml'.
...
```
So there is a timestamp on every line, is that correct?
Should I add timestamp, so it's visible in terminal after command is executed (not only in log file)? 