### PR TITLE
Add specification for hostname

### DIFF
--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -199,6 +199,15 @@ example: |
         boot:
             method: uefi
 
+        # Choose machine with given hostname
+        hostname: kvm-01.lab.us-east-2.company.com
+
+        # Hostname matching a regular expression
+        hostname: "~ kvm-01.*"
+
+        # Hostname not matching a regular expression
+        hostname: "!~ kvm-01.*"
+
         # Using advanced logic operators
         and:
           - cpu:


### PR DESCRIPTION
For Beaker it is possible to choose machine according to hostname.
This is used widely and should be supported.

We should be able to choose hostname via regular expression matching.

Resolves #942 

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>