### PR TITLE
Drop custom label in artemis and mrack status updates

### DIFF
--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -602,8 +602,7 @@ class GuestArtemis(tmt.GuestSsh):
 
             # Log state change on new line when it changes
             if state != previous_state:
-                status_msg = f"[{self.name}({self.guestname})] state: {state}"
-                self.info(status_msg, color=state_color)
+                self.info('state', state, color=state_color)
                 previous_state = state
 
             if state == 'error':

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1561,8 +1561,7 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
 
             # Log state change on new line when it changes
             if state != previous_state:
-                status_msg = f"({self.job_id}) status: {state}"
-                self.info(status_msg, color=state_color)
+                self.info('status', state, color=state_color)
                 previous_state = state
 
             if state in {"Error, Aborted", "Cancelled"}:


### PR DESCRIPTION
When there is just a single `provision` phase, there is no need for a label to distinguish guests apart. When there are more, they get their own logger which prepends phase/guest name at the beginning of each line. There is no need to add phase/guest name to status messages, and only status messages, tmt will handle this perfectly out of the box.

Let's not invent ad hoc labels.

Introduced in #4038.

Pull Request Checklist

* [x] implement the feature