### PR TITLE
Package tmt.plugins to store arbitrary plugins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ __pkg__ = 'tmt'
 __pkgdir__ = {}
 __pkgs__ = [
     'tmt',
+    'tmt/plugins',
     'tmt/steps',
     'tmt/steps/discover',
     'tmt/steps/provision',

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-""" Handle Steps Plugins """
+""" Handle Plugins """
 
 import importlib
 import os
@@ -22,6 +22,9 @@ def explore():
     for step in tmt.steps.STEPS:
         for module in discover(os.path.join(root, 'steps', step)):
             import_(f'tmt.steps.{step}.{module}')
+    # Check for possible plugins in the 'plugins' directory
+    for module in discover(os.path.join(root, 'plugins')):
+        import_(f'tmt.plugins.{module}')
 
     # Check environment variable for user plugins
     try:


### PR DESCRIPTION
Plugins for steps are stored in their respective step directory.
Generic plugins (e.g. functionality shared between steps) can be stored
and explored from tmt.plugins now.

Especially handy for internal DistGit handling for from:sources