### PR TITLE
Make SUPPORTED_DISTRO_PATTERNS tuple

### DIFF
--- a/tmt/steps/prepare/feature/crb.py
+++ b/tmt/steps/prepare/feature/crb.py
@@ -8,7 +8,7 @@ from tmt.steps.prepare.feature import PrepareFeatureData, ToggleableFeature, pro
 from tmt.steps.provision import Guest
 from tmt.utils import ShellScript
 
-SUPPORTED_DISTRO_PATTERNS = (
+SUPPORTED_DISTRO_PATTERNS = tuple(
     re.compile(pattern)
     for pattern in (r'Red Hat Enterprise Linux (8|9|10)', r'CentOS Stream (8|9|10)')
 )

--- a/tmt/steps/prepare/feature/fips.py
+++ b/tmt/steps/prepare/feature/fips.py
@@ -7,7 +7,7 @@ from tmt.container import container, field
 from tmt.steps.prepare.feature import PrepareFeatureData, ToggleableFeature, provides_feature
 from tmt.steps.provision import Guest
 
-SUPPORTED_DISTRO_PATTERNS = (
+SUPPORTED_DISTRO_PATTERNS = tuple(
     re.compile(pattern)
     for pattern in (r'Red Hat Enterprise Linux (8|9|10)', r'CentOS Stream (8|9|10)')
 )


### PR DESCRIPTION
~~Previously, SUPPORTED_DISTRO_PATTERNS was a shared generator. That breaks use of fips prepare feature in multiple plans within the same tmt run. Now SUPPORTED_DISTRO_PATTERS is just a list and sharing has no negative effects.~~

Updated description: Previously, SUPPORTED_DISTRO_PATTERNS was a (shared) generator. That breaks use of fips prepare feature in multiple plans within the same tmt run. Now SUPPORTED_DISTRO_PATTERS is just a tuple and sharing has no negative effects.

Consider the following plan:

```
# reproducer.fmf
summary: Test plan

prepare:
  - name: Enable FIPS mode
    how: feature
    fips: enabled

execute:
  how: tmt

discover:
  - how: shell
    tests:
      - name: sample-test
        test: echo 'hello!'

/first:

/second:
```

Previously:

```
❯ tmt run plan --name /plans/reproducer discover provision --how minute --image rhel-10.1 prepare
/var/tmp/tmt/run-001

/plans/reproducer/first
    discover
        ...
    provision
        ....
        summary: 1 guest provisioned
    prepare
        queued push task #1: push to default-0

        push task #1: push to default-0

        queued prepare task #1: essential-requires on default-0
        queued prepare task #2: Enable FIPS mode on default-0

        prepare task #1: essential-requires on default-0
        how: install
        summary: Install essential required packages
        name: essential-requires
        where: default-0
        package: /usr/bin/python3 and /usr/bin/flock

        prepare task #2: Enable FIPS mode on default-0
        how: feature
        name: Enable FIPS mode
        Enable FIPS

        queued pull task #1: pull from default-0

        pull task #1: pull from default-0

        summary: 2 preparations applied

/plans/reproducer/second
    discover
        ...
    provision
        ...
        summary: 1 guest provisioned
    prepare
        queued push task #1: push to default-0

        push task #1: push to default-0

        queued prepare task #1: essential-requires on default-0
        queued prepare task #2: Enable FIPS mode on default-0

        prepare task #1: essential-requires on default-0
        how: install
        summary: Install essential required packages
        name: essential-requires
        where: default-0
        package: /usr/bin/python3 and /usr/bin/flock

        prepare task #2: Enable FIPS mode on default-0
        how: feature
        name: Enable FIPS mode
        fail: FIPS prepare feature is supported on RHEL/CentOS-Stream 8, 9 or 10.

plan failed

The exception was caused by 1 earlier exceptions

Cause number 1:

    prepare step failed

    The exception was caused by 1 earlier exceptions

    Cause number 1:

        FIPS prepare feature is supported on RHEL/CentOS-Stream 8, 9 or 10.
```

This is because now `SUPPORTED_DISTRO_PATTERNS` is a generator now:

https://github.com/teemtee/tmt/blob/2287b15fbce130ac501db361dcaea124a915c131/tmt/steps/prepare/feature/fips.py#L10C1-L14C1
```
SUPPORTED_DISTRO_PATTERNS = (
    re.compile(pattern)
    for pattern in (r'Red Hat Enterprise Linux (8|9|10)', r'CentOS Stream (8|9|10)')
)

```

And the prepare phase of the first plan already takes the first pattern and hence there is nothing useful left for the prepare phase of the second plan.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
