### PR TITLE
Simplify plugin keys handling in wake() and show()

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -250,6 +250,12 @@ class Plugin(tmt.utils.Common, metaclass=PluginIndex):
     # except for provision (virtual) and report (display)
     how = 'shell'
 
+    # Common keys for all plugins of given step
+    _common_keys = []
+
+    # Keys specific for given plugin
+    _keys = []
+
     def __init__(self, step, data):
         """ Store plugin name, data and parent step """
 
@@ -357,7 +363,7 @@ class Plugin(tmt.utils.Common, metaclass=PluginIndex):
         # Show all or requested step attributes
         base_keys = ['name', 'how']
         if keys is None:
-            keys = [key for key in self.data.keys() if key not in base_keys]
+            keys = self._common_keys + self._keys
         for key in base_keys + keys:
             # Skip showing the default name
             if key == 'name' and self.name == tmt.utils.DEFAULT_NAME:
@@ -369,19 +375,25 @@ class Plugin(tmt.utils.Common, metaclass=PluginIndex):
             if value is not None:
                 echo(tmt.utils.format(key, value))
 
-    def wake(self, options=None):
+    def wake(self, keys=None):
         """
-        Wake up the plugin (override data with command line)
+        Wake up the plugin, process data, apply options
 
-        If a list of option names is provided, their value will be
-        checked and stored in self.data unless empty or undefined.
+        Check command line options corresponding to plugin keys
+        and store their value into the 'self.data' dictionary if
+        their value is True or non-empty.
+
+        By default, all supported options corresponding to common
+        and plugin-specific keys are processed. List of key names
+        in the 'keys' parameter can be used to override only
+        selected ones.
         """
-        if options is None:
-            return
-        for option in options:
-            value = self.opt(option)
+        if keys is None:
+            keys = self._common_keys + self._keys
+        for key in keys:
+            value = self.opt(key)
             if value:
-                self.data[option] = value
+                self.data[key] = value
 
     def go(self):
         """ Go and perform the plugin task """

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -198,11 +198,6 @@ class DiscoverPlugin(tmt.steps.Plugin):
 
         return discover
 
-    @classmethod
-    def options(cls, how=None):
-        """ Prepare command line options for given method """
-        return super().options(how)
-
     def tests(self):
         """
         Return discovered tests

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -65,6 +65,12 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
     # Supported methods
     _methods = [tmt.steps.Method(name='fmf', doc=__doc__, order=50)]
 
+    # Supported keys
+    _keys = [
+        "url", "ref", "path", "test", "filter",
+        "modified-only", "modified-url", "modified-ref",
+        "dist-git-source", "dist-git-type"]
+
     @classmethod
     def options(cls, how=None):
         """ Prepare command line options for given method """
@@ -104,14 +110,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 help='Use the provided DistGit handler instead of detection.'),
             ] + super().options(how)
 
-    def show(self):
-        """ Show discover details """
-        super().show(['url', 'ref', 'path', 'test',
-                      'filter', 'dist-git-source', 'dist-git-type'])
-
-    def wake(self):
-        """ Wake up the plugin (override data with command line) """
-
+    def wake(self, keys=None):
+        """ Wake up the plugin, process data, apply options """
         # Handle backward-compatible stuff
         if 'repository' in self.data:
             self.data['url'] = self.data.pop('repository')
@@ -119,25 +119,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             self.data['ref'] = self.data.pop('revision')
 
         # Make sure that 'filter' and 'test' keys are lists
-        for key in ['filter', 'test']:
-            if key in self.data and not isinstance(self.data[key], list):
-                self.data[key] = [self.data[key]]
+        tmt.utils.listify(self.data, keys=["filter", "test"])
 
         # Process command line options, apply defaults
-        for option in [
-                'url',
-                'ref',
-                'path',
-                'test',
-                'filter',
-                'modified-only',
-                'modified-url',
-                'modified-ref',
-                'dist-git-source',
-                'dist-git-type']:
-            value = self.opt(option)
-            if value:
-                self.data[option] = value
+        super().wake(keys=keys)
 
     def go(self):
         """ Discover available tests """

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -32,7 +32,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
     # Supported methods
     _methods = [tmt.steps.Method(name='shell', doc=__doc__, order=50)]
 
-    def show(self):
+    def show(self, keys=None):
         """ Show config details """
         super().show([])
         tests = self.get('tests')
@@ -40,7 +40,9 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
             test_names = [test['name'] for test in tests]
             click.echo(tmt.utils.format('tests', test_names))
 
-    def wake(self):
+    def wake(self, keys=None):
+        """ Wake up the plugin, process data, apply options """
+        super().wake(keys=keys)
         # Check provided tests, default to an empty list
         if 'tests' not in self.data:
             self.data['tests'] = []

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -188,11 +188,11 @@ class ExecutePlugin(tmt.steps.Plugin):
     # List of all supported methods aggregated from all plugins
     _supported_methods = []
 
+    # Common keys for all execute plugins
+    _common_keys = ["exit-first"]
+
     # Internal executor is the default implementation
     how = 'tmt'
-
-    # List of keys supported for all execute plugins
-    _keys = ['exit-first']
 
     @classmethod
     def base_command(cls, method_class=None, usage=None):
@@ -222,17 +222,11 @@ class ExecutePlugin(tmt.steps.Plugin):
             help='Stop execution after the first test failure.')]
         return options + super().options(how)
 
-    def show(self, keys=None):
-        keys = (keys or []) + self._keys
-        super().show(keys)
-
-    def wake(self, options=None):
-        options = (options or []) + self._keys
-        super().wake(options)
-
     def go(self):
         super().go()
-        self.info('exit-first', self.get('exit-first', default=False), 'green')
+        self.verbose(
+            'exit-first', self.get('exit-first', default=False),
+            'green', level=2)
 
     def data_path(self, test, filename=None, full=False, create=False):
         """

--- a/tmt/steps/execute/detach.py
+++ b/tmt/steps/execute/detach.py
@@ -29,6 +29,9 @@ class ExecuteDetach(tmt.steps.execute.ExecutePlugin):
         tmt.steps.Method(name='beakerlib.detach', doc=__doc__, order=90),
         ]
 
+    # Supported keys
+    _keys = ["script"]
+
     @classmethod
     def options(cls, how=None):
         """ Prepare command line options for given method """
@@ -38,13 +41,9 @@ class ExecuteDetach(tmt.steps.execute.ExecutePlugin):
             help='Shell script to be executed as a test.'))
         return options + super().options(how)
 
-    def show(self):
-        """ Show discover details """
-        super().show(['script'])
-
-    def wake(self):
-        """ Wake up the plugin (override data with command line) """
-        super().wake(options=['script'])
+    def wake(self, keys=None):
+        """ Wake up the plugin, process data, apply options """
+        super().wake(keys=keys)
         # Make sure that 'script' is a list
         tmt.utils.listify(self.data, keys=['script'])
 

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -60,6 +60,9 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
         tmt.steps.Method(name='beakerlib.tmt', doc=__doc__, order=80),
         ]
 
+    # Supported keys
+    _keys = ["script", "interactive"]
+
     @classmethod
     def options(cls, how=None):
         """ Prepare command line options for given method """
@@ -78,15 +81,9 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             help='Disable interactive progress bar showing the current test.'))
         return options + super().options(how)
 
-    def show(self, keys=None):
-        """ Show execute details """
-        keys = (keys or []) + ['script', 'interactive']
-        super().show(keys)
-
-    def wake(self, options=None):
-        """ Wake up the plugin (override data with command line) """
-        options = (options or []) + ['script', 'interactive']
-        super().wake(options=options)
+    def wake(self, keys=None):
+        """ Wake up the plugin, process data, apply options """
+        super().wake(keys=keys)
         # Make sure that script is a list
         tmt.utils.listify(self.data, keys=['script'])
 

--- a/tmt/steps/finish/ansible.py
+++ b/tmt/steps/finish/ansible.py
@@ -29,6 +29,6 @@ class FinishAnsible(tmt.steps.finish.FinishPlugin, PrepareAnsible):
     # Supported methods
     _methods = [tmt.steps.Method(name='ansible', doc=__doc__, order=50)]
 
-    # Explicitely use theses from FinishPlugin class
+    # Explicitly use these from FinishPlugin class
     _supported_methods = tmt.steps.finish.FinishPlugin._supported_methods
     base_command = tmt.steps.finish.FinishPlugin.base_command

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -23,6 +23,9 @@ class FinishShell(tmt.steps.finish.FinishPlugin):
     # Supported methods
     _methods = [tmt.steps.Method(name='shell', doc=__doc__, order=50)]
 
+    # Supported keys
+    _keys = ["script"]
+
     @classmethod
     def options(cls, how=None):
         """ Finish command line options """
@@ -38,13 +41,9 @@ class FinishShell(tmt.steps.finish.FinishPlugin):
             return []
         return default
 
-    def show(self):
-        """ Show provided scripts """
-        super().show(['script'])
-
-    def wake(self, data=None):
-        """ Override options and wake up the guest """
-        super().wake(['script'])
+    def wake(self, keys=None):
+        """ Wake up the plugin, process data, apply options """
+        super().wake(keys=keys)
 
         # Convert to list if single script provided
         tmt.utils.listify(self.data, keys=['script'])

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -31,6 +31,9 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
     # Supported methods
     _methods = [tmt.steps.Method(name='ansible', doc=__doc__, order=50)]
 
+    # Supported keys
+    _keys = ["playbook"]
+
     def __init__(self, step, data):
         """ Store plugin name, data and parent step """
         super().__init__(step, data)
@@ -53,13 +56,9 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
             return []
         return default
 
-    def show(self):
-        """ Show provided playbooks """
-        super().show(['playbook'])
-
-    def wake(self, data=None):
-        """ Override options and wake up the guest """
-        super().wake(['playbook'])
+    def wake(self, keys=None):
+        """ Wake up the plugin, process data, apply options """
+        super().wake(keys=keys)
 
         # Convert to list if necessary
         tmt.utils.listify(self.data, keys=['playbook'])

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -51,6 +51,9 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
     # Supported methods
     _methods = [tmt.steps.Method(name='install', doc=__doc__, order=50)]
 
+    # Supported keys
+    _keys = ["package", "directory", "copr", "exclude", "missing"]
+
     @classmethod
     def options(cls, how=None):
         """ Prepare command line options """
@@ -81,18 +84,14 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
             return []
         return default
 
-    def show(self):
-        """ Show provided scripts """
-        super().show(['package', 'directory', 'copr', 'exclude', 'missing'])
-
-    def wake(self, data=None):
-        """ Override options and wake up the guest """
-        super().wake(['package', 'directory', 'copr', 'exclude', 'missing'])
+    def wake(self, keys=None):
+        """ Wake up the plugin, process data, apply options """
+        super().wake(keys=keys)
 
         # Convert to list if necessary
         tmt.utils.listify(
-            self.data, split=True, keys=[
-                'package', 'directory', 'copr', 'exclude'])
+            self.data, split=True,
+            keys=['package', 'directory', 'copr', 'exclude'])
 
     def enable_copr_epel6(self, copr, guest):
         """ Manually enable copr repositories for epel6 """

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -26,6 +26,9 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin):
     # Supported methods
     _methods = [tmt.steps.Method(name='shell', doc=__doc__, order=50)]
 
+    # Supported keys
+    _keys = ["script"]
+
     @classmethod
     def options(cls, how=None):
         """ Prepare command line options """
@@ -41,13 +44,9 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin):
             return []
         return default
 
-    def show(self):
-        """ Show provided scripts """
-        super().show(['script'])
-
-    def wake(self, data=None):
-        """ Override options and wake up the guest """
-        super().wake(['script'])
+    def wake(self, keys=None):
+        """ Wake up the plugin, process data, apply options """
+        super().wake(keys=keys)
 
         # Convert to list if single script provided
         tmt.utils.listify(self.data, keys=['script'])

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -171,14 +171,14 @@ class ProvisionPlugin(tmt.steps.Plugin):
 
         return provision
 
-    def wake(self, options=None, data=None):
+    def wake(self, keys=None, data=None):
         """
         Wake up the plugin
 
         Override data with command line options.
         Wake up the guest based on provided guest data.
         """
-        super().wake(options)
+        super().wake(keys=keys)
 
     def guest(self):
         """

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -37,6 +37,9 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
     # Supported methods
     _methods = [tmt.steps.Method(name='connect', doc=__doc__, order=50)]
 
+    # Supported keys
+    _keys = ["guest", "key", "user", "password", "port"]
+
     @classmethod
     def options(cls, how=None):
         """ Prepare command line options for connect """
@@ -66,13 +69,9 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
         # No other defaults available
         return default
 
-    def show(self):
-        """ Show provision details """
-        super().show(['guest', 'key', 'user', 'password', 'port'])
-
-    def wake(self, data=None):
-        """ Override options and wake up the guest """
-        super().wake(['guest', 'key', 'user', 'password', 'port'])
+    def wake(self, keys=None, data=None):
+        """ Wake up the plugin, process data, apply options """
+        super().wake(keys=keys, data=data)
         if data:
             self._guest = tmt.Guest(data, name=self.name, parent=self.step)
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -25,8 +25,9 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
     # Supported methods
     _methods = [tmt.steps.Method(name='local', doc=__doc__, order=50)]
 
-    def wake(self, data=None):
-        """ Override options and wake up the guest """
+    def wake(self, keys=None, data=None):
+        """ Wake up the plugin, process data, apply options """
+        super().wake(keys=keys, data=data)
         if data:
             self._guest = GuestLocal(data, name=self.name, parent=self.step)
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -23,7 +23,7 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
     _guest = None
 
     # Supported keys
-    _keys = ['image', 'container', 'pull']
+    _keys = ["image", "container", "pull"]
 
     # Supported methods
     _methods = [tmt.steps.Method(name='container', doc=__doc__, order=50)]
@@ -51,13 +51,9 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
         # No other defaults available
         return default
 
-    def show(self):
-        """ Show provision details """
-        super().show(self._keys)
-
-    def wake(self, data=None):
-        """ Override options and wake up the guest """
-        super().wake(self._keys)
+    def wake(self, keys=None, data=None):
+        """ Wake up the plugin, process data, apply options """
+        super().wake(keys=keys, data=data)
         # Wake up podman instance
         if data:
             guest = GuestContainer(data, name=self.name, parent=self.step)

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -183,6 +183,9 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
         tmt.steps.Method(name='virtual.testcloud', doc=__doc__, order=50),
         ]
 
+    # Supported keys
+    _keys = ["image", "user", "memory", "disk", "connection"]
+
     @classmethod
     def options(cls, how=None):
         """ Prepare command line options for testcloud """
@@ -219,13 +222,9 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
             return defaults[option]
         return default
 
-    def show(self):
-        """ Show provision details """
-        super().show(['image', 'user', 'memory', 'disk', 'connection'])
-
-    def wake(self, data=None):
-        """ Override options and wake up the guest """
-        super().wake(['image', 'memory', 'disk', 'user', 'connection'])
+    def wake(self, keys=None, data=None):
+        """ Wake up the plugin, process data, apply options """
+        super().wake(keys=keys, data=data)
 
         # Convert memory and disk to integers
         for key in ['memory', 'disk']:

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -165,6 +165,9 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
     # Supported methods
     _methods = [tmt.steps.Method(name='html', doc=__doc__, order=50)]
 
+    # Supported keys
+    _keys = ["open"]
+
     @classmethod
     def options(cls, how=None):
         """ Prepare command line options for the html report """

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -44,7 +44,8 @@ class ReportJUnit(tmt.steps.report.ReportPlugin):
     # Supported methods
     _methods = [tmt.steps.Method(name='junit', doc=__doc__, order=50)]
 
-    _keys = ['file']
+    # Supported keys
+    _keys = ["file"]
 
     @classmethod
     def options(cls, how=None):


### PR DESCRIPTION
Simplify and unify plugin keys handling to prevent wake() and
show() code duplication in individual plugins. Plugin-specific
keys are stored in `_keys` and keys which are common for all
implementations of a step in `_common_keys`. Both wake() and
show() now default to process these two lists and use the `keys`
parameter to allow processing selected keys only.

This also fixes html plugin which was missing the `wake()` method
and thus the command line option `--open` had no effect.