### PR TITLE
Revert requiring exact beakerlib version

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -311,7 +311,7 @@ class Test(Core):
         # able to detect if the test has explicitly set the framework.
         self._check('framework', expected=str, default=None)
         if self.framework == 'beakerlib':
-            self.require.append('beakerlib >= 1.28')
+            self.require.append('beakerlib')
 
         # Check that environment is a dictionary
         self._check('environment', expected=dict, default={})


### PR DESCRIPTION
Because `rpm --whatprovides` does not support comparing package
versions, requiring exact `beakerlib` version results in prepare
`install` to always call `dnf` to install and thus `sudo` which is
not good, especially for `provision --how local`. Let's revert to
require name only, fresh `beakerlib` packages are in repos anyway.

This reverts commit 05170ce7151e35931d7517ebcee37afd0718fee8.