### PR TITLE
Keep the `url` schema open to files as well

### DIFF
--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -106,7 +106,6 @@ definitions:
     # seems like we have to repeat properties schemas here as well.
     properties:
       url:
-        # https://github.com/teemtee/tmt/issues/1258
         type: string
 
       ref:
@@ -240,7 +239,6 @@ definitions:
     # seems like we have to repeat properties schemas here as well.
     properties:
       url:
-        # https://github.com/teemtee/tmt/issues/1258
         type: string
 
       ref:
@@ -271,7 +269,6 @@ definitions:
     minProperties: 1
     properties:
       url:
-        # https://github.com/teemtee/tmt/issues/1258
         type: string
 
       ref:


### PR DESCRIPTION
As discussed in #1258, the `url` format for git cloning should support local paths as well. From the `fmf` definition:

    Git repository containing the metadata tree. Use any format
    acceptable by the git clone command.

So there is no pending action. Let's remove the todo links.

Resolve #1258.

Pull Request Checklist

* [x] modify the json schema