### PR TITLE
Add Create Repository Functionality 

### DIFF
--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -219,7 +219,7 @@ class PackageManagerEngine(tmt.utils.Common):
         """
         raise NotImplementedError
 
-    def create_repo(self, directory: Path) -> ShellScript:
+    def create_repository(self, directory: Path) -> ShellScript:
         """
         Create repository metadata for package files in the given directory.
 
@@ -227,7 +227,7 @@ class PackageManagerEngine(tmt.utils.Common):
         :returns: A shell script to create repository metadata.
         :raises PrepareError: If this package manager does not support creating repositories.
         """
-        raise PrepareError("Package Manager not supported for createrepo")
+        raise PrepareError("Package Manager not supported for create_repository")
 
 
 class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
@@ -320,8 +320,8 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
 
         return stdout.strip().splitlines()
 
-    def create_repo(self, directory: Path) -> CommandOutput:
+    def create_repository(self, directory: Path) -> CommandOutput:
         """
-        Wrapper of :py:meth:`PackageManagerEngine.create_repo`.
+        Wrapper of :py:meth:`PackageManagerEngine.create_repository`.
         """
-        return self.guest.execute(self.engine.create_repo(directory))
+        return self.guest.execute(self.engine.create_repository(directory))

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -191,7 +191,7 @@ class DnfEngine(PackageManagerEngine):
             """
         )
 
-    def create_repo(self, directory: Path) -> ShellScript:
+    def create_repository(self, directory: Path) -> ShellScript:
         """
         Create repository metadata for package files in the given directory.
 

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -67,5 +67,5 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
     def essential_requires(self) -> list[tmt.base.Dependency]:
         # createrepo is needed to create repository metadata from downloaded artifacts
         return [
-            tmt.base.DependencySimple('/usr/bin/createrepo_c'),
+            tmt.base.DependencySimple('/usr/bin/createrepo'),
         ]

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -228,7 +228,7 @@ def create_repository(
     # Create Repository Metadata
     logger.debug(f"Creating metadata for '{artifact_dir}'.")
     try:
-        guest.package_manager.create_repo(artifact_dir)
+        guest.package_manager.create_repository(artifact_dir)
     except RunError as error:
         raise PrepareError(f"Failed to create repository metadata in '{artifact_dir}'") from error
 


### PR DESCRIPTION
Implement support for creating local RPM repositories from artifact directories to enable artifact installation.

- Added `create_repo()` method to package manager interface and DNF implementation using `createrepo`.
- In RPM provider, added `create_repository()` function to generate metadata, create `.repo` file, and return a `Repository` object.
- Declared essential dependency on `/usr/bin/createrepo_c`.

Pull Request Checklist

* [x] implement the feature

Closes #4172 