### PR TITLE
Add guest.pull() to the finish step

### DIFF
--- a/tests/finish/ansible/data/plan.fmf
+++ b/tests/finish/ansible/data/plan.fmf
@@ -15,6 +15,10 @@ finish:
       order: 70
       how: shell
       script: bash -xc "[ -f /tmp/finished ]"
+    - name: Create a file that is pulled during the finish stage
+      order: 80
+      how: shell
+      script: touch my_file.txt
 execute:
     how: tmt
     script: echo fake

--- a/tests/finish/ansible/main.fmf
+++ b/tests/finish/ansible/main.fmf
@@ -2,8 +2,9 @@ summary: Check that ansible finish works for basic images
 description:
     Try to provision a container with specific image (fedora,
     centos) and finish it with an ansible playbook. Make sure the
-    environment variables are correctly handed over. In the full
-    testing mode check virtual and local provision method as well.
+    environment variables are correctly handed over and logs are
+    pulled back. In the full testing mode check virtual and local
+    provision method as well.
 
 # By default we run under a container only
 environment:

--- a/tests/finish/ansible/test.sh
+++ b/tests/finish/ansible/test.sh
@@ -4,21 +4,23 @@
 rlJournalStart
     rlPhaseStartSetup
         rlRun "pushd data"
-        # Create a temporary directory used for testing
-        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
     rlPhaseEnd
 
     for method in ${METHODS:-container}; do
         rlPhaseStartTest "Test ($method)"
-            rlRun "tmt run -i $tmp --scratch -av provision -h $method"
+            # Prepare common options, run given method
+            tmt="tmt run -i $run --scratch"
+            rlRun "$tmt -av provision -h $method"
+
             # Check that created file is synced back
-            rlRun "ls -l $tmp/plan/tree"
-            rlAssertExists "$tmp/plan/tree/my_file.txt"
+            rlRun "ls -l $run/plan/tree"
+            rlAssertExists "$run/plan/tree/my_file.txt"
 
             # For container provision try centos images as well
             if [[ $method == container ]]; then
-                rlRun "tmt run -i $tmp --scratch -av finish provision -h $method -i centos:7"
-                rlRun "tmt run -i $tmp --scratch -av finish provision -h $method -i centos:8"
+                rlRun "$tmt -av finish provision -h $method -i centos:7"
+                rlRun "$tmt -av finish provision -h $method -i centos:8"
             fi
 
             # After the local provision remove the test file
@@ -29,7 +31,7 @@ rlJournalStart
     done
 
     rlPhaseStartCleanup
-        rlRun "rm -r $tmp" 0 "Removing tmp directory"
+        rlRun "rm -r $run" 0 "Removing run directory"
         rlRun "popd"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/finish/ansible/test.sh
+++ b/tests/finish/ansible/test.sh
@@ -4,16 +4,21 @@
 rlJournalStart
     rlPhaseStartSetup
         rlRun "pushd data"
+        # Create a temporary directory used for testing
+        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
     rlPhaseEnd
 
     for method in ${METHODS:-container}; do
         rlPhaseStartTest "Test ($method)"
-            rlRun "tmt run -arv provision -h $method"
+            rlRun "tmt run -i $tmp --scratch -av provision -h $method"
+            # Check that created file is synced back
+            rlRun "ls -l $tmp/plan/tree"
+            rlAssertExists "$tmp/plan/tree/my_file.txt"
 
             # For container provision try centos images as well
             if [[ $method == container ]]; then
-                rlRun "tmt run -arv finish provision -h $method -i centos:7"
-                rlRun "tmt run -arv finish provision -h $method -i centos:8"
+                rlRun "tmt run -i $tmp --scratch -av finish provision -h $method -i centos:7"
+                rlRun "tmt run -i $tmp --scratch -av finish provision -h $method -i centos:8"
             fi
 
             # After the local provision remove the test file
@@ -24,6 +29,7 @@ rlJournalStart
     done
 
     rlPhaseStartCleanup
+        rlRun "rm -r $tmp" 0 "Removing tmp directory"
         rlRun "popd"
     rlPhaseEnd
 rlJournalEnd

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -71,6 +71,8 @@ class Finish(tmt.steps.Step):
             guest_copy.parent = self
             for plugin in self.plugins():
                 plugin.go(guest_copy)
+            # Pull logs from guest
+            guest.pull()
 
         # Stop and remove provisioned guests
         for guest in self.plan.provision.guests():


### PR DESCRIPTION
We need to collect logs that are being stored in the working directory during the finish step. 