### PR TITLE
Define "block-device" key for guest topology HW exposition

### DIFF
--- a/spec/hardware/disk.fmf
+++ b/spec/hardware/disk.fmf
@@ -27,7 +27,7 @@ description: |
     .. versionchanged:: 1.32
        Added `driver` and `model-name` into specification.
 
-    .. versionchanged:: 1.33
+    .. versionchanged:: 1.34
        Added ``block-device`` into specification.
 
 example:


### PR DESCRIPTION
Adds a new key, `block-device`, that guest topology may use to inform tests about which disk matches requested by HW requirements.

Related to https://github.com/teemtee/tmt/issues/2402

Pull Request Checklist

* [x] implement the feature
* [x] update the specification