### PR TITLE
Fix test --name '.' used with multiple plans

### DIFF
--- a/tests/test/select/data/subdir/main.fmf
+++ b/tests/test/select/data/subdir/main.fmf
@@ -1,0 +1,7 @@
+enabled: false
+test: 'true'
+adjust:
+    -   when: subdir is defined
+        enabled: true
+        tag:
+        - nonsense

--- a/tests/test/select/test.sh
+++ b/tests/test/select/test.sh
@@ -189,6 +189,26 @@ rlJournalStart
         rlRun "rm -rf $run" 0 "Clean up run"
     rlPhaseEnd
 
+    rlPhaseStartTest "Select by test --name . "
+        rlRun "pushd subdir"
+        run=$(mktemp -d)
+
+        rlRun "tmt -c subdir=1 run --id $run discover tests --name ."
+        # only /subdir test is selected by /plans/all and /plans/filtered
+        for plan in all filtered; do
+            rlAssertEquals "just /subdir in $plan" \
+                "$(grep '^/' $run/plans/$plan/discover/tests.yaml)" "/subdir:"
+        done
+        # other two plans don't select any test
+        for plan in duplicate selected; do
+            rlAssertEquals "no test selected in $plan" \
+                "$(cat $run/plans/$plan/discover/tests.yaml)" "{}"
+        done
+
+        rlRun "rm -rf $run" 0 "Clean up run"
+        rlRun "popd"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm $output" 0 "Remove output file"

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -186,8 +186,8 @@ class Core(tmt.utils.Common):
             # Prepare path from the tree root to the current directory
             else:
                 path = os.path.join('/', os.path.relpath(current, root))
-            cls._context.params['names'] = (
-                path if name == '.' else name for name in names)
+            cls._context.params['names'] = tuple([
+                path if name == '.' else name for name in names])
 
     def name_and_summary(self):
         """ Node name and optional summary """


### PR DESCRIPTION
Fixes #1045

Names inside context were saved as generator expresion.
When evaluation the first plan it was executed and correct
tuple of names was returned.
However all other plans were got empty list as the generator was
exhausted and it behaved as if no --name '.' was used.