### PR TITLE
Polish artifact provider ID naming and API

### DIFF
--- a/tests/unit/artifact/test_base.py
+++ b/tests/unit/artifact/test_base.py
@@ -15,8 +15,8 @@ class MockArtifactInfo(ArtifactInfo):
 
 
 class MockProvider(ArtifactProvider[MockArtifactInfo]):
-    def _parse_artifact_id(self, artifact_id: str) -> str:
-        return artifact_id.split(":", 1)[1]
+    def _extract_provider_id(self, raw_provider_id: str) -> str:
+        return raw_provider_id.split(":", 1)[1]
 
     def list_artifacts(self):
         yield MockArtifactInfo(_raw_artifact={})
@@ -26,7 +26,7 @@ class MockProvider(ArtifactProvider[MockArtifactInfo]):
 
 
 def test_filter_artifacts(root_logger):
-    provider = MockProvider(root_logger, "mock:123")
+    provider = MockProvider("mock:123", root_logger)
 
     artifacts = list(provider._filter_artifacts([re.compile("mock")]))
     assert artifacts == []
@@ -34,7 +34,7 @@ def test_filter_artifacts(root_logger):
 
 def test_download_artifacts(tmp_path, root_logger):
     guest = MagicMock()
-    provider = MockProvider(root_logger, "mock:123")
+    provider = MockProvider("mock:123", root_logger)
 
     paths = provider.download_artifacts(guest, tmp_path, [])
 

--- a/tests/unit/artifact/test_koji.py
+++ b/tests/unit/artifact/test_koji.py
@@ -8,18 +8,20 @@ from tmt.steps.prepare.artifact.providers.koji import KojiArtifactProvider
 @pytest.fixture
 def koji_provider(root_logger):
     """Return a KojiArtifactProvider with a stable build ID for testing."""
-    return KojiArtifactProvider(root_logger, "koji.build:12345")
+    return KojiArtifactProvider("koji.build:12345", root_logger)
 
 
 # --- Tests ---
-def test_parse_artifact_id_valid(koji_provider):
-    assert koji_provider.artifact_id == "12345"
+def test_parse_artifact_provider_id_valid(koji_provider):
+    assert koji_provider.id == "12345"
 
 
-@pytest.mark.parametrize("invalid_artifact_id", ["koji.task:111", "koji.build:abc"])
-def test_parse_artifact_id_invalid(root_logger, invalid_artifact_id):
-    with pytest.raises(ValueError, match="Invalid artifact ID format"):
-        KojiArtifactProvider(root_logger, invalid_artifact_id)
+@pytest.mark.parametrize("invalid_artifact_provider_id", ["koji.task:111", "koji.build:abc"])
+def test_parse_artifact_provider_id_invalid(root_logger, invalid_artifact_provider_id):
+    with pytest.raises(
+        ValueError, match=f"Invalid Koji identifier: '{invalid_artifact_provider_id}'."
+    ):
+        KojiArtifactProvider(invalid_artifact_provider_id, root_logger)
 
 
 def test_call_api_success(koji_provider):
@@ -34,7 +36,7 @@ def test_fetch_rpms_populates_list(root_logger):
     rpm_data = [{"name": "foo", "version": "1.x", "release": "1", "nvr": "foo-1.x-1"}]
 
     with patch.object(KojiArtifactProvider, "_call_api", return_value=rpm_data) as mock_call:
-        provider = KojiArtifactProvider(root_logger, "koji.build:123")
+        provider = KojiArtifactProvider("koji.build:123", root_logger)
         assert provider._rpm_list == rpm_data
         mock_call.assert_called_once_with("listBuildRPMs", 123)
 

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -48,8 +48,8 @@ class ArtifactInfo(ABC):
         return self.id
 
 
-#: A type of an artifact identifier.
-ArtifactId: TypeAlias = str
+#: A type of an artifact provider identifier.
+ArtifactProviderId: TypeAlias = str
 
 #: A type variable representing subclasses of :py:class:`ArtifactInfo`
 #: containers.
@@ -68,23 +68,24 @@ class ArtifactProvider(ABC, Generic[ArtifactInfoT]):
     """
 
     #: Identifier of this artifact provider. It is valid and unique
-    #: in the domain of this provider.
-    artifact_id: ArtifactId
+    #: in the domain of this provider. ``koji.build:12345``. URL for a
+    #: repository, and so on.
+    id: ArtifactProviderId
 
-    def __init__(self, logger: tmt.log.Logger, artifact_id: str):
+    def __init__(self, raw_provider_id: str, logger: tmt.log.Logger):
         self.logger = logger
-        self.artifact_id = self._parse_artifact_id(
-            artifact_id
-        )  # Identifier for the source, e.g. 'koji.build:12345', URL for repository
 
+        self.id = self._extract_provider_id(raw_provider_id)
+
+    @classmethod
     @abstractmethod
-    def _parse_artifact_id(self, artifact_id: str) -> ArtifactId:
+    def _extract_provider_id(cls, raw_provider_id: str) -> ArtifactProviderId:
         """
-        Parse and validate the artifact identifier.
+        Parse and validate the artifact provider identifier.
 
-        :param artifact_id: artifact identifier to parse and validate.
-        :returns: parsed identifier specific to this provider.
-        :raises ValueError: when the artifact identifier is invalid.
+        :param raw_provider_id: artifact provider identifier to parse and validate.
+        :returns: parsed identifier specific to this provider class.
+        :raises ValueError: when the artifact provider identifier is invalid.
         """
 
         raise NotImplementedError


### PR DESCRIPTION
* "artifact identifier" and "artifact ID" are, in fact, artifact *provider* identifier/ID - fixing naming of `__init__()` and `ArtifactId`,
* `artifact_id` parameter of `__init__()` is rather `raw_provider_id`,
* swapped the order of `logger` and `raw_provider_id`, we place `logger` as the last parameter,
* renamed `_parse_artifact_id` to `_extract_provider_id`, better reflects the purpose,
* `_extract_provider_id` seems doing well as classmethod, no teptation to access `self`,
* and `ArtifactProvider.artifact_id` is rather `ArtifactProvider.id`.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation