### PR TITLE
Minor modification of test result specification

### DIFF
--- a/spec/tests/result.fmf
+++ b/spec/tests/result.fmf
@@ -14,10 +14,11 @@ description: |
 
     respect
         test result is respected (fails when test failed)
-    ignore
-        ignore the test result (test always passes)
     xfail
         expected fail (pass when test fails, fail when test passes)
+    pass, info, warn, error, fail
+        ignore the actual test result and always report provided
+        value instead
 
     The default value is ``respect``.
 


### PR DESCRIPTION
Instead of a single `ignore` value which would always report
`pass` allow using any of the supported test result values.