### PR TITLE
Reenable plans/install/docs

### DIFF
--- a/plans/install/docs.fmf
+++ b/plans/install/docs.fmf
@@ -14,10 +14,3 @@ execute:
         python3 -m sphinx -T -E -b html -d _build/doctrees \
             -D language=en . _build/html 2>&1 | tee output
         grep WARNING output && exit 1 || exit 0
-
-# FIXME temporarily skip on fresh Fedoras
-# https://github.com/sphinx-doc/sphinx/issues/9562
-adjust+:
-  - enabled: false
-    when: distro = fedora-rawhide, fedora-35
-    because: Sphinx is broken with Python 3.10


### PR DESCRIPTION
Sphinx has been released for some time and seems to work.
Also Fedora-35 is the main supported Fedora now.

Is `packit/testing-farm-fedora-33-x86_64` required to pass because it is the oldest supported release?