### PR TITLE
Drop the `sdist` filter from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,20 +122,6 @@ source = "vcs"
 raw-options.version_scheme = "release-branch-semver"
 raw-options.git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--abbrev=9", "--match", "*[0-9]*"]
 
-[tool.hatch.build.targets.sdist]
-include = [
-    "/tmt",
-    "/LICENSE",
-    "/examples",
-    "/README.rst",
-    "/tests",
-    "/packaging",
-    "/plans",
-    "/docs",
-    "/completions",
-    "/.fmf",
-    ]
-
 [tool.hatch.envs.default]
 platforms = ["linux"]
 


### PR DESCRIPTION
There is no real reason why we need to inclusively filter. Instead let hatchling use the gitignores. PyPI users would be using the wheels directly so the size of sdist is not an issue.