### PR TITLE
Add verbose attribute to ansible plugin

### DIFF
--- a/spec/plans/prepare.fmf
+++ b/spec/plans/prepare.fmf
@@ -59,12 +59,17 @@ example: |
         ``playbook`` attribute.  Each of them will be applied
         using ``ansible-playbook`` in the given order. The path
         should be relative to the metadata tree root.
+
+        Use ``extra-args`` attribute to enable optional arguments for
+        ``ansible-playbook``.
+
     example: |
         prepare:
             how: ansible
             playbook:
                 - playbooks/common.yml
                 - playbooks/os/rhel7.yml
+            extra-args: '-vvv'
     link:
       - implemented-by: /tmt/steps/provision
 

--- a/tests/prepare/ansible/data/plan.fmf
+++ b/tests/prepare/ansible/data/plan.fmf
@@ -8,5 +8,6 @@ provision:
 prepare:
     how: ansible
     playbook: playbook.yml
+    extra-args: '-vvv'
 execute:
     how: tmt

--- a/tests/prepare/ansible/test.sh
+++ b/tests/prepare/ansible/test.sh
@@ -21,6 +21,13 @@ rlJournalStart
                 rlRun "sudo rm -f /tmp/prepared"
             fi
         rlPhaseEnd
+
+        rlPhaseStartTest "Ansible ($method) - check extra-args attribute"
+            rlRun "tmt run -rddd discover provision -h $method prepare finish \
+                | grep \"ansible-playbook\"\
+                | tee output"
+            rlAssertGrep "-vvv" output
+        rlPhaseEnd
     done
 
     rlPhaseStartCleanup

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -21,6 +21,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
               - playbook/one.yml
               - playbook/two.yml
               - playbook/three.yml
+            extra-args: '-vvv'
 
     The playbook path should be relative to the metadata tree root.
     Use 'order' attribute to select in which order preparation should
@@ -32,7 +33,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
     _methods = [tmt.steps.Method(name='ansible', doc=__doc__, order=50)]
 
     # Supported keys
-    _keys = ["playbook"]
+    _keys = ["playbook", "extra-args"]
 
     def __init__(self, step, data):
         """ Store plugin name, data and parent step """
@@ -47,7 +48,10 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
         return [
             click.option(
                 '-p', '--playbook', metavar='PLAYBOOK', multiple=True,
-                help='Path to an ansible playbook to run.')
+                help='Path to an ansible playbook to run.'),
+            click.option(
+                '--extra-args', metavar='EXTRA-ARGS',
+                help='Optional arguments for ansible-playbook.')
             ] + super().options(how)
 
     def default(self, option, default=None):
@@ -70,4 +74,4 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
         # Apply each playbook on the guest
         for playbook in self.get('playbook'):
             self.info('playbook', playbook, 'green')
-            guest.ansible(playbook)
+            guest.ansible(playbook, self.get('extra-args'))

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -361,6 +361,11 @@ class Guest(tmt.utils.Common):
         else:
             return ' -' + (self.opt('debug') - 2) * 'v'
 
+    @staticmethod
+    def _ansible_extra_args(extra_args):
+        """ Prepare extra arguments for ansible-playbook"""
+        return '' if extra_args is None else str(extra_args)
+
     def _ansible_summary(self, output):
         """ Check the output for ansible result summary numbers """
         if not output:
@@ -395,14 +400,16 @@ class Guest(tmt.utils.Common):
         return 'export {}; '.format(
             ' '.join(tmt.utils.shell_variables(environment)))
 
-    def ansible(self, playbook):
+    def ansible(self, playbook, extra_args=None):
         """ Prepare guest using ansible playbook """
         playbook = self._ansible_playbook_path(playbook)
         stdout, stderr = self.run(
             f'{self._export_environment()}'
             f'stty cols {tmt.utils.OUTPUT_WIDTH}; ansible-playbook '
             f'--ssh-common-args="{self._ssh_options(join=True)}" '
-            f'{self._ansible_verbosity()} -i {self._ssh_guest()}, {playbook}',
+            f'{self._ansible_verbosity()} '
+            f'{self._ansible_extra_args(extra_args)} -i {self._ssh_guest()},'
+            f' {playbook}',
             cwd=self.parent.plan.worktree)
         self._ansible_summary(stdout)
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -51,13 +51,15 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
 class GuestLocal(tmt.Guest):
     """ Local Host """
 
-    def ansible(self, playbook):
+    def ansible(self, playbook, extra_args=None):
         """ Prepare localhost using ansible playbook """
         playbook = self._ansible_playbook_path(playbook)
         stdout, stderr = self.run(
             f'sudo sh -c "stty cols {tmt.utils.OUTPUT_WIDTH}; '
-            f'{self._export_environment()}ansible-playbook'
-            f'{self._ansible_verbosity()} -c local -i localhost, {playbook}"')
+            f'{self._export_environment()}ansible-playbook '
+            f'{self._ansible_verbosity()} '
+            f'{self._ansible_extra_args(extra_args)} -c local -i localhost,'
+            f' {playbook}"')
         self._ansible_summary(stdout)
 
     def execute(self, command, **kwargs):

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -156,7 +156,7 @@ class GuestContainer(tmt.Guest):
         self.podman(['container', 'restart', self.container])
         return self.reconnect()
 
-    def ansible(self, playbook):
+    def ansible(self, playbook, extra_args=None):
         """ Prepare container using ansible playbook """
         playbook = self._ansible_playbook_path(playbook)
         # As non-root we must run with podman unshare
@@ -165,8 +165,9 @@ class GuestContainer(tmt.Guest):
             f'stty cols {tmt.utils.OUTPUT_WIDTH}; '
             f'{self._export_environment()}'
             f'{podman_unshare}ansible-playbook '
-            f'{self._ansible_verbosity()} -c podman -i {self.container}, '
-            f'{playbook}',
+            f'{self._ansible_verbosity()} '
+            f'{self._ansible_extra_args(extra_args)} '
+            f'-c podman -i {self.container}, {playbook}',
             cwd=self.parent.plan.worktree)
         self._ansible_summary(stdout)
 


### PR DESCRIPTION
New verbose attribute with integer value was added to ansible plugin for
prepare step. It will enable different verbose levels for `ansible-playbook`.
`--verbose` option or `verbose` attribute from fmf file will be applied.
Add tests.
Update docs.