### PR TITLE
Missing error message during polarion test export

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -10,6 +10,10 @@ tmt-1.61.0
 Pending tests are now also exported to Polarion thanks to no
 longer missing test case ids in the ``results.yaml``.
 
+Polarion export plugin now fails properly when exporting an fmf tree that
+is not part of a git repository and when there are unsubmitted changes.
+Also allowing the export when ``--ignore-git-validation`` is passed.
+
 
 tmt-1.60.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
During export to Polarion there was no error message when an fmf tree is not part of any git repository. Adding this message and including functionality related to ignore-git-validation, from now it will be possible to export with local repository for both nitrate and polarion test export, intended for testing with dry mode but possible to run with actual export as well.

Fixes #4175 

Pull Request Checklist

* [x] implement the feature
* [x] include a release note
