### PR TITLE
Increase duration for tests using containers

### DIFF
--- a/tests/execute/metadata/main.fmf
+++ b/tests/execute/metadata/main.fmf
@@ -5,3 +5,4 @@ description:
     present and that custom metadata keys are included as well.
 tag-: [container]
 tier: 3
+duration: 15m

--- a/tests/libraries/local/main.fmf
+++ b/tests/libraries/local/main.fmf
@@ -6,3 +6,4 @@ description:
     changed functionality by running the test in a container.
 require+: [tmt-provision-container]
 tier: 3
+duration: 15m


### PR DESCRIPTION
Sometimes a network glitch causes these tests take a little bit
more than 5 minutes to complete (fetch image and dnf metadata).