### PR TITLE
Adjust ansible requires for containers preparation

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -49,7 +49,7 @@ Summary: Container provisioner for the Test Management Tool
 Obsoletes: tmt-container < 0.17
 Requires: tmt == %{version}-%{release}
 Requires: podman
-Requires: (ansible or ansible-core)
+Requires: (ansible or ansible-collection-containers-podman)
 
 %description provision-container
 Dependencies required to run tests in a container environment.


### PR DESCRIPTION
It seems that the `ansible-core` package does not contain podman
module. Recent test jobs are failing with the following error on
rawhide:

    the connection plugin 'podman' was not found

The new subpackage `ansible-collection-containers-podman` seems to
cover what is needed.