### PR TITLE
Add a Fedora integration plan, require `yq` in tests

### DIFF
--- a/plans/friends/fedora.fmf
+++ b/plans/friends/fedora.fmf
@@ -1,0 +1,18 @@
+summary: Fedora integration plan
+
+description:
+    Execute the basic set of functionality tests to ensure that
+    the Fedora build is working as expected.
+
+link:
+  - relates: https://src.fedoraproject.org/rpms/tmt
+    note: this plan is referenced from the dist git repo
+
+discover:
+    how: fmf
+    url: https://github.com/teemtee/tmt
+    ref: fedora
+    filter: "tier:1"
+
+execute:
+    how: tmt

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -2,15 +2,6 @@
 provision:
     how: local
 
-prepare+:
-  # Install jq and yq for cleaner tests, and required make
-  - how: install
-    package:
-      - jq
-      - yq
-      - make
-      - python3-pip
-
 # Use the internal executor
 execute:
     how: tmt

--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -2,7 +2,7 @@ test: ./test.sh
 framework: beakerlib
 contact: Petr Šplíchal <psplicha@redhat.com>
 tier: 2
-require: [tmt]
+require: [tmt, yq]
 check: [avc]
 duration: 10m
 environment:


### PR DESCRIPTION
Add a new friends plan `/fedora` to be used for verifying koji builds before releasing them in Fedora. Instead of maintaining it in the dist-git branches, let's store it in the main `tmt` repo and import it as a remote plan from there.

Also move the `yq` package requirement directly to the test metadata as it simplifies the `prepare` step and allows to more easily develop individual tests in a `tmt try` session (each test brings the required packages automatically).

Pull Request Checklist

* [x] extend the test coverage