### PR TITLE
Fix the forgotten template in `/tests/discover/link`

### DIFF
--- a/tests/discover/link/main.fmf
+++ b/tests/discover/link/main.fmf
@@ -1,4 +1,5 @@
-summary: Verify that this and that works like this
+summary: Both single and multiple links work
 description:
-    Include a bit longer description which would help a stranger
-    or your future self to quickly grasp the purpose of the test.
+    Ensure that both a single string and a list of strings can be
+    provided in the `link` key or the `--link` option and that the
+    filter works as expected.


### PR DESCRIPTION
Add a reasonable summary and description about the test. This slipped through in #4146.