### PR TITLE
Add support for where keyword to execute

### DIFF
--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -141,12 +141,12 @@ description: |
         is not defined, tests are executed on all provisioned
         guests.
     example: |
-        # Execute discovered tests on the client
+        # Execute discovered tests on the client (already supported)
         execute:
           - how: tmt
             where: client
 
-        # Run different script for each role
+        # Run different script for each role (not supported yet)
         execute:
           - name: run-the-client-code
             script: client.py

--- a/tests/multihost/web/data/plan.fmf
+++ b/tests/multihost/web/data/plan.fmf
@@ -32,3 +32,4 @@ prepare:
 
 execute:
     script: curl http://server/ | grep foo
+    where: client

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -136,10 +136,12 @@ class Execute(tmt.steps.Step):
             raise tmt.utils.ExecuteError("No guests available for execution.")
 
         # Execute the tests, store results
-        for plugin in self.plugins():
-            plugin.go()
-            if isinstance(plugin, ExecutePlugin):
-                self._results = plugin.results()
+        for guest in self.plan.provision.guests():
+            for plugin in self.plugins():
+                if plugin.enabled_on_guest(guest):
+                    plugin.go(guest)
+                    if isinstance(plugin, ExecutePlugin):
+                        self._results = plugin.results()
 
         # Give a summary, update status and save
         self.summary()


### PR DESCRIPTION
As discussed at hacking session today, I am updating the current multihost implementation. I don't want to overly complicate things especially since it will be mostly reworked due to the parallelization so:
 - no support for CLI (the TF use-case will be temporarily covered by the artemis plugin)
 - no support for discover's where either (though discovering a single test and then running it on the specified guests should work correctly with this implementation)
 - no support for the new group syntax, parsing with the current tmt's structure would be awkward, a bit too hacky IMO
 - support for `where` under `execute` as was planned in the original specification.

This makes example such as (inspired by #1135) this work:

```yaml
provision:
  - name: server
    how: virtual
    connection: system

  - name: client
    how: virtual
    connection: system

prepare:
  - name: Install httpd
    how: install
    package: httpd
    where: server

  - name: Start the service
    how: shell
    script: systemctl start httpd
    where: server

  - name: Prepare page
    how: shell
    script: echo foo > /var/www/html/index.html
    where: server

  - name: Install curl
    how: install
    package: curl
    where: client

execute:
    script: curl http://server/ | grep foo
    where: client
```