### PR TITLE
Make run --force behave more expectably

### DIFF
--- a/tests/core/force/test.sh
+++ b/tests/core/force/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    rlPhaseStartTest "Force the whole run"
+    rlPhaseStartTest "Force the whole run - new workdir"
         # The first run, fresh, no results should be found
         rlRun "tmt run -ddvvi $run discover | tee output" 0 "First run (fresh)"
         rlAssertGrep "Run data not found." output
@@ -28,7 +28,7 @@ rlJournalStart
         rlAssertNotGrep "1 guest provisioned" output
 
         # Force, all steps should be executed again
-        rlRun "tmt run --force -ddvvi $run | tee output" 0 "Third run (force)"
+        rlRun "tmt run --scratch -ddvvi $run | tee output" 0 "Third run (force)"
         rlAssertGrep "Run data not found." output
         rlAssertGrep "Discovered tests not found." output
         rlAssertNotGrep "Discover.*already done" output
@@ -44,6 +44,23 @@ rlJournalStart
         rlAssertGrep "Provision.*already done" output
         rlAssertGrep "1 test selected" output
         rlAssertGrep "1 guest provisioned" output
+    rlPhaseEnd
+
+    rlPhaseStartTest "Force all steps"
+        # The first run, start from scratch, no results should be found
+        rlRun "tmt run --scratch -ddvvi $run | tee output" 0 "First run (fresh)"
+        rlAssertGrep "Discovered tests not found." output
+        rlAssertGrep "1 test selected" output
+
+        new_file="$run/tmpfile"
+        rlRun "touch $new_file" 0 "Create a file in the workdir"
+        rlAssertExists $new_file
+
+        # Second run, force all enabled steps
+        rlRun "tmt run --force -ddvvi $run | tee output" 0 "Second run (force)"
+        rlAssertGrep "Discovered tests not found." output
+        rlAssertGrep "1 test selected" output
+        rlAssertExists $new_file
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/execute/basic/test.sh
+++ b/tests/execute/basic/test.sh
@@ -22,7 +22,7 @@ rlJournalStart
 
     for verbosity in '' '-dv' '-ddvv' '-dddvvv'; do
         rlPhaseStartTest "Run $verbosity"
-            rlRun "tmt run $verbosity --force --id $run" 2 "Run all plans"
+            rlRun "tmt run $verbosity --scratch --id $run" 2 "Run all plans"
         rlPhaseEnd
     done
 

--- a/tests/provision/reboot/test.sh
+++ b/tests/provision/reboot/test.sh
@@ -28,7 +28,7 @@ rlJournalStart
 
     if [[ "$METHODS" =~ virtual ]]; then
         rlPhaseStartTest "Virtual"
-            rlRun "tmt run -fi $run provision -h virtual"
+            rlRun "tmt run --scratch -i $run provision -h virtual"
 
             rlRun -s "tmt run -l reboot"
             rlAssertGrep "Reboot finished" $rlRun_LOG

--- a/tests/steps/invalid/test.sh
+++ b/tests/steps/invalid/test.sh
@@ -9,9 +9,9 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "tmt run -fi $tmp 2>&1 | tee output" 2 "Expect the run to fail"
+        rlRun "tmt run --scratch -i $tmp 2>&1 | tee output" 2 "Expect the run to fail"
         rlAssertGrep "Unsupported provision method" "output"
-        rlRun "tmt run -fi $tmp discover 2>&1 | tee output" 0 \
+        rlRun "tmt run --scratch -i $tmp discover 2>&1 | tee output" 0 \
             "Invalid step not enabled, do not fail"
         rlAssertGrep "warn: Unsupported provision method" "output"
     rlPhaseEnd

--- a/tests/steps/select/test.sh
+++ b/tests/steps/select/test.sh
@@ -10,7 +10,7 @@ rlJournalStart
         rlRun "set -o pipefail"
     rlPhaseEnd
 
-    options='-fi $tmp'
+    options='--scratch -i $tmp'
     for selected_step in $steps; do
         rlPhaseStartTest "Select $selected_step"
             exitcode=0

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -207,6 +207,9 @@ def main(click_contex, root, context, **kwargs):
     '-r', '--rm', '--remove', 'remove', is_flag=True,
     help='Remove the workdir when test run is finished.')
 @click.option(
+    '--scratch', is_flag=True,
+    help='Remove the run workdir before executing to start from scratch.')
+@click.option(
     '--follow', is_flag=True,
     help='Output the logfile as it grows.')
 @click.option(

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -496,8 +496,8 @@ class Common(object):
             raise GeneralError(
                 f"Invalid workdir '{id_}', expected a string or None.")
 
-        # Cleanup possible old workdir if called with --force
-        if self.opt('force'):
+        # Cleanup possible old workdir if called with --scratch
+        if self.opt('scratch'):
             self._workdir_cleanup(workdir)
 
         # Create the workdir


### PR DESCRIPTION
Previously, tmt run -f behaved differently from the other common flags
(such as verbose). Not only was it inehrited into children (steps), but
it also removed the run workdir which could lead to surprising the user
if they only wanted to rerun the selected steps, without having to
specify -f to all of them manually.

Make --force behaviour more in line with the other flags and add a new
option --scratch that follows the behaviour of former --force (remove
the whole workdir).

Resolves: https://github.com/psss/tmt/issues/286