### PR TITLE
Make tests --name to just prune discovered tests

### DIFF
--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -227,10 +227,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         filters = list(tmt.base.Test._opt('filters') or self.get('filter', []))
         for filter_ in filters:
             self.info('filter', filter_, 'green')
-        # Check the 'test --name' option first, then 'test' from discover
-        names = list(tmt.base.Test._opt('names') or self.get('test', []))
+        # Names of tests selected by --test option
+        names = self.get('test', [])
         if names:
-            self.info('names', fmf.utils.listed(names), 'green')
+            self.info('tests', fmf.utils.listed(names), 'green')
 
         # Filter only modified tests if requested
         modified_only = self.get('modified-only')


### PR DESCRIPTION
Resolve: #954

The later commit changes how `--test` is presented in the show(): Used to be printed as `names` but should be as `test` (same as the option, IMO). It modifies line close to what is changed to fix the issue and IMHO there is no point in having two PRs.