### PR TITLE
Use `centos:stream8` image instead of `centos:8`

### DIFF
--- a/tests/prepare/adjust/test.sh
+++ b/tests/prepare/adjust/test.sh
@@ -12,15 +12,15 @@ rlJournalStart
         for test in without defined; do
             # Skip when both/none define required packages
             [[ $plan == $test ]] && continue
-            for distro in 7 8; do
+            for distro in 7 stream8; do
                 rlPhaseStartTest "Test: Plan $plan, test $test, CentOS $distro"
-                    cmd="tmt -c distro=centos-$distro run -arvvv "
+                    cmd="tmt -c distro=centos-${distro/stream} run -arvvv "
                     cmd+="provision -h container -i centos:$distro "
                     cmd+="plan --name $plan test --name $test "
                     cmd+="2>&1 | tee $output"
                     rlRun "$cmd"
                     rlAssertGrep 'out: Smoke test for yaml' $output
-                    if [[ $distro == 8 ]]; then
+                    if [[ $distro == "stream8" ]]; then
                         rlAssertGrep 'python3-yaml' $output
                         rlAssertNotGrep 'PyYAML' $output
                     else

--- a/tests/prepare/install/data/debuginfo.fmf
+++ b/tests/prepare/install/data/debuginfo.fmf
@@ -19,7 +19,7 @@ execute:
 /centos-8:
     summary+: " on CentOS 8"
     provision+:
-        image: centos:8
+        image: centos:stream8
 
     # FIXME This is needed for CentOS 8, but why? Filed:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1964505

--- a/tests/prepare/recommend/test.sh
+++ b/tests/prepare/recommend/test.sh
@@ -6,7 +6,7 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    for image in centos:7 centos:8 fedora; do
+    for image in centos:7 centos:stream8 fedora; do
         rlPhaseStartTest "Test $image"
             rlRun "tmt run -ar provision -h container -i $image"
         rlPhaseEnd


### PR DESCRIPTION
CentOS Linux 8 reached End Of Life on December 31st, 2021.
Let's use the `centos:stream8` image for container tests instead.