### PR TITLE
Allow to pick objects by --link

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -136,8 +136,8 @@ Filter Tests
 ------------------------------------------------------------------
 
 Both ``tmt tests ls`` and ``tmt tests show`` can optionally filter
-tests with a regular expression, filter expression or a Python
-condition::
+tests with a regular expression, filter expression, a Python
+condition or link expression::
 
     $ tmt tests show docs
     /tests/docs
@@ -153,8 +153,11 @@ condition::
     $ tmt tests ls --filter 'tier: 0'
     /tests/docs
 
-    $ tmt tests ls --condition 'int(tier) > 0'
+    $ tmt tests ls --condition 'tier and int(tier) > 0'
     /tests/ls
+
+    $ tmt tests ls --link verifies:issues/423$
+    /tests/prepare/shell
 
 In order to select tests under the current working directory use
 the single dot notation::

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -84,13 +84,20 @@ description: |
 
         See also the `fmf identifier`_ documentation for details.
         Use the following keys to limit the test discovery by test
-        name or an advanced filter:
+        name, an advanced filter or link:
 
         test
             List of test names or regular expressions used to
             select tests by name. Duplicate test names are allowed
             to enable repetitive test execution, preserving the
             listed test order.
+        link
+            Select tests using the :ref:`/spec/core/link` keys.
+            Values should be in the form of ``RELATION:TARGET``,
+            tests containing at least one of them are selected.
+            Regular expressions are supported for both relation
+            and target. Relation part can be omitted to match all
+            relations.
         filter
             Apply advanced filter based on test metadata
             attributes. See ``pydoc fmf.filter`` for more info.
@@ -145,6 +152,11 @@ description: |
             path: /metadata/tree/path
             test: [regexp]
             filter: tier:1
+
+        # Choose tests verifying given issue
+        discover:
+            how: fmf
+            link: verifies:issues/123$
 
         # Select only tests which have been modified
         discover:

--- a/tests/discover/data/tests.fmf
+++ b/tests/discover/data/tests.fmf
@@ -3,10 +3,14 @@ test: true
 /discover1:
     summary: Discover one
     tier: 1
+    link: /tmp/foo
 
 /discover2:
     summary: Discover two
     tier: 2
+    link:
+    - note: Some text
+      verifies: https://github.com/psss/tmt/issues/870
 
 /discover3:
     summary: Discover three

--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -28,6 +28,23 @@ rlJournalStart
         rlAssertNotGrep '/tests/discover3' output
     rlPhaseEnd
 
+    rlPhaseStartTest "Filter by link"
+        plan='plans --default'
+        for link_relation in "" "relates:" "rel.*:"; do
+            discover="discover -h fmf --link ${link_relation}/tmp/foo"
+            rlRun 'tmt run -dvr $discover $plan finish | tee output'
+            rlAssertGrep '1 test selected' output
+            rlAssertGrep '/tests/discover1' output
+        done
+        for link_relation in "verifies:https://github.com/psss/tmt/issues/870" \
+            "ver.*:.*/issues/870" ".*/issues/870"; do
+            discover="discover -h fmf --link $link_relation --link rubbish"
+            rlRun "tmt run -dvr $discover $plan finish | tee output"
+            rlAssertGrep '1 test selected' output
+            rlAssertGrep '/tests/discover2' output
+        done
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun 'rm -f output' 0 'Removing tmp file'
         rlRun 'popd'

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -85,6 +85,10 @@ def name_filter_condition(function):
         click.option(
             '-c', '--condition', 'conditions', metavar="EXPR", multiple=True,
             help="Use arbitrary Python expression for filtering."),
+        click.option(
+            '--link', 'links', metavar="RELATION:TARGET", multiple=True,
+            help="Filter by linked objects (regular expressions are "
+                 "supported for both relation and target)."),
         ]
 
     for option in reversed(options):
@@ -103,6 +107,10 @@ def name_filter_condition_long(function):
         click.option(
             '--condition', 'conditions', metavar="EXPR", multiple=True,
             help="Use arbitrary Python expression for filtering."),
+        click.option(
+            '--link', 'links', metavar="RELATION:TARGET", multiple=True,
+            help="Filter by linked objects (regular expressions are "
+                 "supported for both relation and target)."),
         ]
 
     for option in reversed(options):
@@ -269,6 +277,10 @@ run.add_command(tmt.steps.Reboot.command())
     '-c', '--condition', 'conditions', metavar="EXPR", multiple=True,
     help="Use arbitrary Python expression for filtering.")
 @click.option(
+    '--link', 'links', metavar="RELATION:TARGET", multiple=True,
+    help="Filter by linked objects (regular expressions are "
+         "supported for both relation and target).")
+@click.option(
     '--default', is_flag=True,
     help="Use default plans even if others are available.")
 @verbose_debug_quiet
@@ -293,6 +305,10 @@ def plans(context, **kwargs):
 @click.option(
     '-c', '--condition', 'conditions', metavar="EXPR", multiple=True,
     help="Use arbitrary Python expression for filtering.")
+@click.option(
+    '--link', 'links', metavar="RELATION:TARGET", multiple=True,
+    help="Filter by linked objects (regular expressions are "
+         "supported for both relation and target).")
 @verbose_debug_quiet
 def tests(context, **kwargs):
     """


### PR DESCRIPTION
Initial version, I've checked `tmt tests ls --link ...` and `tmt run discover --how fmf --link ...`, plans and stories might work too.

However I have usability questions about assumptions:
1. AND vs OR when multiple --link are used -> for now it is OR. Is there a use case when it should be AND ? I'm thinking mostly about Usage as "Find all mentioned bugzilla links  in PR and schedule all tests which verify those issues" So the expectation is to have multiple links to search for and no test will satisfy all of them
2. Split relation:value by first colon makes troubles for http:// - One is forced to always specify relation otherwise scheme is always taken as relation and raises an error. 
3. No way to ignore relation - UC - found tests which have any relation to "target" - One can do that in condition....



