### PR TITLE
Do not install `yq` if already present

### DIFF
--- a/plans/friends/main.fmf
+++ b/plans/friends/main.fmf
@@ -15,5 +15,5 @@ prepare:
     # as root?
   - how: shell
     script:
-      - pip3 install --user yq || pip3 install yq
+      - command -v yq || pip3 install --user yq || pip3 install yq
       - yq --help

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -18,7 +18,7 @@ prepare+:
       # have to run as root to do that, and who's running tmt test suite
       # as root?
       #
-      - pip3 install --user yq || pip3 install yq
+      - command -v yq || pip3 install --user yq || pip3 install yq
       - yq --help
 
 # Use the internal executor


### PR DESCRIPTION
This is a blocker for #4087.

Basically because we are referencing the tmt repo itself in the tests, some of the tests are running steps from the `main` branch in this case
https://github.com/teemtee/tmt/blob/b19b58c55eabfe5bd30fe26a33b7452c9d64fb1e/plans/main.fmf#L13-L22
even if I delete those in #4087 because it is taking the `main` ref instead of the current ref.

For now a quick workaround is to first merge this in `main` to avoid installing `yq` if already present and then delete it later in #4087.