### PR TITLE
Restraint context to govern restraint-related addition to execution

### DIFF
--- a/tmt/steps/context/restraint.py
+++ b/tmt/steps/context/restraint.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+import tmt.log
+from tmt.container import container
+from tmt.utils import Environment, EnvVarValue
+
+
+@container
+class RestraintContext:
+    """
+    Provides restraint-related context for execution.
+    """
+
+    #: Phase owning this context.
+    # phase: tmt.steps.Phase
+
+    enabled: bool
+
+    #: Used for logging.
+    logger: tmt.log.Logger
+
+    taskname: Optional[str] = None
+
+    @property
+    def environment(self) -> Environment:
+        environment = Environment()
+
+        environment["TMT_RESTRAINT_COMPATIBLE"] = EnvVarValue(str(int(self.enabled)))
+
+        if self.enabled and self.taskname:
+            environment["RSTRNT_TASKNAME"] = EnvVarValue(self.taskname)
+
+        return environment

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -35,6 +35,7 @@ from tmt.steps.context.abort import AbortContext, AbortStep
 from tmt.steps.context.pidfile import PidFileContext
 from tmt.steps.context.reboot import RebootContext
 from tmt.steps.context.restart import RestartContext
+from tmt.steps.context.restraint import RestraintContext
 from tmt.steps.discover import Discover, DiscoverPlugin, DiscoverStepData
 from tmt.steps.provision import Guest
 from tmt.utils import (
@@ -306,6 +307,18 @@ class TestInvocation(HasStepWorkdir):
         """
 
         return PidFileContext(phase=self.phase, guest=self.guest, logger=self.logger)
+
+    @functools.cached_property
+    def restraint(self) -> RestraintContext:
+        """
+        Restraint context for this invocation.
+        """
+
+        return RestraintContext(
+            enabled=self.phase.data.restraint_compatible,
+            taskname=self.test.name,
+            logger=self.logger,
+        )
 
     def invoke_test(
         self,

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -316,18 +316,12 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
             invocation.path / tmt.steps.execute.TEST_METADATA_FILENAME
         )
 
-        # Set the restraint-compatible mode if enabled
-        environment["TMT_RESTRAINT_COMPATIBLE"] = EnvVarValue(
-            str(int(self.data.restraint_compatible))
-        )
-        if self.data.restraint_compatible:
-            environment["RSTRNT_TASKNAME"] = EnvVarValue(invocation.test.name)
-
         # Add variables from invocation contexts
         environment.update(invocation.abort.environment)
         environment.update(invocation.reboot.environment)
         environment.update(invocation.restart.environment)
         environment.update(invocation.pidfile.environment)
+        environment.update(invocation.restraint.environment)
 
         # Add variables the framework wants to expose
         environment.update(


### PR DESCRIPTION
Similar to reboot, restarts, abort and pidfile contexts: bundles info connected to Restraint, and adds it to `execute` environment. Later, it will be used by `prepare` and `finish` too, and gain more functionality. Restraint-related info will not be spread across classes.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
