### PR TITLE
Use a fresh sphinx when building the readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,7 @@
+# Config for building https://tmt.readthedocs.io/
+version: 2
+python:
+    install:
+      - method: pip
+        path: .
+        extra_requirements: [docs]

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     'ruamel.yaml'
 ]
 extras_require = {
-    'docs': ['sphinx', 'sphinx_rtd_theme', 'mock'],
+    'docs': ['sphinx>=3', 'sphinx_rtd_theme', 'mock'],
     'tests': ['pytest', 'python-coveralls', 'mock', 'requre', 'pre-commit'],
     'provision': ['testcloud>=0.6.1'],
     'convert': ['nitrate', 'markdown', 'python-bugzilla'],


### PR DESCRIPTION
Add a readthedocs config to install a fresh version of the sphinx
package during docs building. This fixes recent docs build
failures caused by ancient sphinx.