### PR TITLE
Restart sshd on EL 8 to workaround delays after boot up

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -60,6 +60,9 @@ runcmd:
   - [sh, -c, 'if systemctl status systemd-networkd |
   grep -q "enabled;\\svendor\\spreset:\\senabled"; then
   systemctl restart systemd-networkd; fi']
+  # CentOS and RHEL 8 keeps waiting before restarting sshd causing delays
+  - [sh, -c, 'if cat /etc/os-release |
+  grep -q platform:el8; then systemctl restart sshd; fi']
 """
 
 # Libvirt domain XML template related variables


### PR DESCRIPTION
Without this, CentOS / RHEL 8 Guests wait for almost up to a minute before restarting sshd after cloud-init configuration and tmt becomes able to connect to it.

This fix makes sure EL 8 behaves like any other distributions, saving up to a minute of wait before proceeding.