### PR TITLE
Fix `compose-id` schema for the `polarion` report plugin

### DIFF
--- a/tmt/schemas/report/polarion.yaml
+++ b/tmt/schemas/report/polarion.yaml
@@ -67,7 +67,7 @@ properties:
   logs:
     type: string
 
-  composeid:
+  compose-id:
     type: string
 
   fips:


### PR DESCRIPTION
When setting `compose-id` in `report.polarion`, tmt raises warning "is not valid under any of the given schemas" due to schema property typo.

Pull Request Checklist

* [x] modify the json schema