### PR TITLE
Wait for subuids to be created in toolbox test

### DIFF
--- a/tests/provision/container/toolbox/test.sh
+++ b/tests/provision/container/toolbox/test.sh
@@ -18,7 +18,7 @@ rlJournalStart
         # This prevents a race condition where `toolbox create` runs before
         # the user's subuids are available.
         rlLog "Waiting for subuid/subgid allocation for user '$toolbox_user'..."
-        rlWaitForCmd "getent subuid '$toolbox_user'" 15 1
+        rlWaitForCmd "grep -q '^${toolbox_user}:' /etc/subuid" 15 1
 
         rlRun "toolbox_user_id=\$(id -u $toolbox_user)"
 


### PR DESCRIPTION
Just a hunch this is causing the intermittent test failures:  
```
Error: Missing subgid and/or subuid ranges for user toolbox
See the podman(1), subgid(5), subuid(5) and usermod(8) manuals for more
information.  
```
