### PR TITLE
Add the multihost testing specification

### DIFF
--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -108,6 +108,16 @@ description: |
       - implemented-by: /tmt/steps/execute/detach.py
       - verified-by: /tests/execute/framework
 
+/multi-host:
+    summary: Execute on a given multi-host role
+    description: |
+        Execute test on a given multi-host role specified by ``on``
+        option. By default execution is done on all roles.
+    example: |
+        execute:
+            how: tmt
+            on: server
+
 /script:
     summary: Execute shell scripts
     story: As a user I want to easily run shell script as a test.
@@ -161,7 +171,7 @@ description: |
                     - echo foo > /var/www/html/index.html
                     - curl http://localhost/ | grep foo
 
-    /multi:
+    /multi-line:
         summary: Multi-line shell script
         title: Multi-line script
         description:

--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -108,14 +108,31 @@ description: |
       - implemented-by: /tmt/steps/execute/detach.py
       - verified-by: /tests/execute/framework
 
-/multi-host:
-    summary: Execute on a given multi-host role
+/on:
+    summary: Execute tests on selected guests
     description: |
-        Execute test on a given multi-host role specified by ``on``
-        option. By default execution is done on all roles.
+        In the :ref:`/spec/plans/provision/multihost` scenarios it
+        is often necessary to execute test code on selected guests
+        only or execute different test code on individual guests.
+        The ``on`` key allows to select guests where the tests
+        should be executed by providing their ``name`` or the
+        ``role`` they play in the scenario. Use a list to specify
+        multiple names or roles. By default, when the ``on`` key
+        is not defined, tests are executed on all provisioned
+        guests.
     example: |
+        # Execute discovered tests on the client
         execute:
-            how: tmt
+          - how: tmt
+            on: client
+
+        # Run different script for each role
+        execute:
+          - name: run-the-client-code
+            script: client.py
+            on: client
+          - name: run-the-server-code
+            script: server.py
             on: server
 
 /script:
@@ -171,7 +188,7 @@ description: |
                     - echo foo > /var/www/html/index.html
                     - curl http://localhost/ | grep foo
 
-    /multi-line:
+    /multi:
         summary: Multi-line shell script
         title: Multi-line script
         description:

--- a/spec/plans/prepare.fmf
+++ b/spec/plans/prepare.fmf
@@ -19,6 +19,9 @@ description: |
     individual tests order ``70`` is used, for recommended
     packages it is ``75``.
 
+    Use the ``on`` attribute to specify on what role the
+    preparation should happen in multi-host scenario.
+
 example: |
     # Install fresh packages from a custom copr repository
     prepare:
@@ -34,6 +37,12 @@ example: |
       - name: service
         how: shell
         script: systemctl start httpd
+
+    # Stop auditd service on a server
+    prepare:
+      - how: shell
+        on: server
+        script: service auditd stop
 
 /shell:
     summary:
@@ -113,3 +122,13 @@ example: |
     link:
       - implemented-by: /tmt/steps/provision
       - verified-by: /tests/prepare/install
+
+/multi-host:
+    summary: Prepare a given multi-host role
+    description: |
+        Perform preparation on a given multi-host role specified by
+        ``on`` option. By default preparation is done on all roles.
+    example: |
+        execute:
+            how: tmt
+            on: server

--- a/spec/plans/prepare.fmf
+++ b/spec/plans/prepare.fmf
@@ -19,9 +19,6 @@ description: |
     individual tests order ``70`` is used, for recommended
     packages it is ``75``.
 
-    Use the ``on`` attribute to specify on what role the
-    preparation should happen in multi-host scenario.
-
 example: |
     # Install fresh packages from a custom copr repository
     prepare:
@@ -37,12 +34,6 @@ example: |
       - name: service
         how: shell
         script: systemctl start httpd
-
-    # Stop auditd service on a server
-    prepare:
-      - how: shell
-        on: server
-        script: service auditd stop
 
 /shell:
     summary:
@@ -123,12 +114,26 @@ example: |
       - implemented-by: /tmt/steps/provision
       - verified-by: /tests/prepare/install
 
-/multi-host:
-    summary: Prepare a given multi-host role
+/on:
+    summary: Apply preparation on selected guests
     description: |
-        Perform preparation on a given multi-host role specified by
-        ``on`` option. By default preparation is done on all roles.
+        In the :ref:`/spec/plans/provision/multihost` scenarios it
+        is often necessary to perform different preparation tasks on
+        individual guests. The ``on`` key allows to select guests
+        where the preparation should be applied by providing their
+        ``name`` or the ``role`` they play in the scenario. Use a
+        list to specify multiple names or roles. By default, when
+        the ``on`` key is not defined, preparation is done on all
+        provisioned guests.
     example: |
-        execute:
-            how: tmt
+        # Start Apache on the server
+        prepare:
+          - how: shell
+            script: systemctl start httpd
             on: server
+
+        # Apply common setup on the primary server and all replicas
+        prepare:
+          - how: ansible
+            playbook: common.yaml
+            on: [primary, replica]

--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -5,8 +5,9 @@ description: |
     should be provisioned. Provides a generic and an extensible
     way to write down essential hardware requirements. For example
     one consistent way how to specify "at least 2 GB of RAM" for
-    all supported provisioners. Might fail if it cannot provision
-    according to the constraints.
+    all supported provisioners. Supports not only single-host use
+    case but also multi-host environments. Might fail if it cannot
+    provision according to the constraints.
 
 example: |
     provision:
@@ -203,3 +204,22 @@ example: |
                     model: 67
               - cpu:
                     model: 69
+
+/multi-host:
+    summary: Multi-host testing specification
+
+    description: |
+        As a part of the provision step it is possible to assign
+        a role using ``role`` parameter for multi-host testing.
+        A role can be arbitrary identifier, for example there can
+        be server and client roles for server-client multi-host
+        provisioning.
+
+    example: |
+        provision:
+            - name: server provisioning
+              how: local
+              role: server
+            - name: client provisioning
+              how: local
+              role: client

--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -5,9 +5,8 @@ description: |
     should be provisioned. Provides a generic and an extensible
     way to write down essential hardware requirements. For example
     one consistent way how to specify "at least 2 GB of RAM" for
-    all supported provisioners. Supports not only single-host use
-    case but also multi-host environments. Might fail if it cannot
-    provision according to the constraints.
+    all supported provisioners. Might fail if it cannot provision
+    according to the constraints.
 
 example: |
     provision:
@@ -205,21 +204,44 @@ example: |
               - cpu:
                     model: 69
 
-/multi-host:
-    summary: Multi-host testing specification
+/multihost:
+    summary: Multihost testing specification
 
     description: |
-        As a part of the provision step it is possible to assign
-        a role using ``role`` parameter for multi-host testing.
-        A role can be arbitrary identifier, for example there can
-        be server and client roles for server-client multi-host
-        provisioning.
+        As a part of the provision step it is possible to request
+        multiple guests to be provisioned for testing. Each guest
+        has to be assigned a unique ``name`` which is used to
+        identify it.
+
+        The optional parameter ``role`` can be used to mark
+        related guests so that common actions can be applied to
+        all such guests at once. An example role name can be
+        `client` or `server` but arbitrary identifier can be used.
+
+        Both `name` and `role` can be used together with the
+        ``on`` key to select guests on which the
+        :ref:`preparation</spec/plans/prepare/on>`
+        tasks should be applied or where the test
+        :ref:`execution</spec/plans/execute/on>` should
+        take place.
 
     example: |
+        # Request two guests
         provision:
-            - name: server provisioning
-              how: local
-              role: server
-            - name: client provisioning
-              how: local
-              role: client
+          - name: server
+            how: virtual
+          - name: client
+            how: virtual
+
+        # Assign role to guests
+        provision:
+          - name: main-server
+            role: primary
+          - name: backup-one
+            role: replica
+          - name: backup-two
+            role: replica
+          - name: tester-one
+            role: client
+          - name: tester-two
+            role: client


### PR DESCRIPTION
Previously, specifications for plans supported only single-host
testing scenario. This work adds support also for multi-host
testing. Namely, provision specification was extended in order
to express provisioning of multiple roles and both prepare and 
execute specifications were extended so that it can be 
(optionally) expressed on which multi-host role that step should
happen (by default on all).

Signed-off-by: Ondrej Moris <omoris@redhat.com>