### PR TITLE
Deprecation timing, mention vagrant box support

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -23,7 +23,7 @@ class Execute(tmt.steps.Step):
 
     Note that the old execution methods 'shell.tmt', 'beakerlib.tmt',
     'shell.detach' and 'beakerlib.detach' have been deprecated and the
-    backward-compatible support for them will be dropped in March 2021.
+    backward-compatible support for them will be dropped in tmt-2.0.
 
     Use the new L1 metadata attribute 'framework' instead to specify
     which test framework should be used for execution. This allows to
@@ -83,7 +83,7 @@ class Execute(tmt.steps.Step):
         framework = matched.group(1)
         self.warn(f"Set 'framework: {framework}' in test metadata (L1).")
         self._framework = framework
-        self.warn("Support for old methods will be dropped in March 2021.")
+        self.warn("Support for old methods will be dropped in tmt-2.0.")
 
     def wake(self):
         """ Wake up the step (process workdir and command line) """

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -157,6 +157,9 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
     Use the full path for images stored on local disk, for example:
 
         /var/tmp/images/Fedora-Cloud-Base-31-1.9.x86_64.qcow2
+
+    In addition to the qcow2 format, vagrant boxes can be used as well,
+    testcloud will take care of unpacking the image for you.
     """
 
     # Guest instance


### PR DESCRIPTION
Update warning about the old execution methods deprecation.
Document that vagrant boxes are supported by testcloud as well.