### PR TITLE
Require essential packages for tmt testing

### DIFF
--- a/tests/core/adjust/main.fmf
+++ b/tests/core/adjust/main.fmf
@@ -1,3 +1,4 @@
 summary: Verify test/plan adjustments based on context
 description:
     Perform a basic check using 'tmt test/plan show'.
+require+: [tmt-provision-container]

--- a/tests/discover/libraries/main.fmf
+++ b/tests/discover/libraries/main.fmf
@@ -9,6 +9,9 @@ tier: 3
 duration: 15m
 tag-: [virtual, container]
 enabled: False
+require+:
+  - tmt-provision-container
+  - tmt-provision-virtual
 
 adjust:
     enabled: True

--- a/tests/execute/main.fmf
+++ b/tests/execute/main.fmf
@@ -1,0 +1,1 @@
+require+: [tmt-provision-container]

--- a/tests/libraries/local/main.fmf
+++ b/tests/libraries/local/main.fmf
@@ -4,5 +4,5 @@ description:
     works as expected. Fetches the example library from upstream,
     modifies it a bit, references it from a test and verifies the
     changed functionality by running the test in a container.
-require: git
+require+: [tmt-provision-container]
 tier: 3

--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -3,3 +3,4 @@ framework: beakerlib
 contact: Petr Šplíchal <psplicha@redhat.com>
 tier: 2
 tag: [container, virtual]
+require: [tmt]

--- a/tests/prepare/main.fmf
+++ b/tests/prepare/main.fmf
@@ -1,3 +1,4 @@
 tier: 3
 duration: 15m
 tag-: [container]
+require+: [tmt-provision-container]

--- a/tests/provision/main.fmf
+++ b/tests/provision/main.fmf
@@ -1,0 +1,1 @@
+require+: [tmt-provision-container]

--- a/tests/run/worktree/main.fmf
+++ b/tests/run/worktree/main.fmf
@@ -5,6 +5,7 @@ description:
     experience. By default tested in a `container, for pull
     requests also against `local` and during `full` testing using
     `virtual` as well.
+require+: [tmt-provision-container]
 
 environment:
     METHODS: 'container'

--- a/tests/test/import/main.fmf
+++ b/tests/test/import/main.fmf
@@ -1,1 +1,2 @@
 summary: Verify test import and metadata deduplication
+require+: [tmt-test-convert]


### PR DESCRIPTION
As for now tests would fail unless tmt packages were installed on
the guest manually or explicitly in the prepare step.