### PR TITLE
Test virtual & bootc provision plugins in public

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -114,11 +114,12 @@ _:
           - status | discuss
           - ci | skip
 
-  # Internal provisioning jobs
-  - &internal-provision
+  # Provisioning jobs
+  - &provision
     <<: *test-base
-    <<: *internal
     <<: *require-full-tests
+    targets:
+      - fedora-latest-stable
     tf_extra_params:
       environments:
         - tmt:
@@ -167,11 +168,11 @@ jobs:
     tmt_plan: '/plans/features/extended-unit-tests$'
 
   # Test provision plugins
-  - <<: *internal-provision
+  - <<: *provision
     identifier: provision-bootc
     tmt_plan: /plans/provision/bootc
 
-  - <<: *internal-provision
+  - <<: *provision
     identifier: provision-virtual
     tmt_plan: /plans/provision/virtual
 


### PR DESCRIPTION
Openstack experience is getting worse and worse, let's try to run the tests on public bare metal instances instead.

Resolves #3691

