### PR TITLE
Remove dependency on the `python3-mock` package

### DIFF
--- a/containers/Dockerfile.full
+++ b/containers/Dockerfile.full
@@ -9,7 +9,7 @@ RUN set -x && \
 RUN set -x && \
     dnf install -y dnf-plugins-core && \
     dnf copr enable -y psss/tmt && \
-    dnf install -y tmt-all beakerlib python3-{mock,test} && \
+    dnf install -y tmt-all beakerlib && \
     dnf autoremove -y && \
     dnf clean all
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,8 +14,7 @@
 
 import os
 import sys
-
-from mock import Mock as MagicMock
+from unittest.mock import Mock as MagicMock
 
 import tmt
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -533,9 +533,7 @@ package then could be done in the following way::
     prepare+:
       - name: pytest
         how: install
-        package:
-            - python3-pytest
-            - python3-mock
+        package: python3-pytest
 
 
 Parametrize Plans

--- a/examples/symlinks/plans/unit.fmf
+++ b/examples/symlinks/plans/unit.fmf
@@ -9,6 +9,4 @@ discover:
 prepare+:
   - name: pytest
     how: install
-    package:
-        - python3-pytest
-        - python3-mock
+    package: python3-pytest

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ install_requires = [
     'ruamel.yaml'
 ]
 extras_require = {
-    'docs': ['sphinx>=3', 'sphinx_rtd_theme', 'mock'],
-    'tests': ['pytest', 'python-coveralls', 'mock', 'requre', 'pre-commit'],
+    'docs': ['sphinx>=3', 'sphinx_rtd_theme'],
+    'tests': ['pytest', 'python-coveralls', 'requre', 'pre-commit'],
     'provision': ['testcloud>=0.6.1'],
     'convert': ['nitrate', 'markdown', 'python-bugzilla'],
     'report-html': ['jinja2'],

--- a/tmt.spec
+++ b/tmt.spec
@@ -29,7 +29,6 @@ BuildRequires: python%{python3_pkgversion}-setuptools
 BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python%{python3_pkgversion}-click
 BuildRequires: python%{python3_pkgversion}-fmf
-BuildRequires: python%{python3_pkgversion}-mock
 BuildRequires: python%{python3_pkgversion}-requests
 BuildRequires: python%{python3_pkgversion}-testcloud
 BuildRequires: python%{python3_pkgversion}-markdown


### PR DESCRIPTION
The `mock` module is now part of the standard library so there is
no need to require the extra package. See also the following doc:
https://fedoraproject.org/wiki/Changes/DeprecatePythonMock

Remove the dependency, modify code to use `unittest.mock` instead
and remove various places where the package is mentioned.