### PR TITLE
Ensure that workdir has a correct selinux context

### DIFF
--- a/tests/test/debug/main.fmf
+++ b/tests/test/debug/main.fmf
@@ -1,0 +1,11 @@
+summary: Verify that test debugging works fine
+description:
+    Prepare the environment for testing using provision & prepare,
+    then debug test code using repeated discover & execute.
+
+environment:
+    METHODS: local container
+adjust:
+    environment:
+        METHODS: local container virtual
+    when: how == full

--- a/tests/test/debug/test.sh
+++ b/tests/test/debug/test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+        rlRun "pushd $tmp"
+        rlRun "tmt init"
+        rlRun "tmt plan create --template base /plan"
+        rlRun "tmt test create --template shell /test"
+    rlPhaseEnd
+
+    for method in ${METHODS:-local}; do
+        rlPhaseStartTest "Test $method"
+            # Run until execute
+            tmt="tmt run --id $run --verbose"
+            rlRun "$tmt --all --scratch --before execute provision -h $method"
+
+            # Failing test
+            rlRun "echo -e '#!/bin/bash\n/bin/false' > test/test.sh"
+            rlRun "$tmt discover --force execute --force" 1 "Failing test"
+
+            # Fixed test
+            rlRun "echo -e '#!/bin/bash\n/bin/true' > test/test.sh"
+            rlRun "$tmt discover --force execute --force" 0 "Fixed test"
+
+            # Clenup until finish
+            rlRun "$tmt --until finish"
+        rlPhaseEnd
+    done
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp $run" 0 "Remove tmp & run directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -202,7 +202,11 @@ class GuestContainer(tmt.Guest):
             [self.container or 'dry', 'sh', '-c', command], **kwargs)
 
     def push(self, source=None, destination=None, options=None):
-        """ Nothing to be done to push workdir """
+        """ Make sure that the workdir has a correct selinux context """
+        self.debug("Update selinux context of the run workdir.", level=3)
+        self.run(
+            ["chcon", "--recursive", "--type=container_file_t",
+             self.parent.plan.workdir], shell=False)
 
     def pull(self, source=None, destination=None, options=None):
         """ Nothing to be done to pull workdir """


### PR DESCRIPTION
This fixes `permission denied` errors when `discover --force` is
used together with `container` provision method. Should also cover
the recent problem with accessing symlinked tree: BZ#2044249.