### PR TITLE
Use a colon for separating `TMT_PLUGINS` paths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -324,6 +324,10 @@ TMT_DEBUG
     levels from 1 to 3. However, some of the plugins go even
     deeper when needed.
 
+TMT_PLUGINS
+    Path to a directory with additional plugins. Multiple paths
+    separated with the ``:`` character can be provided as well.
+
 NO_COLOR
     Disable colors in the terminal output. Output only plain,
     non-colored text. See https://no-color.org/ for more

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -30,7 +30,7 @@ def explore():
     try:
         paths = [
             os.path.realpath(os.path.expandvars(os.path.expanduser(path)))
-            for path in os.environ['TMT_PLUGINS'].split(' ')]
+            for path in os.environ["TMT_PLUGINS"].split(os.pathsep)]
     except KeyError:
         log.debug('No custom plugin locations detected in TMT_PLUGINS.')
         paths = []


### PR DESCRIPTION
Instead of a space use `:` to separate multiple directory paths
in the `TMT_PLUGINS` variable to make it consistent with how
`PATH` works. Document the variable as well.

Resolves #1005.