### PR TITLE
Correct the `playbook` attribute in the spec

### DIFF
--- a/spec/plans/finish.fmf
+++ b/spec/plans/finish.fmf
@@ -30,7 +30,7 @@ example: |
         Perform finishing tasks using ansible
     description:
         One or more playbooks can be provided as a list under the
-        ``playbooks`` attribute.  Each of them will be applied
+        ``playbook`` attribute.  Each of them will be applied
         using ``ansible-playbook`` in the given order. The path
         should be relative to the metadata tree root.
     example: |

--- a/spec/plans/prepare.fmf
+++ b/spec/plans/prepare.fmf
@@ -56,7 +56,7 @@ example: |
         Apply ansible playbook to get the desired final state.
     description:
         One or more playbooks can be provided as a list under the
-        ``playbooks`` attribute.  Each of them will be applied
+        ``playbook`` attribute.  Each of them will be applied
         using ``ansible-playbook`` in the given order. The path
         should be relative to the metadata tree root.
     example: |

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -203,7 +203,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
             click.option(
                 '-c', '--connection',
                 type=click.Choice(['session', 'system']),
-                help='What session type to use, "session" by default'),
+                help="What session type to use, 'session' by default."),
             ] + super().options(how)
 
     def default(self, option, default=None):


### PR DESCRIPTION
For all attributes we use a singular form, fix the typo.
Plus a minor consistency nitpick (missing dot).