### PR TITLE
Use `containers-storage:` prefix only for local containers

### DIFF
--- a/tmt/steps/provision/bootc.py
+++ b/tmt/steps/provision/bootc.py
@@ -12,6 +12,7 @@ import tmt.steps.provision
 import tmt.steps.provision.testcloud
 import tmt.utils
 from tmt.container import container, field
+from tmt.package_managers.bootc import LOCALHOST_BOOTC_IMAGE_PREFIX
 from tmt.steps.provision.testcloud import GuestTestcloud
 from tmt.utils import Path
 from tmt.utils.templates import render_template
@@ -270,7 +271,7 @@ class ProvisionBootc(tmt.steps.provision.ProvisionPlugin[BootcData]):
         containerfile_parsed = render_template(containerfile_template, base_image=base_image)
         (self.phase_workdir / 'Containerfile').write_text(containerfile_parsed)
 
-        image_tag = f'localhost/tmtmodified-{self._get_id()}'
+        image_tag = f'{LOCALHOST_BOOTC_IMAGE_PREFIX}modified-{self._get_id()}'
         tmt.utils.Command(
             "podman",
             "build",
@@ -293,7 +294,7 @@ class ProvisionBootc(tmt.steps.provision.ProvisionPlugin[BootcData]):
         Build the "base" or user supplied container image
         """
 
-        image_tag = f'localhost/tmtbase-{self._get_id()}'
+        image_tag = f'{LOCALHOST_BOOTC_IMAGE_PREFIX}base-{self._get_id()}'
         self._logger.debug("Build container image.")
         tmt.utils.Command(
             "podman",


### PR DESCRIPTION
For remote registry container images, this is not needed and it actually causes issues if the image is not yet pulled on the host.

By omitting the local registry storage, the image will be pulled automatically by `podman` if not present.

Pull Request Checklist

* [x] implement the feature