### PR TITLE
Do not expand the process environment variables

### DIFF
--- a/tests/discover/parametrize.sh
+++ b/tests/discover/parametrize.sh
@@ -23,17 +23,12 @@ rlJournalStart
         rlAssertGrep 'url: https://github.com/psss/fmf' 'output'
     rlPhaseEnd
 
-    rlPhaseStartTest 'From existing environment'
-        rlRun "REPO=tmt tmt run -r $plan $steps | tee output"
-        rlAssertGrep 'url: https://github.com/psss/tmt' 'output'
-        # Precedence of existing environment over environment attribute
+    rlPhaseStartTest 'Process environment should be ignored'
         rlRun "REPO=fmf tmt run -r $plan_env $steps | tee output"
-        rlAssertGrep 'url: https://github.com/psss/fmf' 'output'
-        # Precedence of existing environment over option
-        rlRun "REPO=fmf tmt run -r -e REPO=tmt $plan_env $steps | tee output"
-        rlAssertGrep 'url: https://github.com/psss/fmf' 'output'
-        rlRun "REPO=fmf tmt run -r -e REPO=tmt $plan $steps | tee output"
-        rlAssertGrep 'url: https://github.com/psss/fmf' 'output'
+        rlAssertGrep 'url: https://github.com/psss/tmt' 'output'
+        # No substitution should happen
+        rlRun "REPO=tmt tmt run -r $plan $steps | tee output" 2
+        rlAssertGrep 'url: https://github.com/psss/${REPO}' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'Undefined variable'

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -477,7 +477,9 @@ class Plan(Core):
         self._environment = dict([
             (key, str(value)) for key, value
             in node.get('environment', dict()).items()])
-        self._expand_node_vars(node)
+        # Expand all environment variables in the node
+        with tmt.utils.modify_environ(self.environment):
+            self._expand_node_data(node.data)
         super().__init__(node, parent=run)
 
         # Initialize test steps
@@ -519,15 +521,6 @@ class Plan(Core):
             for i in range(len(data)):
                 data[i] = self._expand_node_data(data[i])
         return data
-
-    def _expand_node_vars(self, node):
-        """ Expand environment variables in a node """
-        with tmt.utils.modify_environ():
-            # Give precedence to present env variables over plan environment
-            for key, value in self.environment.items():
-                if key not in os.environ:
-                    os.environ[key] = value
-            self._expand_node_data(node.data)
 
     @property
     def environment(self):

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -751,9 +751,10 @@ def environment_to_dict(variables):
 
 
 @contextlib.contextmanager
-def modify_environ(**new_elements):
+def modify_environ(new_elements):
     """ A context manager for os.environ that restores the initial state """
     environ_backup = os.environ.copy()
+    os.environ.clear()
     os.environ.update(new_elements)
     try:
         yield


### PR DESCRIPTION
Expanding variables from the tmt process could reveal sensitive
information such as user tokens. Let's substitute only explicitly
provided variables in the plan and the `--environment` option.