### PR TITLE
Make reboot support a bit more backward compatible

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -349,6 +349,17 @@ TMT_PLAN_DATA
     back from the guest and available for inspection after the
     plan is completed.
 
+TMT_REBOOT_COUNT
+    During the test execution the ``tmt-reboot`` command can be
+    used to request reboot of the guest. This variable contains
+    number of reboots which already happened during the test.
+    Value is set to ``0`` if no reboot occurred.
+
+    In order to keep backward-compatibility with older tests,
+    ``rhts-reboot`` and ``rstrnt-reboot`` commands are supported
+    for requesting the reboot, variables ``REBOOTCOUNT`` and
+    ``RSTRNT_REBOOTCOUNT`` contain number of reboots as well.
+
 
 Links
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/stories/features/reboot.fmf
+++ b/stories/features/reboot.fmf
@@ -5,12 +5,9 @@ story:
 description: |
     Some tests may require a reboot as a part of them, e.g.
     upgrading the system, rebooting and then running some checks.
-
-    The functionality is compatible with how restraint
-    works, hence ``rhts-reboot``, ``rstrnt-reboot`` or ``tmt-reboot``
-    can be used to start the reboot. The ``REBOOT_COUNT`` environment
-    variable is used to pass the test information about the number
-    of reboots done.
+    The ``tmt-reboot`` command can be used to request the guest
+    reboot from the test and the ``TMT_REBOOT_COUNT`` environment
+    variable provides number of successfully completed reboots.
 
     Note that this only works with the internal tmt executor and
     works with guests provisioned by tmt (e.g. container or
@@ -19,11 +16,16 @@ description: |
     will not work on machines where ``reboot`` command is not
     available.
 
+    For backward-compatibility reasons the ``rstrnt-reboot`` and
+    ``rhts-reboot`` commands are provided as well together with
+    the ``RSTRNT_REBOOTCOUNT`` and ``REBOOTCOUNT`` environment
+    variables.
+
 example: |
-    if [ -z "$REBOOT_COUNT" ] || [ "$REBOOT_COUNT" -eq 0 ]; then
+    if [ "$TMT_REBOOT_COUNT" -eq 0 ]; then
         rlRun "echo 'Before the reboot'"
-        rlRun "rhts-reboot" 0 "Reboot the machine"
-    elif [ "$REBOOT_COUNT" -eq 1 ]; then
+        rlRun "tmt-reboot" 0 "Reboot the machine"
+    elif [ "$TMT_REBOOT_COUNT" -eq 1 ]; then
         rlRun "echo 'After the reboot'"
     fi
 link:

--- a/tests/execute/reboot/basic.sh
+++ b/tests/execute/reboot/basic.sh
@@ -10,11 +10,11 @@ rlJournalStart
 
     rlPhaseStartTest "Simple reboot test"
         rlRun -s "tmt run -i $run -dddvvv"
-        rlAssertGrep "Rebooting during test /test, reboot count: 0" $rlRun_LOG
+        rlAssertGrep "Reboot during test '/test' with reboot count 1" $rlRun_LOG
         rlAssertGrep "After first reboot" $rlRun_LOG
-        rlAssertGrep "Rebooting during test /test, reboot count: 1" $rlRun_LOG
+        rlAssertGrep "Reboot during test '/test' with reboot count 2" $rlRun_LOG
         rlAssertGrep "After second reboot" $rlRun_LOG
-        rlAssertGrep "Rebooting during test /test, reboot count: 2" $rlRun_LOG
+        rlAssertGrep "Reboot during test '/test' with reboot count 3" $rlRun_LOG
         rlAssertGrep "After third reboot" $rlRun_LOG
         rlRun "rm $rlRun_LOG"
 

--- a/tests/execute/reboot/reuse.sh
+++ b/tests/execute/reboot/reuse.sh
@@ -28,11 +28,11 @@ rlJournalStart
         provision="provision -h connect -g $guest -P $port -u $user -k $key"
         for _ in $(seq 0 1); do
             rlRun -s "tmt run --scratch -ai $run -dddvvv $provision"
-            rlAssertGrep "Rebooting during test /test, reboot count: 0" $rlRun_LOG
+            rlAssertGrep "Reboot during test '/test' with reboot count 1" $rlRun_LOG
             rlAssertGrep "After first reboot" $rlRun_LOG
-            rlAssertGrep "Rebooting during test /test, reboot count: 1" $rlRun_LOG
+            rlAssertGrep "Reboot during test '/test' with reboot count 2" $rlRun_LOG
             rlAssertGrep "After second reboot" $rlRun_LOG
-            rlAssertGrep "Rebooting during test /test, reboot count: 2" $rlRun_LOG
+            rlAssertGrep "Reboot during test '/test' with reboot count 3" $rlRun_LOG
             rlAssertGrep "After third reboot" $rlRun_LOG
             rlRun "rm $rlRun_LOG"
 


### PR DESCRIPTION
Both beaker [1] and restraint [2] documentation mention the
`REBOOTCOUNT` as the variable used to store number of reboots.
Keep the backward-compatible naming consistent to make the test
migration as simple and straightforward as possible.

Add support for `TMT_REBOOT_COUNT` and `RSTRNT_REBOOTCOUNT`
variables as well and document them. Slighly modify the reboot
implementation to always define the reboot variables (as it is
done in restraint/beaker). Adjust tests and docs accordingly.

[1] https://beaker-project.org/docs/user-guide/task-environment.html#envvar-REBOOTCOUNT
[2] https://restraint.readthedocs.io/en/latest/remove_rhts.html#legacy-rhts-task-environment-variables

Resolves #991.