### PR TITLE
Use the recommended format of the copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
 MIT License
 
-Copyright (c) 2019 Red Hat, Inc.
+Copyright Red Hat
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.rst
+++ b/README.rst
@@ -386,7 +386,7 @@ Kopkova.
 Copyright
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Copyright (c) 2019 Red Hat, Inc.
+Copyright Red Hat
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the MIT License.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ master_man = 'man.1'
 
 # General information about the project.
 project = u'tmt'
-copyright = u'2019, Red Hat'
+copyright = u'Red Hat'
 author = u'Petr Šplíchal'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
According to the latest recommendations the copyright line should
not contain year and the short "Red Hat" name should be used.