### PR TITLE
Adjust `tmt test lint` test for old yaml format

### DIFF
--- a/tests/test/lint/test.sh
+++ b/tests/test/lint/test.sh
@@ -29,8 +29,13 @@ directory." output
     rlPhaseEnd
 
     rlPhaseStartTest "Old yaml"
-        rlRun "tmt test lint old-yaml | tee output"
-        rlAssertGrep 'warn seems to use YAML 1.1' output
+        if rlRun "tmt test lint old-yaml 2>&1 | tee output" 0,2; then
+            # Before fmf-1.0 we give just a warning
+            rlAssertGrep 'warn seems to use YAML 1.1' output
+        else
+            # Since fmf-1.0 old format is no more supported
+            rlAssertGrep 'Invalid.*enabled.*in test' output
+        fi
     rlPhaseEnd
 
     rlPhaseStartTest "Bad"


### PR DESCRIPTION
Since `fmf-1.0` the old yaml format is not supported. Instead of
warning during `tmt test lint` an error is raised already during
check for correct key values according to the specification.

Related fmf pull request: https://github.com/psss/fmf/pull/145