### PR TITLE
Add basic pci/net heuristics when libguestfs python is missing

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -450,6 +450,22 @@ class GuestTestcloud(tmt.Guest):
             connection='qemu:///session')
         self.verbose('name', self.instance_name, 'green')
 
+        # Decide which networking setup to use
+        # Autodetect works with libguestfs python bindings
+        # We fall back to basic heuristics based on file name
+        # without that installed (eg. from pypi).
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1075594
+        try:
+            import guestfs
+        except ImportError:
+            match_legacy = re.match(
+                r'(.*)rhel-(.*)-7.(.*).qcow2',
+                self.image_url.lower())
+            if match_legacy:
+                self.instance.pci_net = "e1000"
+            else:
+                self.instance.pci_net = "virtio-net-pci"
+
         # Prepare ssh key
         self.prepare_ssh_key()
 

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -424,6 +424,7 @@ class GuestTestcloud(tmt.Guest):
         # mapping value and try to guess the URL
         if not re.match(r'^(?:https?|file)://.*', self.image_url):
             self.image_url = self._guess_image_url(self.image_url)
+            self.debug(f"Guessed image url: '{self.image_url}'", level=3)
 
         # Initialize and prepare testcloud image
         self.image = testcloud.image.Image(self.image_url)
@@ -458,9 +459,8 @@ class GuestTestcloud(tmt.Guest):
         try:
             import guestfs
         except ImportError:
-            match_legacy = re.match(
-                r'(.*)rhel-(.*)-7.(.*).qcow2',
-                self.image_url.lower())
+            match_legacy = re.search(
+                r'(rhel|centos).*-7', self.image_url.lower())
             if match_legacy:
                 self.instance.pci_net = "e1000"
             else:


### PR DESCRIPTION
RHEL 7 needs e1000 pci net adapter
RHEL 9 needs virtio-net-pci

Fedoras from at least 28 work with the newer virtio-net-pci. Testcloud attempts proper detection, but that depends on libguestfs python bindings which aren't on pypi ( https://bugzilla.redhat.com/show_bug.cgi?id=1075594 ). This adds a basic heuristics based on image name.