### PR TITLE
Retry `git clone` calls in tests

### DIFF
--- a/tests/discover/distgit.sh
+++ b/tests/discover/distgit.sh
@@ -39,7 +39,7 @@ rlJournalStart
     rlPhaseStartSetup
         rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
         rlRun 'set -o pipefail'
-        rlRun "git clone https://src.fedoraproject.org/rpms/tmt.git $tmp/tmt"
+        rlWaitForCmd "git clone https://src.fedoraproject.org/rpms/tmt.git $tmp/tmt" -m 5 -d 10 -t 300 || rlDie "Unable to clone Fedora distgit repository"
         export CLONED_RPMS_TMT=$tmp/tmt
         rlRun "cp data/plans.fmf $CLONED_RPMS_TMT/plans"
         # Append existing TMT_PLUGINS content

--- a/tests/full/test.sh
+++ b/tests/full/test.sh
@@ -75,7 +75,7 @@ rlJournalStart
             rlRun "chown root:root -R ."
         else
             # Clone repo otherwise
-            rlRun "git clone https://github.com/teemtee/tmt $USER_HOME/tmt"
+            rlWaitForCmd "git clone https://github.com/teemtee/tmt $USER_HOME/tmt" -m 5 -d 10 -t 300 || rlDie "Unable to clone tmt repository"
             rlRun "pushd $USER_HOME/tmt"
             [ -n "$BRANCH" ] && rlRun "git checkout --force '$BRANCH'"
         fi

--- a/tests/libraries/local/test.sh
+++ b/tests/libraries/local/test.sh
@@ -5,7 +5,7 @@ rlJournalStart
     rlPhaseStartSetup "Prepare library"
         rlRun "libdir=\$(mktemp -d)" 0 "Create libdir directory"
         rlRun "pushd $libdir"
-        rlRun "git clone https://github.com/beakerlib/example"
+        rlWaitForCmd "git clone https://github.com/beakerlib/example" -m 5 -d 10 -t 300 || rlDie "Unable to clone beakerlib/example repository"
         rlRun "sed -i 's/Creating file/Create fyle/' example/file/lib.sh"
         rlRun "popd"
     rlPhaseEnd

--- a/tests/plan/show/test.sh
+++ b/tests/plan/show/test.sh
@@ -83,7 +83,7 @@ rlJournalStart
         worktree="TREE"
         ref="myref"
 
-        rlRun "git clone https://github.com/teemtee/tmt $local_repo"
+        rlWaitForCmd "git clone https://github.com/teemtee/tmt $local_repo" -m 5 -d 10 -t 300 || rlDie "Unable to clone tmt repository"
         rlRun "pushd $local_repo"
         # fmf id fields should be shown when under the default branch
         rlRun -s "tmt plan show $plan -vvv"


### PR DESCRIPTION
Motivated by Fedora distgit, but wrapping all `git clone` calls with `rlWaitForCmd`.

Pull Request Checklist

* [x] implement the feature