### PR TITLE
Migrate to self-hosted renovate

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -1,0 +1,8 @@
+{
+  "configValidationError": true,
+  "onboarding": false,
+  "platform": "github",
+  "repositories": [
+    "teemtee/tmt"
+  ]
+}

--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -1,5 +1,6 @@
 {
   "configValidationError": true,
+  "prHourlyLimit": 0,
   "onboarding": false,
   "platform": "github",
   "repositories": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "schedule:weekly",
     ":enablePreCommit",
     ":semanticCommitsDisabled"
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,9 +35,9 @@
       "matchManagers": ["pre-commit"]
     },
     {
-      "description": "Disable all python dependencies. Specific matchers will be used.",
-      "matchManagers": ["pep621"],
-      "enabled": false
+      "description": "Python dependencies with lockfile",
+      "groupName": "Locked dependencies",
+      "matchManagers": ["pep621"]
     },
     {
       "description": "Group documentation dependencies together",
@@ -45,19 +45,7 @@
       "matchManagers": ["pep621"],
       "matchDepTypes": ["project.optional-dependencies"],
       "enabled": true,
-      "matchPackageNames": [
-        "/renku-sphinx-theme/",
-        "/sphinx/",
-        "/readthedocs-sphinx-ext/",
-        "/docutils/"
-      ]
-    },
-    {
-      "description": "Group hatch dev dependencies together",
-      "groupName": "hatch dev Dependencies",
-      "matchManagers": ["pep621"],
-      "matchDepTypes": ["tool.hatch.envs.dev"],
-      "enabled": true
+      "matchJsonata": ["managerData.depGroup = 'docs'"]
     }
   ]
 }

--- a/.github/workflows/build-and-publish-renovate.yml
+++ b/.github/workflows/build-and-publish-renovate.yml
@@ -9,6 +9,8 @@ on:
         description: Committish to build and publish
         required: true
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-publish-renovate.yml
+++ b/.github/workflows/build-and-publish-renovate.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - containers/Containerfile.renovate
+    branches: [main]
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/build-and-publish-renovate.yml
+++ b/.github/workflows/build-and-publish-renovate.yml
@@ -1,0 +1,31 @@
+name: Build and publish renovate image
+on:
+  push:
+    paths:
+      - containers/Containerfile.renovate
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Committish to build and publish
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: redhat-actions/buildah-build@v2
+        with:
+          image: renovate-tmt
+          containerfiles: ./containers/Containerfile.renovate
+      - uses: redhat-actions/push-to-registry@v2
+        with:
+          image: renovate-tmt
+          tags: latest
+          registry: ghcr.io/teemtee
+          username: ${{ github.actor }}
+          password: ${{ github.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,31 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - containers/Containerfile.renovate
+      - .github/workflows/renovate.yml
+      - .github/workflows/build-and-publish-renovate.yml
+  schedule:
+    # Weekly on Friday
+    - cron: 0 0 * * 5
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Get GitHub App token
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RENOVATE_BOT_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - uses: renovatebot/github-action@v44.2.0
+        with:
+          configurationFile: .github/renovate-config.json
+          token: '${{ steps.token.outputs.token }}'
+          renovate-image: ghcr.io/teemtee/renovate-tmt
+          renovate-version: latest

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,6 +17,7 @@ permissions: {}
 
 jobs:
   renovate:
+    environment: renovate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,6 +11,10 @@ on:
     # Weekly on Friday
     - cron: 0 0 * * 5
 
+# Note that the real permissions are being handled by actions/create-github-app-token,
+# this only affects the other steps like actions/checkout
+permissions: {}
+
 jobs:
   renovate:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Get GitHub App token
         id: token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RENOVATE_BOT_APP_ID }}
           private-key: ${{ secrets.RENOVATE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -34,3 +34,5 @@ jobs:
           token: '${{ steps.token.outputs.token }}'
           renovate-image: ghcr.io/teemtee/renovate-tmt
           renovate-version: latest
+        env:
+          LOG_LEVEL: ${{ runner.debug == '1' && 'debug' || 'info' }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RENOVATE_BOT_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - uses: renovatebot/github-action@v44.2.0

--- a/containers/Containerfile.renovate
+++ b/containers/Containerfile.renovate
@@ -1,5 +1,6 @@
 FROM ghcr.io/renovatebot/renovate:42
 
+# Changing user to root and back to run the apt-get commands
 USER root
 
 # hadolint ignore=DL3008,DL3015
@@ -10,4 +11,6 @@ RUN apt-get update && \
     libpq-dev && \
   rm -rf /var/lib/apt/lists/*
 
+# Changing back to the user defined in the original renovate image
+# Last known source location: https://github.com/renovatebot/renovate/blob/main/tools/docker/Dockerfile
 USER 12021

--- a/containers/Containerfile.renovate
+++ b/containers/Containerfile.renovate
@@ -1,0 +1,13 @@
+FROM ghcr.io/renovatebot/renovate:42
+
+USER root
+
+# hadolint ignore=DL3008,DL3015
+RUN apt-get update && \
+  apt-get install -y \
+    libvirt-dev \
+    libkrb5-dev \
+    libpq-dev && \
+  rm -rf /var/lib/apt/lists/*
+
+USER 12021


### PR DESCRIPTION
In order to properly run renovate with python dependencies that require system packages (see [failure](https://github.com/teemtee/tmt/pull/4432#issuecomment-3652570856)) we have to run renovate as [self-hosted](https://docs.renovatebot.com/examples/self-hosting/) and embed the dependencies needed in the renovate runner to be able to run `uv sync`.

A breakdown of how this works:
- `containers/Containerfile.renovate`: Inherits from upstream [renovate image](https://github.com/renovatebot/renovate/blob/main/tools/docker/Dockerfile) aka ghcr.io/renovatebot/renovate
- `build-and-publish-renovate.yml`: Whenever the file above is updated or if run manually, this workflow build the container as `renovate-tmt:latest` and publishes it to this repo's [github container respository](https://github.com/teemtee/tmt/pkgs/container/renovate-tmt)
- `renovate.yml`: Using the container above, this workflow basically runs renovate itself using the `renovate-config.json` for the runner, after which it is equivalent with the hosted renovate
- In order for Github Actions to be run on PRs created by a different github action, a token other than `${github.token}` must be used. In this case a Github app will be created and owned at the teemtee organization which is then fed into `actions/create-github-app-token` to get the final token that renovate would be using. See [renovatebot/github-action example](https://github.com/renovatebot/github-action?tab=readme-ov-file#example-with-github-app) for more explanation

Besides the workflow above, to make sure everything is working correctly this PR reconfigures `renovate.json` as well:
- Simplify the `Documentation Dependencies` flow. Something is probably still missing to properly make the PRs for these, but will continue this work afterwards
- Drop the hatch devDependencies
- Enable the python dependency update for everything. This probably needs more fine-tuning probably with [`lockFileMaintenance`](https://docs.astral.sh/uv/guides/integration/dependency-bots/#renovate)