### PR TITLE
Special operator for `boot.method` HW requirement

### DIFF
--- a/tests/unit/test_hardware.py
+++ b/tests/unit/test_hardware.py
@@ -181,7 +181,7 @@ FULL_HARDWARE_REQUIREMENTS = """
         pool: "!= foo.*"
         panic-watchdog: True
     boot:
-        method: bios
+        method: "!= bios"
     compatible:
         distro:
             - rhel-7
@@ -296,7 +296,7 @@ def test_parse_maximal_constraint() -> None:
           - and:
               - beaker.pool: '!= foo.*'
               - beaker.panic-watchdog: == True
-          - boot.method: contains bios
+          - boot.method: not contains exclusive bios
           - and:
               - compatible.distro: contains rhel-7
               - compatible.distro: contains rhel-8
@@ -419,3 +419,20 @@ def test_report_support(
         message=MATCH(r"warn: Hardware requirement 'memory: != 4 GB' is not supported."),
         levelno=logging.WARNING,
     )
+
+
+@pytest.mark.parametrize(
+    ('operator', 'left', 'right', 'expected'),
+    [
+        (tmt.hardware.not_contains, ['foo'], 'foo', False),
+        (tmt.hardware.not_contains, ['foo', 'bar'], 'foo', False),
+        (tmt.hardware.not_contains, ['foo'], 'bar', True),
+        (tmt.hardware.not_contains_exclusive, ['foo'], 'foo', False),
+        (tmt.hardware.not_contains_exclusive, ['foo', 'bar'], 'foo', True),
+        (tmt.hardware.not_contains_exclusive, ['foo'], 'bar', True),
+    ],
+)
+def test_operators(
+    operator: tmt.hardware.OperatorHandlerType, left: Any, right: Any, expected: bool
+) -> None:
+    assert operator(left, right) is expected

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -82,14 +82,18 @@ class Operator(enum.Enum):
     LTE = '<='
     LT = '<'
 
+    #: Needle must be present in the haystack.
     CONTAINS = 'contains'
+    #: Needle must not be present in the haystack.
     NOTCONTAINS = 'not contains'
+    #: Needle may be present in the haystack as long it is not the only item.
+    NOTCONTAINS_EXCLUSIVE = 'not contains exclusive'
 
 
 INPUTABLE_OPERATORS = [
     operator
     for operator in Operator.__members__.values()
-    if operator not in (Operator.CONTAINS, Operator.NOTCONTAINS)
+    if operator not in (Operator.CONTAINS, Operator.NOTCONTAINS, Operator.NOTCONTAINS_EXCLUSIVE)
 ]
 
 
@@ -275,6 +279,24 @@ def not_contains(haystack: list[str], needle: str) -> bool:
     return needle not in haystack
 
 
+def not_contains_exclusive(haystack: list[str], needle: str) -> bool:
+    """
+    Find out whether an item is in the given list.
+
+    .. note::
+
+       A variant of :py:func:`not_contains`: an item may be present,
+       as long as other items are present.
+
+    :param haystack: container to examine.
+    :param needle: item to look for in ``haystack``.
+    :returns: ``True`` if ``needle`` is **not** in ``haystack`` or if
+        ``needle`` is in ``haystack`` but other items are there as well.
+    """
+
+    return haystack != [needle]
+
+
 OPERATOR_SIGN_TO_OPERATOR = {
     '=': Operator.EQ,
     '==': Operator.EQ,
@@ -303,6 +325,7 @@ OPERATOR_TO_HANDLER: dict[Operator, OperatorHandlerType] = {
     Operator.NOTMATCH: not_match,
     Operator.CONTAINS: operator.contains,
     Operator.NOTCONTAINS: not_contains,
+    Operator.NOTCONTAINS_EXCLUSIVE: not_contains_exclusive,
 }
 
 
@@ -1169,7 +1192,7 @@ def _parse_boot(spec: Spec) -> BaseConstraint:
             constraint.change_operator(Operator.CONTAINS)
 
         elif constraint.operator == Operator.NEQ:
-            constraint.change_operator(Operator.NOTCONTAINS)
+            constraint.change_operator(Operator.NOTCONTAINS_EXCLUSIVE)
 
         group.constraints += [constraint]
 


### PR DESCRIPTION
`boot.method: != foo` cannot use the simple `not contains` operator, because `foo` *can* be allowed on the list of supported boot methods, as long as other boot methods are supported as well. Provisioning can than chose the right method:

```
!= bios + [uefi]       -> allowed, obviously
!= bios + [bios]       -> not allowed, there is no other option
!= bios + [bios, uefi] -> allowed, plugin can chose uefi
```

Therefor adding new operator and teaching `boot.method` parsing to use it.

Related https://issues.redhat.com/browse/TFT-3558, and https://gitlab.com/testing-farm/artemis/-/merge_requests/1466/

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage