### PR TITLE
Dist git source can contain multiple files

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -436,5 +436,5 @@ def test_FedoraDistGit(tmpdir):
         'SHA512 (fn-1.tar.gz) = 09af\n')
     tmpdir.join('tmt.spec').write('')
     fedora_sources_obj = tmt.utils.FedoraDistGit()
-    assert ("https://src.fedoraproject.org/repo/pkgs/rpms/tmt/fn-1.tar.gz/sha512/09af/fn-1.tar.gz",
-            "fn-1.tar.gz") == fedora_sources_obj.url_and_name(cwd=tmpdir)
+    assert [("https://src.fedoraproject.org/repo/pkgs/rpms/tmt/fn-1.tar.gz/sha512/09af/fn-1.tar.gz",
+            "fn-1.tar.gz")] == fedora_sources_obj.url_and_name(cwd=tmpdir)

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -228,14 +228,16 @@ class DiscoverPlugin(tmt.steps.Plugin):
             handler = tmt.utils.get_distgit_handler(remotes=remotes)
         else:
             handler = tmt.utils.get_distgit_handler(usage_name=handler_name)
-        url, source_name = handler.url_and_name(distgit_dir)
-        self.debug(f"Download sources from '{url}'.")
-        session = tmt.utils.retry_session()
-        response = session.get(url)
-        response.raise_for_status()
-        os.makedirs(target_dir, exist_ok=True)
-        with open(os.path.join(target_dir, source_name), 'wb') as tarball:
-            tarball.write(response.content)
-        self.run(
-            f"tar --auto-compress --extract -f {source_name}",
-            cwd=target_dir)
+        for url, source_name in handler.url_and_name(distgit_dir):
+            if source_name.endswith('.sign'):
+                continue
+            self.debug(f"Download sources from '{url}'.")
+            session = tmt.utils.retry_session()
+            response = session.get(url)
+            response.raise_for_status()
+            os.makedirs(target_dir, exist_ok=True)
+            with open(os.path.join(target_dir, source_name), 'wb') as tarball:
+                tarball.write(response.content)
+            self.run(
+                f"tar --auto-compress --extract -f {source_name}",
+                cwd=target_dir)


### PR DESCRIPTION
I've just found out that one component contains 'something.sign'  file in 'sources'. Let's download all files listed except .sign (as it clearly isn't a tarball) and extract all downloaded.