### PR TITLE
Rename `ansible()` to `run_ansible_playbook()`

### DIFF
--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -257,7 +257,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
                 else:
                     playbook_root, playbook = normalize_local_playbook(lowercased_playbook)
 
-                output = guest.ansible(
+                output = guest.run_ansible_playbook(
                     playbook,
                     playbook_root=playbook_root,
                     extra_args=self.data.extra_args,

--- a/tmt/steps/prepare/feature/__init__.py
+++ b/tmt/steps/prepare/feature/__init__.py
@@ -214,7 +214,7 @@ class FeatureBase(tmt.utils.Common):
             )
 
         logger.info(f'{op.capitalize()} {cls.FEATURE_NAME.upper()}')
-        guest.ansible(playbook_path)
+        guest.run_ansible_playbook(playbook_path)
 
 
 class ToggleableFeature(FeatureBase):

--- a/tmt/steps/prepare/feature/environment_profile.py
+++ b/tmt/steps/prepare/feature/environment_profile.py
@@ -63,4 +63,4 @@ class Profile(Feature):
     def enable(cls, guest: Guest, value: str, logger: tmt.log.Logger) -> None:
         logger.info('Guest profile', value)
 
-        guest.ansible(AnsibleCollectionPlaybook(f'{value}.{PLAYBOOK_NAME}'))
+        guest.run_ansible_playbook(AnsibleCollectionPlaybook(f'{value}.{PLAYBOOK_NAME}'))

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1835,7 +1835,7 @@ class Guest(
 
         raise NotImplementedError
 
-    def ansible(
+    def run_ansible_playbook(
         self,
         playbook: AnsibleApplicable,
         playbook_root: Optional[Path] = None,


### PR DESCRIPTION
In order to prevent collision with the newly introduced `ansible` key for generating ansible inventories, let's use more unique name for the method.

Fix #4150.

Pull Request Checklist

* [x] implement the feature