### PR TITLE
Testcloud: Use cache='unsafe' for a nice IO boost

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -87,7 +87,7 @@ DOMAIN_TEMPLATE = """<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/d
   <devices>
     <emulator>{{ emulator_path }}</emulator>
     <disk type='file' device='disk'>
-      <driver name='qemu' type='qcow2'/>
+      <driver name='qemu' type='qcow2' cache='unsafe'/>
       <source file="{{ disk }}"/>
       <target dev='vda' bus='virtio'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>


### PR DESCRIPTION
This goes well in conjunction with testcloud-0.6.1 which enabled also lazy_refcounts . 

I believe unsafe cache doesn't have any cons for tmt use-case, it will cause problems with guests if the host gets down, which doesn't seem like an issue.

(This PR doesn't require new testcloud)