### PR TITLE
Add `bios.method` to hardware spec

### DIFF
--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -190,6 +190,13 @@ example: |
             is-supported: false
             hypervisor: kvm
 
+        # Features related to machine boot modes
+        boot:
+            method: bios
+
+        boot:
+            method: uefi
+
         # Using advanced logic operators
         and:
           - cpu:


### PR DESCRIPTION
This hadware specification should describe what
boot method you want to use. It is related only
to some provisioners ...

Related to #917  

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>