### PR TITLE
Add ssh-option field to provision plugins JSON schema

### DIFF
--- a/tmt/schemas/provision/artemis.yaml
+++ b/tmt/schemas/provision/artemis.yaml
@@ -82,6 +82,9 @@ properties:
   user:
     type: string
 
+  ssh-option:
+    $ref: "/schemas/common#/definitions/one_or_more_strings"
+
   become:
     type: boolean
 

--- a/tmt/schemas/provision/beaker.yaml
+++ b/tmt/schemas/provision/beaker.yaml
@@ -58,6 +58,9 @@ properties:
   public-key:
     $ref: "/schemas/common#/definitions/one_or_more_strings"
 
+  ssh-option:
+    $ref: "/schemas/common#/definitions/one_or_more_strings"
+
   beaker-job-group:
     type: string
 

--- a/tmt/schemas/provision/bootc.yaml
+++ b/tmt/schemas/provision/bootc.yaml
@@ -37,6 +37,9 @@ properties:
   key:
     $ref: "/schemas/common#/definitions/one_or_more_strings"
 
+  ssh-option:
+    $ref: "/schemas/common#/definitions/one_or_more_strings"
+
   memory:
     type: integer
 

--- a/tmt/schemas/provision/connect.yaml
+++ b/tmt/schemas/provision/connect.yaml
@@ -43,6 +43,9 @@ properties:
   key:
     type: string
 
+  ssh-option:
+    $ref: "/schemas/common#/definitions/one_or_more_strings"
+
   port:
     type: integer
     minimum: 0

--- a/tmt/schemas/provision/virtual.yaml
+++ b/tmt/schemas/provision/virtual.yaml
@@ -37,6 +37,9 @@ properties:
   key:
     $ref: "/schemas/common#/definitions/one_or_more_strings"
 
+  ssh-option:
+    $ref: "/schemas/common#/definitions/one_or_more_strings"
+
   memory:
     type: integer
 


### PR DESCRIPTION
 This adds ssh-option schema definitions to all provision plugins to match
 the existing code implementation in https://github.com/teemtee/tmt/blob/dc9b82eb03ff47250c0f22f11ef89e31aba1dd23/tmt/steps/provision/__init__.py#L2327-L2338
Fixes: #4268

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
