### PR TITLE
Disable UseDNS, GSSAPI for faster SSH in testcloud

### DIFF
--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -18,11 +18,13 @@ example: |
     summary: Provision a virtual machine (default)
     description:
         Create a new virtual machine on the localhost using
-        libvirt or another provider which is enabled in vagrant.
+        testcloud (libvirt). Testcloud takes care of downloading
+        an image and making necessary changes to it for optimal
+        experience (such as disabling UseDNS and GSSAPI for SSH).
     example: |
         provision:
             how: virtual
-            image: fedora/31-cloud-base
+            image: fedora
     link:
       - implemented-by: /tmt/steps/provision/testcloud.py
 

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -49,6 +49,8 @@ ssh_pwauth: true
 disable_root: false
 runcmd:
   - sed -i -e '/^.*PermitRootLogin/s/^.*$/PermitRootLogin yes/'
+    -e '/^.*UseDNS/s/^.*$/UseDNS no/'
+    -e '/^.*GSSAPIAuthentication/s/^.*$/GSSAPIAuthentication no/'
     /etc/ssh/sshd_config
   - systemctl reload sshd
   - [sh, -c, 'if [ ! -f /etc/systemd/network/20-tc-usernet.network ] &&


### PR DESCRIPTION
Greatly reduces SSH connection times in testcloud provisioner:

- switches off UseDNS (Specifies whether sshd(8) should look up the remote host name and check that the resolved host name for the remote IP address maps back to the very same IP address.) - seems irrelevant for tmt/testcloud use case
- switches off GSSAPI (Specifies whether user authentication based on GSSAPI is allowed.) - again, seems like nothing we'll ever be using or caring about

The effect of the change is most visible with el7 based systems, where it cuts a time to boot up and start executing tests from 240 seconds to 40 seconds on rpms/bash plans. 