### PR TITLE
Disable X11 forwarding in ssh connections

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -253,6 +253,7 @@ class Guest(tmt.utils.Common):
     def _ssh_options(self, join=False):
         """ Return common ssh options (list or joined) """
         options = [
+            '-oForwardX11=no',
             '-oStrictHostKeyChecking=no',
             '-oUserKnownHostsFile=/dev/null',
             ]


### PR DESCRIPTION
In some cases the X11 forwarding caused the connection to get
stuck. Let's disable the forwarding by default. We can add an
option to enable it upon request if needed later.

Resolves #1023.