### PR TITLE
Refactor artifact providers from iterator to cached property pattern

### DIFF
--- a/tests/unit/artifact/test_base.py
+++ b/tests/unit/artifact/test_base.py
@@ -18,8 +18,9 @@ class MockProvider(ArtifactProvider[MockArtifactInfo]):
     def _extract_provider_id(self, raw_provider_id: str) -> str:
         return raw_provider_id.split(":", 1)[1]
 
-    def list_artifacts(self):
-        yield MockArtifactInfo(_raw_artifact={})
+    @property
+    def artifacts(self):
+        return [MockArtifactInfo(_raw_artifact={})]
 
     def _download_artifact(self, artifact, guest, destination):
         destination.write_text("ok")

--- a/tests/unit/artifact/test_koji.py
+++ b/tests/unit/artifact/test_koji.py
@@ -6,15 +6,13 @@ from tmt.steps.prepare.artifact.providers.koji import KojiArtifactProvider
 @pytest.mark.integration
 def test_koji_valid_build(root_logger):
     provider = KojiArtifactProvider("koji.build:2829512", root_logger)
-    rpms = list(provider.list_artifacts())
-    assert len(rpms) == 13
+    assert len(provider.artifacts) == 13
 
 
 @pytest.mark.integration
 def test_koji_valid_nvr(root_logger):
     provider = KojiArtifactProvider("koji.nvr:tmt-1.58.0-1.fc43", root_logger)
-    rpms = list(provider.list_artifacts())
-    assert len(rpms) == 13
+    assert len(provider.artifacts) == 13
     assert provider.build_id == 2829512  # Known build ID for this NVR
 
 
@@ -30,9 +28,8 @@ def test_koji_invalid_nvr(root_logger):
 @pytest.mark.integration
 def test_koji_valid_task_id_actual_build(root_logger):
     provider = KojiArtifactProvider("koji.task:137451383", root_logger)
-    rpms = list(provider.list_artifacts())
     assert provider.build_id == 2829512  # Known build ID for this task
-    assert len(rpms) == 13
+    assert len(provider.artifacts) == 13
 
 
 @pytest.mark.integration
@@ -41,10 +38,9 @@ def test_koji_valid_task_id_scratch_build(root_logger):
     tasks = provider._get_task_children(137705547)
     assert len(tasks) == 13
     assert 137705547 in tasks  # The parent task itself should be included
-    rpms = list(provider.list_artifacts())
     assert provider.build_id is None
     assert (
-        rpms[0]._raw_artifact['url']
+        provider.artifacts[0]._raw_artifact['url']
         == 'https://kojipkgs.fedoraproject.org/work/tasks/5553/137705553/python-scikit-build-core-0.11.5-5.fc44.src.rpm'
     )
-    assert len(rpms) == 2
+    assert len(provider.artifacts) == 2

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -3,7 +3,8 @@ Abstract base class for artifact providers.
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
+from functools import cached_property
 from re import Pattern
 from shlex import quote
 from typing import Any, Generic, Optional, TypeVar
@@ -90,10 +91,17 @@ class ArtifactProvider(ABC, Generic[ArtifactInfoT]):
 
         raise NotImplementedError
 
+    @cached_property
     @abstractmethod
-    def list_artifacts(self) -> Iterator[ArtifactInfoT]:
+    def artifacts(self) -> Sequence[ArtifactInfoT]:
         """
-        List all artifacts available from this provider.
+        Collect all artifacts available from this provider.
+
+        The method is left for derived classes to implement with respect
+        to the actual artifact provider they implement. The list of
+        artifacts will be cached, and is treated as read-only.
+
+        :returns: a list of provided artifacts.
         """
 
         raise NotImplementedError
@@ -182,7 +190,7 @@ class ArtifactProvider(ABC, Generic[ArtifactInfoT]):
         :yields: artifacts that satisfy the filtering.
         """
 
-        for artifact in self.list_artifacts():
+        for artifact in self.artifacts:
             if not any(pattern.search(artifact.id) for pattern in exclude_patterns):
                 yield artifact
 

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -2,7 +2,7 @@
 Artifact provider for repository files.
 """
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from re import Pattern
 from shlex import quote
 from typing import Optional
@@ -77,13 +77,8 @@ class RepositoryFileProvider(ArtifactProvider[RpmArtifactInfo]):
         # from the repository. Currently using an empty list as a temporary solution.
         self._rpm_list = []
 
-    def list_artifacts(self) -> Iterator[RpmArtifactInfo]:
-        """
-        List all RPMs available from the repository.
-
-        Note: This requires the repository to be installed and queried first,
-        which is handled by the ``fetch_contents`` method.
-        """
+    @property
+    def artifacts(self) -> Sequence[RpmArtifactInfo]:
         raise NotImplementedError
 
     def _download_artifact(


### PR DESCRIPTION
The changes convert the artifact provider interface from using `list_artifacts()` generators to artifacts cached properties that return sequences. This eliminates the need for the intermediate `rpm_iterator` abstraction and simplifies the API by providing direct access to materialized artifact lists rather than requiring iteration.

No matter how many generators we add, providers need to store the collection of artifacts - the other option is to read them from API every item their list is requested. Therefore `artifacts` stores them, and it would remain the single place where their list is stored, the rest of code should avoid copying this list.

* replace `list_artifacts()` method with `artifacts` cached property
* remove abstract `rpm_iterator` property from `KojiArtifactProvider`

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation