### PR TITLE
Avoid indented multiline shell script when creating a yum/dnf repository on guest

### DIFF
--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -183,12 +183,12 @@ class DnfEngine(PackageManagerEngine):
         )
 
     def list_packages(self, repository: Repository) -> ShellScript:
-        command = self.command + Command(
-            "repoquery",
-            "--disablerepo=*",
-            *[f"--enablerepo={repo_id}" for repo_id in repository.repo_ids],
+        repo_ids = " ".join(f"--enablerepo={repo_id}" for repo_id in repository.repo_ids)
+        return ShellScript(
+            f"""
+            {self.command.to_script()} repoquery --disablerepo='*' {repo_ids}
+            """
         )
-        return command.to_script()
 
 
 # ignore[type-arg]: TypeVar in package manager registry annotations is


### PR DESCRIPTION
Consolidate the multi-line raw f-string used for the `tee` here-document into a more compact, single-line f-string with proper spacing.
Some extra spaces in the front of `tee` command were creating an issue. 

```diff
-                        [docker-ce-stable]
+            [docker-ce-stable]
             name=Docker CE Stable - $basearch
             baseurl=https://download.docker.com/linux/centos/$releasever/$basearch/stable
```