### PR TITLE
Expose fmf ID of tests in results

### DIFF
--- a/spec/plans/results.fmf
+++ b/spec/plans/results.fmf
@@ -20,6 +20,12 @@ description: |
        # String, name of the test.
        name: /test/one
 
+       # fmf ID of the test.
+       fmf_id:
+         url: http://some.git.host.com/project/tests.git
+         name: /test/one
+         path: /
+
        # String, outcome of the test execution.
        result: "pass"|"fail"|"info"|"warn"|"error"
 
@@ -98,8 +104,8 @@ description: |
     The first ``log`` item is considered to be the "main" log, presented
     to the user by default.
 
-    The ``serialnumber`` and ``guest`` keys, if present in the custom
-    results file, will be overwritten by tmt during their import after
+    The ``serialnumber``, ``guest`` and ``fmf_id`` keys, if present in the
+    custom results file, will be overwritten by tmt during their import after
     test completes. This happens on purpose, to assure this vital
     information is correct.
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -651,6 +651,12 @@ class Core(
     def fmf_id(self) -> FmfId:
         """ Return full fmf identifier of the node """
 
+        # When the object is built from an fmf node without a root, it's
+        # probably not possible for the object to have any fmf ID in the
+        # context of a non-existent fmf tree.
+        if self.node.root is None:
+            return FmfId()
+
         return tmt.utils.fmf_id(name=self.name, fmf_root=Path(self.node.root), logger=self._logger)
 
     def web_link(self) -> Optional[str]:


### PR DESCRIPTION
To help identify each test, include their fmf IDs in the final `results.yaml`.