### PR TITLE
Produce better errors for unsupported plugins

### DIFF
--- a/tmt/options.py
+++ b/tmt/options.py
@@ -91,8 +91,9 @@ def create_method_class(methods):
         def _check_method(self, context, args):
             """ Manually parse the --how option """
             how = None
+            subcommands = (
+                tmt.steps.STEPS + tmt.steps.ACTIONS + ['tests', 'plans'])
 
-            upcoming_value = False
             for index in range(len(args)):
                 # Handle '--how method' or '-h method'
                 if args[index] in ['--how', '-h']:
@@ -109,22 +110,9 @@ def create_method_class(methods):
                 elif args[index].startswith('-h'):
                     how = re.sub('^-h ?', '', args[index])
                     break
-                # Do not check how of other methods if chaining is used
-                # (e.g. tmt run discover provision -h local)
-                elif not upcoming_value and args[index] in tmt.steps.STEPS:
+                # Stop search at the first argument looking like a subcommand
+                elif args[index] in subcommands:
                     break
-                else:
-                    # Check if the current argument expects a value
-                    for opt in self.params:
-                        if not isinstance(opt, click.Option):
-                            continue
-                        expects_value = not opt.count and not opt.is_flag
-                        if args[index] in opt.opts and expects_value:
-                            upcoming_value = True
-                            break
-                    else:
-                        # Value received, reset
-                        upcoming_value = False
 
             # Find method with the first matching prefix
             if how is not None:
@@ -137,7 +125,7 @@ def create_method_class(methods):
                 # Use run for logging, steps may not be initialized yet
                 show_step_method_hints(context.obj.run, self.name, how)
                 raise tmt.utils.SpecificationError(
-                    f"Unsupported {self.name} method '{how}'")
+                    f"Unsupported {self.name} method '{how}'.")
 
         def parse_args(self, context, args):
             self._check_method(context, args)

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -8,6 +8,7 @@ import click
 from click import echo
 
 import tmt.utils
+from tmt.options import show_step_method_hints
 from tmt.utils import GeneralError
 
 STEPS = ['discover', 'provision', 'prepare', 'execute', 'report', 'finish']
@@ -312,38 +313,7 @@ class Plugin(tmt.utils.Common, metaclass=PluginIndex):
                     f"for the '{data['how']}' method.", level=2)
                 return method.class_(step, data)
 
-        # Give some hints when provision plugins are not installed
-        if step.name == 'provision':
-            if data['how'] == 'virtual':
-                step.info(
-                    'hint', "Install 'tmt-provision-virtual' "
-                    "to run tests in a virtual machine.", color='blue')
-            if data['how'] == 'container':
-                step.info(
-                    'hint', "Install 'tmt-provision-container' "
-                    "to run tests in a container.", color='blue')
-            step.info(
-                'hint', "Use the 'local' method to execute tests "
-                "directly on your localhost.", color='blue')
-            step.info(
-                'hint', "See 'tmt run provision --help' for all "
-                "available provision options.", color='blue')
-        elif step.name == 'report':
-            if data['how'] == 'html':
-                step.info(
-                    'hint', "Install 'tmt-report-html' to format results "
-                    "as a html report.", color='blue')
-            if data['how'] == 'junit':
-                step.info(
-                    'hint', "Install 'tmt-report-junit' to write results "
-                    "in JUnit format.", color='blue')
-            step.info(
-                'hint', "Use the 'display' method to show test results "
-                "on the terminal.", color='blue')
-            step.info(
-                'hint', "See 'tmt run report --help' for all "
-                "available report options.", color='blue')
-
+        show_step_method_hints(step, step.name, data['how'])
         # Report invalid method
         raise tmt.utils.SpecificationError(
             f"Unsupported {step.name} method '{data['how']}' "

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -11,7 +11,9 @@ import tmt.utils
 from tmt.options import show_step_method_hints
 from tmt.utils import GeneralError
 
+# Supported steps and actions
 STEPS = ['discover', 'provision', 'prepare', 'execute', 'report', 'finish']
+ACTIONS = ['login', 'reboot']
 
 # Step phase order
 PHASE_START = 10


### PR DESCRIPTION
Previously, if an unsupported plugin was used on the command line along
with its options (e.g. tmt run provision -h virtual -i image), the
plugin option would be assigned by click to provision instead resulting
in a confusing message (Unknown option for provision). This was an issue
with provision and report since they have installable plugins.

Give installation hints also when the step method is passed through CLI,
not just through L2 metadata.

A few examples that I experimented with (using a virtualenv + removing `testcloud.py`):
```
$ cat plan.fmf
summary: Basic smoke test
execute:
    script: tmt --help

$ tmt run
/var/tmp/tmt/run-020

/plan
    hint: Install 'tmt-provision-virtual' to run tests in a virtual machine.
    hint: Use the 'local' method to execute tests directly on your localhost.
    hint: See 'tmt run provision --help' for all available provision options.
Unsupported provision method 'virtual' in the '/plan' plan.

$ tmt run provision -h virtual
hint: Install 'tmt-provision-virtual' to run tests in a virtual machine.
hint: Use the 'local' method to execute tests directly on your localhost.
hint: See 'tmt run provision --help' for all available provision options.
Unsupported provision method 'virtual'

$ tmt run provision -h virtual -i test
hint: Install 'tmt-provision-virtual' to run tests in a virtual machine.
hint: Use the 'local' method to execute tests directly on your localhost.
hint: See 'tmt run provision --help' for all available provision options.
Unsupported provision method 'virtual'
```

The indentation is different since the logging objects are different but I think it looks good this way.

Not really sure if and how I can write a test for this that would work both in CI and locally.

Resolves: https://github.com/psss/tmt/issues/811