### PR TITLE
Revert changes for `ruamel` in precommit mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,6 @@ repos:
           - "types-lxml"
 
         pass_filenames: false
-        args: [--config-file=pyproject.toml]
 
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.399


### PR DESCRIPTION
Since the [mypy upstream issue](https://github.com/python/mypy/issues/12664) has been fixed, the workaround is no longer needed and the warning could be avoided.

Pull Request Checklist

* [x] implement the feature