### PR TITLE
Generate release notes from `tmt` stories

### DIFF
--- a/docs/release/1.60.0/3672.fmf
+++ b/docs/release/1.60.0/3672.fmf
@@ -1,0 +1,11 @@
+description:
+    tmt now supports automatic generation of Ansible inventory
+    files during the provision phase. The new
+    :ref:`/spec/plans/ansible` configuration allows users to
+    define custom inventory layouts and organize provisioned
+    guests into Ansible groups with host-specific variables. See
+    the :ref:`/spec/plans/ansible` and
+    :ref:`/spec/plans/provision/ansible` sections for
+    configuration details.
+tag: feature
+order: 10

--- a/docs/release/1.60.0/4171.fmf
+++ b/docs/release/1.60.0/4171.fmf
@@ -1,0 +1,6 @@
+description:
+    New :ref:`sprints` section has been added to the documentation
+    for contributors. It describes the overall sprint process, the
+    key sync points and provides links to progress tracking
+    boards.
+tag: doc

--- a/docs/release/1.60.0/4191.fmf
+++ b/docs/release/1.60.0/4191.fmf
@@ -1,0 +1,6 @@
+description:
+    The :ref:`/plugins/report/reportportal` report plugin now
+    supports a new ``auto-analysis`` key. This key allows users to
+    enable immediate auto-analysis of failed tests reported to
+    ReportPortal.
+tag: feature

--- a/docs/release/main.fmf
+++ b/docs/release/main.fmf
@@ -1,0 +1,1 @@
+story: Release note


### PR DESCRIPTION
One possible way how to prevent release notes conflicts could be storing them as individual `tmt` stories. The approach is similar to `towncrier` but it might bring us some other benefits:

 * naturally fits into the other git repo metadata
 * users do not have to learn a new tool, just write a description
 * optional `tag` could be used for categorization
 * and `order` for bringing interesting news more up
 * we could also use the `link` key for related stuff
 * no extra github action needed, just `make docs` as usual

If the files are named with the issue number, we could automatically include it at the end of the release note. Or we could use the `link` key for this.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note

Fix #4084.