### PR TITLE
Make application of policy visible even without the policy log topic

### DIFF
--- a/tests/policy/test.sh
+++ b/tests/policy/test.sh
@@ -14,7 +14,9 @@ rlJournalStart
             local filter="$3"
             local expected="$4"
 
-            rlRun    "tmt -vv test export --policy-file ../policies/test/$1 $plan"
+            rlRun -s "tmt -vv test export --policy-file ../policies/test/$1 $plan"
+            rlAssertGrep "Apply tmt policy '../policies/test/$1' to tests." $rlRun_LOG
+
             rlRun -s "tmt -vv test export --policy-file ../policies/test/$1 $plan 2> /dev/null | yq -cSr '.[] | $filter'"
 
             rlAssertEquals \

--- a/tmt/policy.py
+++ b/tmt/policy.py
@@ -244,9 +244,8 @@ class Policy(MetadataContainer):
         """
 
         logger.info(
-            f"Apply tmt policy '{self.name}'.",
+            f"Apply tmt policy '{self.name}' to tests.",
             color='green',
-            topic=Topic.POLICY,
         )
 
         self._apply(tests, self.test_policy, logger.descend())


### PR DESCRIPTION
The details remain guarded by the log topic, but tmt should at least report the policy is active.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage