### PR TITLE
Allow providing multiple ssh keys in `connect`

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2255,6 +2255,7 @@ class GuestSshData(GuestData):
         default_factory=list,
         option=('-k', '--key'),
         metavar='PATH',
+        multiple=True,
         help="""
              Private key to use as SSH identity for key-based
              authentication.


### PR DESCRIPTION
Fix #1491.

Pull Request Checklist

* [x] implement the feature
* [x] include a release note