### PR TITLE
Split `provision` Packit job into per-plugin jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -114,6 +114,21 @@ _:
           - status | discuss
           - ci | skip
 
+  # Internal provisioning jobs
+  - &internal-provision
+    <<: *test-base
+    <<: *internal
+    <<: *require-full-tests
+    tf_extra_params:
+      environments:
+        - tmt:
+            context:
+              how: provision
+          <<: *tmt-cloud-resources
+    # Temporarily running these on F42 because tests started to break due to avc on F43
+    # TODO: Move revert this targets overwrite
+    targets:
+      - fedora-42
 
 jobs:
   # Build released bits to stable
@@ -155,22 +170,14 @@ jobs:
     identifier: extended-unit-tests
     tmt_plan: '/plans/features/extended-unit-tests$'
 
-  # Test virtual & bootc provision plugins
-  - <<: *test-base
-    <<: *internal
-    <<: *require-full-tests
-    identifier: provision
-    tmt_plan: '/plans/provision/(bootc|virtual)'
-    tf_extra_params:
-      environments:
-        - tmt:
-            context:
-              how: provision
-          <<: *tmt-cloud-resources
-    # Temporarily running these on F42 because tests started to break due to avc on F43
-    # TODO: Move revert this targets overwrite
-    targets:
-      - fedora-42
+  # Test provision plugins
+  - <<: *internal-provision
+    identifier: 'provision:bootc'
+    tmt_plan: /plans/provision/bootc
+
+  - <<: *internal-provision
+    identifier: 'provision:virtual'
+    tmt_plan: /plans/provision/virtual
 
   # Test internal plugins
   - <<: *test-base


### PR DESCRIPTION
There will be more such jobs in the close future, and we can afford having one job for each plugin.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
