### PR TITLE
Enable the `avc` check for `centos-stream` as well

### DIFF
--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -10,13 +10,6 @@ environment:
 
 adjust:
   - check: []
-    when: distro == centos-stream
-    because:
-        fresh container-selinux packages are not yet available for centos-stream
-        https://gitlab.com/redhat/centos-stream/rpms/container-selinux/-/merge_requests/149
-        https://gitlab.com/redhat/centos-stream/rpms/container-selinux/-/merge_requests/148
-
-  - check: []
     when: initiator is not defined or initiator != packit
     because:
         we don't want to run the avc check for local testing as it


### PR DESCRIPTION
The fresh `container-selinux` with the `avc` fix should now be available for both `centos-stream-9` and `centos-stream-10`:

* https://gitlab.com/redhat/centos-stream/rpms/container-selinux/-/merge_requests/151
* https://gitlab.com/redhat/centos-stream/rpms/container-selinux/-/merge_requests/150

Let's enable the `avc` check across all supported distros.