### PR TITLE
Disable the extra verbose progress in testcloud

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -444,6 +444,7 @@ class GuestTestcloud(tmt.GuestSsh):
         # Make sure download progress is disabled unless in debug mode,
         # so it does not spoil our logging
         self.config.DOWNLOAD_PROGRESS = self.opt('debug') > 2
+        self.config.DOWNLOAD_PROGRESS_VERBOSE = False
 
         # Configure to tmt's storage directories
         self.config.DATA_DIR = TESTCLOUD_DATA


### PR DESCRIPTION
Together with https://pagure.io/testcloud/pull-request/131 should
fix the extra detailed image download progress output which could
take up several megabytes in the logs.

Fixes: https://pagure.io/testcloud/issue/128