### PR TITLE
Require `typing-extensions>=4`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "requests>=2.25.1",
     "ruamel.yaml>=0.16.6",
     "urllib3>=1.26.5, <3.0",
-    "typing-extensions>=4.12.2; python_version < '3.13'",
+    "typing-extensions>=4; python_version < '3.13'",
     ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
In c10s, RHEL10, the python3-typing-extensions package is included in the system repos, as opposed to EPEL. The package, currently, have an lower version than the one in EPEL9, this change relaxes the minimal version of typing-extensions on Python<13 to "4". See: https://typing-extensions.readthedocs.io/en/latest/#versioning-and-backwards-compatibility

Blocks https://github.com/teemtee/tmt/pull/3234