### PR TITLE
Use current git remote for url in fmf-id

### DIFF
--- a/tests/test/identifier/test.sh
+++ b/tests/test/identifier/test.sh
@@ -13,9 +13,6 @@ rlJournalStart
         for test in $(tmt tests ls); do
             rlAssertGrep "$test" $output
         done
-        remote=$(git status -sb | head -n 1 | grep -oP '(?<=\...).*?(?=/)')
-        url=$(git ls-remote --get-url $remote | grep -oP  '(?<=\:).*')
-        rlAssertGrep "$url" "$output"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/test/identifier/test.sh
+++ b/tests/test/identifier/test.sh
@@ -13,6 +13,9 @@ rlJournalStart
         for test in $(tmt tests ls); do
             rlAssertGrep "$test" $output
         done
+        remote=$(git status -sb | head -n 1 | grep -oP '(?<=\...).*?(?=/)')
+        url=$(git ls-remote --get-url $remote | grep -oP  '(?<=\:).*')
+        rlAssertGrep "$url" "$output"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -144,9 +144,15 @@ class Core(tmt.utils.Common):
 
         fmf_id = {'name': self.name}
 
-        # Prepare url (for now handle just the most common schemas)
-        origin = run('git config --get remote.origin.url')
-        fmf_id['url'] = tmt.utils.public_git_url(origin)
+        # Prepare url
+        branch = run(
+            'git rev-parse --abbrev-ref --symbolic-full-name @{u}')
+        try:
+            remote_name = branch[:branch.index('/')]
+        except ValueError:
+            remote_name = 'origin'
+        remote = run('git config --get remote.{}.url'.format(remote_name))
+        fmf_id['url'] = tmt.utils.public_git_url(remote)
 
         # Get the ref (skip for master as it is the default)
         ref = run('git rev-parse --abbrev-ref HEAD')

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -139,19 +139,21 @@ class Core(tmt.utils.Common):
 
         def run(command):
             """ Run command, return output """
-            result = subprocess.run(command.split(), stdout=subprocess.PIPE)
+            result = subprocess.run(
+                command.split(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL)
             return result.stdout.strip().decode("utf-8")
 
         fmf_id = {'name': self.name}
 
-        # Prepare url
-        branch = run(
-            'git rev-parse --abbrev-ref --symbolic-full-name @{u}')
+        # Prepare url (for now handle just the most common schemas)
+        branch = run("git rev-parse --abbrev-ref --symbolic-full-name @{u}")
         try:
             remote_name = branch[:branch.index('/')]
         except ValueError:
             remote_name = 'origin'
-        remote = run('git config --get remote.{}.url'.format(remote_name))
+        remote = run(f"git config --get remote.{remote_name}.url")
         fmf_id['url'] = tmt.utils.public_git_url(remote)
 
         # Get the ref (skip for master as it is the default)


### PR DESCRIPTION
#806

Previously fmf-id always used git remote origin regardless the real remote of the current branch. The updated version will use current remote.
I have created a test for the patch that will use another way to find current remote. If the test looks too weird maybe it makes sense to remove the test.