### PR TITLE
Fix broken test after #3157

### DIFF
--- a/tests/plan/show/test.sh
+++ b/tests/plan/show/test.sh
@@ -4,7 +4,7 @@
 function dump_fmf_id_block
 {
     typeset output=${1?"*** output file"}
-    typeset lineno=$(cat -n $output | grep -E 'fmf-id' | awk '{print $1}')
+    typeset lineno=$(cat -n $output | grep -E 'fmf-id' | grep -v false | awk '{print $1}')
     sed -n "$lineno,$"p $output
 }
 
@@ -79,7 +79,7 @@ rlJournalStart
 
     rlPhaseStartTest "Show a plan with -vvv in work tree"
         local_repo="$show_dir3/tmt"
-        plan="/plans/sanity/lint"
+        plan="/plans/sanity/with-tmt"
         worktree="TREE"
         ref="myref"
 


### PR DESCRIPTION
See #4166 for details why the test broke and the issue will track the improvement to make it less brittle.

Note the new plan lists multiple plans, one without an `fmf-id` so make sure the grep ignores `fmf-id` set to `false`, breaking getting the fmf id block line number.

