### PR TITLE
Improve environment variables specification a bit

### DIFF
--- a/spec/plans/environment.fmf
+++ b/spec/plans/environment.fmf
@@ -4,10 +4,13 @@ description:
     Specifies environment variables available in all steps.
     Plugins need to include these environment variables while
     running commands or other programs. These environment
-    variables should override L1 ``environment`` if present.
+    variables override test :ref:`/spec/tests/environment` if
+    present. Command line option ``--environment`` can be used to
+    override environment variables defined in both tests and plan.
     Use the :ref:`/spec/plans/environment-file` key to load
     variables from files.
 example: |
+    # Environment variables defined in a plan
     /plan:
         environment:
             KOJI_TASK_ID: 42890031
@@ -15,6 +18,13 @@ example: |
         execute:
             script:
                 - echo "Testing $KOJI_TASK_ID on release $RELEASE"
+
+    # Variables from the command line
+    tmt run --environment X=1 --environment Y=2
+    tmt run --environment "X=1 Y=2"
+
+    # Make sure to quote properly values which include spaces
+    tmt run --environment "BUGS='123 456 789'"
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/tests/environment.fmf
+++ b/spec/tests/environment.fmf
@@ -10,7 +10,8 @@ description:
     part of the ``test`` attribute it makes sense to have a
     dedicated field for this, especially when the number of
     parameters grows. This might be useful for virtual test cases
-    as well. Should be a ``dictionary``.
+    as well. Plan :ref:`/spec/plans/environment` overrides test
+    environment. Should be a ``dictionary``.
 
 example: |
     environment:


### PR DESCRIPTION
Explicitly mention how to provide values including spaces.
Interlink environment sections of tests and plans.

Resolves #940.