### PR TITLE
Add `html2text` to the `convert` pip dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ extras_require = {
     'docs': ['sphinx>=3', 'sphinx_rtd_theme'],
     'tests': ['pytest', 'python-coveralls', 'requre', 'pre-commit'],
     'provision': ['testcloud>=0.6.1'],
-    'convert': ['nitrate', 'markdown', 'python-bugzilla'],
+    'convert': ['nitrate', 'markdown', 'python-bugzilla', 'html2text'],
     'report-html': ['jinja2'],
     'report-junit': ['junit_xml'],
 }


### PR DESCRIPTION
The module is needed for manual test instructions conversion
during `tmt test import`.