### PR TITLE
Use `BeakerLib Libraries` for the library examples

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -416,7 +416,8 @@ at https://github.com/psss/python-nitrate
 Configuration and guide for setting up pylero can be found
 at https://github.com/RedHatQE/pylero
 
-Test Libraries
+
+BeakerLib Libraries
 ------------------------------------------------------------------
 
 In order to prevent unnecessary test code duplication it makes


### PR DESCRIPTION
As suggested in #1884 the generic name seems to be a bit confusing. Let's explicitly include `BeakerLib` in the section name to make the scope obvious.

Fix #1884.

Pull Request Checklist

* [x] write the documentation