### PR TITLE
Use `TMT_TEST_DATA` as location for `rlFileSubmit`

### DIFF
--- a/tests/execute/filesubmit/test.sh
+++ b/tests/execute/filesubmit/test.sh
@@ -8,10 +8,13 @@ rlJournalStart
         rlRun "set -o pipefail"
     rlPhaseEnd
 
+    # would be set by TMT_TEST_DATA
+    tmt_test_data="plans/default/execute/data/data"
+
     rlPhaseStartTest
         rlRun "tmt run -vfi $tmp -a provision -h container"
-        FILE_PATH=$tmp/plans/default/execute/data/submitted/this_file.txt
-        BUNDLE_PATH=$tmp/plans/default/execute/data/submitted/tmp-bundle_name.tar.gz
+        FILE_PATH=$tmp/$tmt_test_data/this_file.txt
+        BUNDLE_PATH=$tmp/$tmt_test_data/tmp-bundle_name.tar.gz
 
         # File was submitted and has correct content
         rlAssertExists $FILE_PATH

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -35,10 +35,9 @@ REBOOT_TEMPLATE_NAME = "reboot_template"
 FILE_SUBMIT_SCRIPT = """\
 #!/bin/sh
 FILENAME="$2"
-STORE_NAME="$BEAKERLIB_DIR/submitted/"
-[ -d $STORE_NAME ] || mkdir -p $STORE_NAME
-cp $FILENAME $STORE_NAME
-echo "File $FILENAME stored to $STORE_NAME"
+[ -d "$TMT_TEST_DATA" ] || mkdir -p "$TMT_TEST_DATA"
+cp "$FILENAME" "$TMT_TEST_DATA"
+echo "File $FILENAME stored to $TMT_TEST_DATA"
 """
 FILE_SUBMIT_NAME = "tmt-file-submit"
 


### PR DESCRIPTION
Test artifacts should be available from the same location.
One can either copy to $TMT_TEST_DATA or do rlFileSubmit (for beakerlib
tests)