### PR TITLE
Improve fetching remote environment files

### DIFF
--- a/tests/core/environment-file/data/main.fmf
+++ b/tests/core/environment-file/data/main.fmf
@@ -25,3 +25,10 @@
     /escape:
         environment-file:
           - ../../../../../../../../../../../../../../etc/secret
+    /fetch:
+        /good:
+            environment-file:
+            - https://raw.githubusercontent.com/psss/tmt/22a46a4a6760517e3eadbbff0c9bebdb95442760/tests/core/env/data/vars.yaml
+        /bad:
+            environment-file:
+            - https://invalid.host.name/vars.yaml

--- a/tests/core/environment-file/test.sh
+++ b/tests/core/environment-file/test.sh
@@ -7,7 +7,7 @@ rlJournalStart
         rlRun 'set -o pipefail'
     rlPhaseEnd
 
-    good="plan --name good"
+    good="plan --name /plan/good"
 
     rlPhaseStartTest "Check environment-file option reads properly"
         rlRun "tmt run -rvvvddd $good | tee output"
@@ -34,6 +34,17 @@ rlJournalStart
     rlPhaseStartTest "Escape from the tree"
         rlRun "tmt run -rvvvddd plan -n escape 2>&1 | tee output" 2
         rlAssertGrep "path '/etc/secret' is outside" 'output'
+    rlPhaseEnd
+
+    rlPhaseStartTest "Fetch a remote file"
+        # Good
+        rlRun "tmt plan show fetch/good | tee output"
+        rlAssertGrep "STR: O" 'output'
+        rlAssertGrep "INT: 0" 'output'
+        # Bad
+        rlRun "tmt plan show fetch/bad 2>&1 | tee output" 2
+        rlAssertGrep "Failed to fetch the environment file" 'output'
+        rlAssertGrep "Name or service not known" 'output'
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
Currently using a remote file to fetch environment variables would
only work if preceeded by a local file because `full_path` was not
initialized. Fix the bug and also improve error handling for urls.