### PR TITLE
Add comprehensive sensitive data masking for logging security

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -404,7 +404,9 @@ class StepData(
         Called before normalization, useful for tweaking raw data
         """
 
-        logger.debug(f'{cls.__name__}: original raw data', str(raw_data), level=4)
+        # Mask sensitive data before logging
+        masked_raw_data = tmt.utils.mask_sensitive_data(raw_data)
+        logger.debug(f'{cls.__name__}: original raw data', str(masked_raw_data), level=4)
 
     def post_normalization(self, raw_data: _RawStepData, logger: tmt.log.Logger) -> None:
         """
@@ -1679,8 +1681,14 @@ class BasePlugin(Phase, Generic[StepDataT, PluginReturnValueT]):
         else:
             raise tmt.utils.GeneralError('Either data or raw data must be given.')
 
+        # Create masked versions for logging to hide sensitive data
+        masked_data = f"<{data.__class__.__name__}>" if data is not None else None
+        masked_raw_data = f"<{type(raw_data).__name__}>" if raw_data is not None else None
+
         step.debug(
-            f'{cls.__name__}.delegate(step={step}, data={data}, raw_data={raw_data})', level=3
+            f'{cls.__name__}.delegate(step={step}, data={masked_data}, '
+            f'raw_data={masked_raw_data})',
+            level=3,
         )
 
         # Filter matching methods, pick the one with the lowest order

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1192,19 +1192,22 @@ class GuestData(SerializableContainer):
             if value == self.default(key):
                 continue
 
+            # Mask sensitive fields before displaying
+            display_value = tmt.utils.mask_sensitive_data({key: value}).get(key, value)
+
             # TODO: it seems tmt.utils.format() needs a key, and logger.info()
             # does not accept already formatted string.
-            if isinstance(value, (list, tuple)):
-                printable_value = fmf.utils.listed(value)
+            if isinstance(display_value, (list, tuple)):
+                printable_value = fmf.utils.listed(display_value)
 
-            elif isinstance(value, dict):
-                printable_value = tmt.utils.format_value(value)
+            elif isinstance(display_value, dict):
+                printable_value = tmt.utils.format_value(display_value)
 
-            elif isinstance(value, tmt.hardware.Hardware):
-                printable_value = tmt.utils.dict_to_yaml(value.to_spec())
+            elif isinstance(display_value, tmt.hardware.Hardware):
+                printable_value = tmt.utils.dict_to_yaml(display_value.to_spec())
 
             else:
-                printable_value = str(value)
+                printable_value = str(display_value)
 
             logger.info(key_to_option(key).replace('-', ' '), printable_value, color='green')
 

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -985,7 +985,24 @@ EOF
                     },
                 ]
 
-            logger.debug('mrack request', req, level=4)
+            # Create a masked version for logging
+            masked_req = req.copy()
+            if masked_req.get('ks_append'):
+                masked_ks_append = []
+                for ks_item in masked_req['ks_append']:
+                    if (
+                        isinstance(ks_item, str)
+                        and 'auth.json' in ks_item
+                        and host.bootc_credentials
+                    ):
+                        # Mask JSON credentials in kickstart using utility function
+                        masked_ks_item = tmt.utils.mask_sensitive_data(ks_item)
+                        masked_ks_append.append(masked_ks_item)
+                    else:
+                        masked_ks_append.append(ks_item)
+                masked_req['ks_append'] = masked_ks_append
+
+            logger.debug('mrack request', masked_req, level=4)
 
             logger.info('whiteboard', host.whiteboard, 'green')
 


### PR DESCRIPTION
Implement centralized masking utility to prevent secrets like passwords, tokens, and registry credentials from appearing in logs and debug output.

- Add mask_sensitive_data() utility function supporting dict and string masking
- Mask sensitive fields in step data logging, guest provision display, and Beaker mrack requests
- Ensure bootc registry secrets are properly masked in kickstart files

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
