### PR TITLE
Enable duplicate test names and preserve ordering

### DIFF
--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -83,7 +83,9 @@ description: |
             used.
         test
             List of test names or regular expressions used to
-            select tests by name.
+            select tests by name. Duplicate test names are allowed
+            to enable repetitive test execution, preserving the
+            listed test order.
         filter
             Apply advanced filter based on test metadata
             attributes. See ``pydoc fmf.filter`` for more info.

--- a/tests/test/select/data/plans.fmf
+++ b/tests/test/select/data/plans.fmf
@@ -14,3 +14,11 @@ execute:
     discover:
         how: fmf
         filter: tag:nonsense
+
+/duplicate:
+    discover:
+        how: fmf
+        test:
+        - /tier/two
+        - /tier/one
+        - /tier/two

--- a/tests/test/select/test.sh
+++ b/tests/test/select/test.sh
@@ -130,6 +130,30 @@ rlJournalStart
         done
     rlPhaseEnd
 
+    rlPhaseStartTest "Select duplicate tests preserving tests ordering"
+        # 'tmt test ls' lists test name once
+        rlRun "tmt tests ls tier | tee $output"
+        rlAssertGrep '/tests/tier/two' $output
+        rlAssertEquals "/tests/tier/two is listed only once" 1 $( grep -c 'tier/two' $output )
+
+        rlRun "tmt tests ls tier/two tier/two | tee $output"
+        rlAssertGrep '/tests/tier/two' $output
+        rlAssertEquals "/tests/tier/two is listed only once" 1 $( grep -c 'tier/two' $output )
+
+        # 'tmt test show' lists test name once
+        rlRun "tmt tests show tier | tee $output"
+        rlAssertGrep '/tests/tier/two' $output
+        rlAssertEquals "/tests/tier/two is listed only once" 1 $( grep -c 'tier/two' $output )
+
+        # 'tmt run discover' lists duplicate test names preserving order
+        rlRun "tmt run discover -v plan --name duplicate | tee $output"
+        rlAssertGrep 'names: /tier/two, /tier/one and /tier/two' $output
+        rlAssertGrep 'summary: 3 tests selected' $output
+        rlRun "grep -A 1 summary $output | tail -1 | grep '/tests/tier/two'"
+        rlRun "grep -A 2 summary $output | tail -1 | grep '/tests/tier/one'"
+        rlRun "grep -A 3 summary $output | tail -1 | grep '/tests/tier/two'"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm $output" 0 "Remove output file"

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1153,7 +1153,13 @@ class Tree(tmt.utils.Common):
         """ Metadata root """
         return self.tree.root
 
-    def tests(self, keys=None, names=None, filters=None, conditions=None):
+    def tests(
+            self,
+            keys=None,
+            names=None,
+            filters=None,
+            conditions=None,
+            unique=True):
         """ Search available tests """
         # Handle defaults, apply possible command line options
         keys = (keys or []) + ['test']
@@ -1162,9 +1168,20 @@ class Tree(tmt.utils.Common):
         conditions = (conditions or []) + list(Test._opt('conditions', []))
 
         # Build the list and convert to objects
-        return self._filters_conditions(
-            [Test(test) for test in self.tree.prune(keys=keys, names=names)],
-            filters, conditions)
+        # If duplicate test names are allowed, match test name/regexp one-by-one
+        # and preserve the order of tests within a plan
+        if not unique and names:
+            tests = []
+            for name in names:
+                tests.extend(
+                    self._filters_conditions(
+                        [Test(test) for test in self.tree.prune(keys=keys, names=[name])],
+                        filters, conditions))
+            return tests
+        else:
+            return self._filters_conditions(
+                [Test(test) for test in self.tree.prune(keys=keys, names=names)],
+                filters, conditions)
 
     def plans(self, keys=None, names=None, filters=None, conditions=None,
               run=None):

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -220,7 +220,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             return
         tree = tmt.Tree(path=tree_path, context=self.step.plan._fmf_context())
         self._tests = tree.tests(filters=filters, names=names,
-                                 conditions=["manual is False"])
+                                 conditions=["manual is False"], unique=False)
 
         # Prefix tests and handle library requires
         for test in self._tests:


### PR DESCRIPTION
Preserve test ordering when a plan is enabled by enumerating test names (regexp patterns). 
E.g.
```
summary:
  Tests used by Packit/TFT CI on Github
discover:
  how: fmf
  test: 
   - /setup/configure_tpm_emulator
   - /setup/install_upstream_keylime
   - "/functional/.*"

execute:
    how: tmt
```
As a consequence duplicate tests are enabled within a test plan.
This should address 
https://github.com/psss/tmt/issues/941