### PR TITLE
Use a symlink for testcloud local images

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1024,10 +1024,7 @@ class GuestTestcloud(tmt.GuestSsh):
             image_path = Path(self.image_url.removeprefix("file://"))
             # We should not symlink any supported formats, e.g. the `.xz`
             # does an extract step that would be skip if we make the symlink.
-            # TODO: Maybe more suffixes are desired
-            # Note: we are assuming selinux and other preparations are done
-            #  by the user.
-            if image_path.suffixes[-1] in (".qcow2",):
+            if image_path.suffixes and image_path.suffixes[-1] in (".qcow2",):
                 # Create a symlink in the testcloud STORE_DIR and make sure
                 # it is always updated to the requested version.
                 image_symlink = self.testcloud_image_dirpath / image_path.name


### PR DESCRIPTION
Prompted by @cgwalters:

> I'm trying to use tmt with the (local) virtual provisioner with a locally generated disk:
> ```yaml
> provision:
>   how: virtual
>    # Build via `./tests/build.sh`
>    image: $@{test_disk_image}
> execute:
>   how: tmt
> ```
>
> However testcloud copies this disk image over to `/var/tmp/tmt/testcloud/images`...and then never looks for any changes. That's burned me badly a few times.

It seems to me that instead of implementing this in the testcloud, it would be better handled on `tmt` side.

Relates-to https://github.com/teemtee/testcloud/issues/17

---

Pull Request Checklist

* [x] implement the feature
