### PR TITLE
Enable internal Functional Safety integration tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -176,7 +176,7 @@ jobs:
     <<: *require-full-tests
     identifier: internal-fusa
     fmf_url: "https://gitlab.cee.redhat.com/automotive/tests/all.git"
-    fmf_ref: "nsaini-pr-4009"
+    fmf_ref: "main"
     tmt_plan: '/tmt/plans/fusa/tests'
     targets:
       - epel-9


### PR DESCRIPTION
This PR adds a new check `internal-fusa` which should be run on testing-farm for centos9 check platform.
There were some gaps detected in the risk assessment, hence the tmt/fusa test plan contains tests related to podman & ssh.

Pull Request Checklist

* [X] extend the test coverage