### PR TITLE
Add Repository Class with Tests

### DIFF
--- a/tests/unit/artifact/test_repository.py
+++ b/tests/unit/artifact/test_repository.py
@@ -58,25 +58,27 @@ def temp_repo_file_no_ext(tmp_path):
     return repo_file
 
 
-def test_init_from_content():
+def test_init_from_content(root_logger):
     """Test successful initialization from a content string"""
-    repo = Repository.from_content(name="from-content", content=VALID_REPO_CONTENT)
+    repo = Repository.from_content(
+        name="from-content", content=VALID_REPO_CONTENT, logger=root_logger
+    )
     assert repo.name == "from-content"
     assert repo.content == VALID_REPO_CONTENT
     assert repo.repo_ids == EXPECTED_REPO_IDS
     assert repo.filename == "from-content.repo"
 
 
-def test_init_from_file(temp_repo_file):
+def test_init_from_file(temp_repo_file, root_logger):
     """Test successful initialization from a local file path"""
-    repo = Repository.from_file_path(file_path=temp_repo_file)
+    repo = Repository.from_file_path(file_path=temp_repo_file, logger=root_logger)
     assert repo.name == "docker-ce"
     assert repo.content == VALID_REPO_CONTENT
     assert repo.repo_ids == EXPECTED_REPO_IDS
 
 
 @patch('tmt.steps.prepare.artifact.providers.tmt.utils.retry_session')
-def test_init_from_url(mock_retry_session):
+def test_init_from_url(mock_retry_session, root_logger):
     """Test successful initialization from a URL"""
     mock_session = MagicMock()
     mock_response = MagicMock()
@@ -86,7 +88,7 @@ def test_init_from_url(mock_retry_session):
     mock_retry_session.return_value.__enter__.return_value = mock_session
 
     repo_url = "https://download.docker.com/linux/centos/docker-ce.repo"
-    repo = Repository.from_url(url=repo_url)
+    repo = Repository.from_url(url=repo_url, logger=root_logger)
 
     assert repo.name == "docker-ce"
     assert repo.content == VALID_REPO_CONTENT
@@ -95,10 +97,10 @@ def test_init_from_url(mock_retry_session):
 
 
 @patch('tmt.steps.prepare.artifact.providers.tmt.utils.retry_session')
-def test_name_derivation(mock_retry_session, temp_repo_file):
+def test_name_derivation(mock_retry_session, temp_repo_file, root_logger):
     """Test the logic for deriving the repository name"""
     # Provided name takes precedence
-    repo = Repository.from_content(name="explicit-name", content="[foo]")
+    repo = Repository.from_content(name="explicit-name", content="[foo]", logger=root_logger)
     assert repo.name == "explicit-name"
 
     # Mock the session for the URL test
@@ -110,52 +112,54 @@ def test_name_derivation(mock_retry_session, temp_repo_file):
     mock_retry_session.return_value.__enter__.return_value = mock_session
 
     # Name derived from URL
-    repo = Repository.from_url(url="http://a.b/c/docker-ce.repo")
+    repo = Repository.from_url(url="http://a.b/c/docker-ce.repo", logger=root_logger)
     assert repo.name == "docker-ce"
 
     # Name derived from file path
-    repo = Repository.from_file_path(file_path=temp_repo_file)
+    repo = Repository.from_file_path(file_path=temp_repo_file, logger=root_logger)
     assert repo.name == "docker-ce"
 
 
-def test_repo_id_parsing():
+def test_repo_id_parsing(root_logger):
     """Test the parsing of repo IDs from content"""
     # Valid content with multiple sections
-    repo = Repository.from_content(name="valid", content=VALID_REPO_CONTENT)
+    repo = Repository.from_content(name="valid", content=VALID_REPO_CONTENT, logger=root_logger)
     assert repo.repo_ids == EXPECTED_REPO_IDS
 
     # Content with no sections (empty)
     with pytest.raises(GeneralError, match="No repository sections found"):
-        Repository.from_content(name="no-sections", content="")
+        Repository.from_content(name="no-sections", content="", logger=root_logger)
 
     # Content with options but no section header
     with pytest.raises(GeneralError, match="No repository sections found"):
-        Repository.from_content(name="no-sections", content=NO_SECTION_CONTENT)
+        Repository.from_content(name="no-sections", content=NO_SECTION_CONTENT, logger=root_logger)
 
     # Malformed content should also raise an error
     with pytest.raises(GeneralError, match=r"The .repo file may be malformed"):
-        Repository.from_content(name="malformed", content=MALFORMED_REPO_CONTENT)
+        Repository.from_content(
+            name="malformed", content=MALFORMED_REPO_CONTENT, logger=root_logger
+        )
 
 
 @patch('tmt.steps.prepare.artifact.providers.tmt.utils.retry_session')
-def test_failed_url_fetch(mock_retry_session):
+def test_failed_url_fetch(mock_retry_session, root_logger):
     """Test that a failed URL fetch raises an error"""
     mock_session = MagicMock()
     mock_session.get.side_effect = requests.RequestException("Connection failed")
     mock_retry_session.return_value.__enter__.return_value = mock_session
 
     with pytest.raises(GeneralError, match="Failed to fetch repository content"):
-        Repository.from_url(url="http://example.com/invalid.repo")
+        Repository.from_url(url="http://example.com/invalid.repo", logger=root_logger)
 
 
-def test_nonexistent_file():
+def test_nonexistent_file(root_logger):
     """Test that a non-existent file path raises an error"""
     with pytest.raises(GeneralError, match="Failed to read repository file"):
-        Repository.from_file_path(file_path=Path("/no/such/file.repo"))
+        Repository.from_file_path(file_path=Path("/no/such/file.repo"), logger=root_logger)
 
 
 @patch('tmt.steps.prepare.artifact.providers.tmt.utils.retry_session')
-def test_url_trailing_slash(mock_retry_session):
+def test_url_trailing_slash(mock_retry_session, root_logger):
     """Test URL with trailing slash"""
     mock_session = MagicMock()
     mock_response = MagicMock()
@@ -164,12 +168,12 @@ def test_url_trailing_slash(mock_retry_session):
     mock_session.get.return_value = mock_response
     mock_retry_session.return_value.__enter__.return_value = mock_session
 
-    repo = Repository.from_url(url="https://example.com/repo/")
+    repo = Repository.from_url(url="https://example.com/repo/", logger=root_logger)
     assert repo.name == "repo"
 
 
 @patch('tmt.steps.prepare.artifact.providers.tmt.utils.retry_session')
-def test_url_no_repo_ext(mock_retry_session):
+def test_url_no_repo_ext(mock_retry_session, root_logger):
     """Test URL without .repo extension"""
     mock_session = MagicMock()
     mock_response = MagicMock()
@@ -178,34 +182,34 @@ def test_url_no_repo_ext(mock_retry_session):
     mock_session.get.return_value = mock_response
     mock_retry_session.return_value.__enter__.return_value = mock_session
 
-    repo = Repository.from_url(url="https://example.com/docker-ce")
+    repo = Repository.from_url(url="https://example.com/docker-ce", logger=root_logger)
     assert repo.name == "docker-ce"
 
 
-def test_file_no_repo_ext(temp_repo_file_no_ext):
+def test_file_no_repo_ext(temp_repo_file_no_ext, root_logger):
     """Test file without .repo extension"""
-    repo = Repository.from_file_path(file_path=temp_repo_file_no_ext)
+    repo = Repository.from_file_path(file_path=temp_repo_file_no_ext, logger=root_logger)
     assert repo.name == "docker-ce"
 
 
-def test_content_no_name():
+def test_content_no_name(root_logger):
     """Test content without name raises error"""
     with pytest.raises(GeneralError, match="Repository name cannot be empty"):
-        Repository.from_content(content=VALID_REPO_CONTENT, name="")
+        Repository.from_content(content=VALID_REPO_CONTENT, name="", logger=root_logger)
 
 
 @patch('tmt.steps.prepare.artifact.providers.tmt.utils.retry_session')
-def test_invalid_url_format(mock_retry_session):
+def test_invalid_url_format(mock_retry_session, root_logger):
     """Test initialization with invalid URL format"""
     mock_session = MagicMock()
     mock_session.get.side_effect = requests.exceptions.InvalidURL("Invalid URL")
     mock_retry_session.return_value.__enter__.return_value = mock_session
 
     with pytest.raises(GeneralError, match="Failed to fetch repository content"):
-        Repository.from_url(url="invalid_url")
+        Repository.from_url(url="invalid_url", logger=root_logger)
 
 
-def test_url_no_path():
+def test_url_no_path(root_logger):
     """Test URL with no path raises error"""
     with patch(
         'tmt.steps.prepare.artifact.providers.tmt.utils.retry_session'
@@ -218,4 +222,4 @@ def test_url_no_path():
         mock_retry_session.return_value.__enter__.return_value = mock_session
 
         with pytest.raises(GeneralError, match="Could not derive repository name from URL"):
-            Repository.from_url(url="https://example.com/")
+            Repository.from_url(url="https://example.com/", logger=root_logger)

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -238,18 +238,21 @@ class Repository:
             ) from error
 
     @classmethod
-    def from_url(cls, url: str, name: Optional[str] = None) -> "Repository":
+    def from_url(
+        cls, url: str, logger: tmt.log.Logger, name: Optional[str] = None
+    ) -> "Repository":
         """
         Create a Repository instance by fetching content from a URL.
 
         :param url: The URL to fetch the repository content from.
+        :param logger: Logger to use for the operation.
         :param name: Optional name for the repository. If not provided,
             derived from the URL.
         :returns: A Repository instance.
         :raises GeneralError: If fetching or parsing fails.
         """
         try:
-            with tmt.utils.retry_session() as session:
+            with tmt.utils.retry_session(logger=logger) as session:
                 response = session.get(url)
                 response.raise_for_status()
                 content = response.text
@@ -266,11 +269,14 @@ class Repository:
         return cls(name=name, content=content)
 
     @classmethod
-    def from_file_path(cls, file_path: Path, name: Optional[str] = None) -> "Repository":
+    def from_file_path(
+        cls, file_path: Path, logger: tmt.log.Logger, name: Optional[str] = None
+    ) -> "Repository":
         """
         Create a Repository instance by reading content from a local file path.
 
         :param file_path: The local path to the repository file.
+        :param logger: Logger to use for the operation.
         :param name: Optional name for the repository. If not provided,
             derived from the file path.
         :returns: A Repository instance.
@@ -291,12 +297,13 @@ class Repository:
         return cls(name=name, content=content)
 
     @classmethod
-    def from_content(cls, content: str, name: str) -> "Repository":
+    def from_content(cls, content: str, name: str, logger: tmt.log.Logger) -> "Repository":
         """
         Create a Repository instance directly from provided content string.
 
         :param content: The string content of the repository.
         :param name: The name for the repository (required when using content).
+        :param logger: Logger to use for the operation.
         :returns: A Repository instance.
         :raises GeneralError: If the name is empty.
         """


### PR DESCRIPTION
This commit introduces the core functionality for creating and identifying `Repository` objects. The primary goal is to provide flexible initialization options while ensuring that identical repositories always resolve to the same unique ID.

**Repository Creation Methods:**
1.  **From URL:**
    -   The last segment of the URL path is treated as the filename.
    -   The repository `name` defaults to the filename but can be overridden by an explicit parameter.
    -   Handles URLs that end with or without the `.repo` extension.
2.  **From File Path:**
        -   The repository `name` is derived from the file path.
        -   An explicit `name` parameter will take precedence over the derived name.
3.  **From Content:**
        -   Requires the raw content and a `file_name` to be provided directly.
       