### PR TITLE
Remove unreachable exception for `require-test` key

### DIFF
--- a/tests/execute/require-test/test.sh
+++ b/tests/execute/require-test/test.sh
@@ -19,7 +19,7 @@ rlJournalStart
         rlRun -s "tmt run --id $run --scratch -vvv plan -n /plans/skipped" 2
         rlAssertGrep "summary: 5 tests selected" "$rlRun_LOG"
         rlAssertGrep "summary: 3 tests executed, 2 tests skipped" "$rlRun_LOG"
-        rlAssertGrep "Required test '/second/tests/skip' was skipped." "$rlRun_LOG"
+        rlAssertGrep "Required test '/second/tests/skip' on guest 'default-0' was skipped." "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/multihost/complete/data/req_test_fail.fmf
+++ b/tests/multihost/complete/data/req_test_fail.fmf
@@ -1,0 +1,45 @@
+provision:
+  - how: container
+    name: client-1
+    role: client
+    image: fedora:36
+
+  - how: container
+    name: client-2
+    role: client
+    image: fedora:36
+
+  - how: container
+    name: server
+    role: server
+    image: fedora:36
+
+execute:
+  how: tmt
+
+discover:
+  - name: server-setup
+    how: fmf
+    test:
+      - /tests/A
+    where:
+      - server
+    require-test:
+      - /tests/A
+
+  - name: tests
+    how: fmf
+    test:
+      - /tests/B
+      - /tests/D
+    where:
+      - server
+      - client
+    require-test:
+      - /tests/B
+      - /tests/D
+
+  - name: teardown
+    how: fmf
+    test:
+      - /tests/C

--- a/tests/multihost/complete/data/tests/main.fmf
+++ b/tests/multihost/complete/data/tests/main.fmf
@@ -5,3 +5,7 @@ test: ./test.sh
 
 /B:
   summary: Dummy test B
+
+/D:
+  summary: Test that returns SKIP if the host is client-2
+  test: ./test_D.sh

--- a/tests/multihost/complete/data/tests/test_D.sh
+++ b/tests/multihost/complete/data/tests/test_D.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+source "$TMT_TOPOLOGY_BASH"
+
+if [ "${TMT_GUEST["name"]}" == "client-2" ]; then
+    tmt-report-result D SKIP
+fi

--- a/tests/multihost/complete/test.sh
+++ b/tests/multihost/complete/test.sh
@@ -40,7 +40,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Prepare"
-        rlRun -s "tmt -vvv run --scratch --id $run discover provision prepare"
+        rlRun -s "tmt -vvv run --scratch --id $run discover provision prepare plan -n plans"
 
         rlRun "grep '^        queued prepare task #1: essential-requires on client-1 (client), client-2 (client) and server (server)' $rlRun_LOG"
         rlRun "grep '^        queued prepare task #2: default-0 on client-1 (client) and client-2 (client)' $rlRun_LOG"
@@ -86,7 +86,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Execute"
-        rlRun -s "tmt -vvv run --scratch --id $run discover provision execute finish"
+        rlRun -s "tmt -vvv run --scratch --id $run discover provision execute finish cleanup plan -n plans"
 
         rlRun "grep 'summary: 7 tests executed' $rlRun_LOG"
 
@@ -125,6 +125,11 @@ rlJournalStart
         check_shared_topology "$client1_topology_yaml"
         check_shared_topology "$client2_topology_yaml"
         check_shared_topology "$server_topology_yaml"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Require Test Skipped on Client-2 with error return code"
+        rlRun -s "tmt -vvv run --scratch --id $run plan -n req_test_fail" 2
+        rlAssertGrep "Required test '/tests/tests/D' on guest 'client-2' was skipped." $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
Remove unreachable multihost exception for the new require-test key.

Improve require-test key execute exception messages to include guest name. Update affected test.

Improve test coverage by adding a multihost test that triggers the require-test execute exception when a required-test is skipped on 'client-2', but the same test is not skipped on 'server' or 'client-1'

Fixes: [#3932](https://github.com/teemtee/tmt/issues/3932)

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
