### PR TITLE
Improve detection of required keys in tmt lint

### DIFF
--- a/tests/core/fmf-id/data/test-with-valid-ref.fmf
+++ b/tests/core/fmf-id/data/test-with-valid-ref.fmf
@@ -3,10 +3,12 @@ test: /bin/false
 require:
   - ref: branch-or-tag-ref
     type: library
+    url: http://localhost
 
   # commit, an obviously hexadecimal one
   - ref: 8deadbeaf8
     type: library
+    url: http://localhost
 
   # Add one pure string requirement for good measure
   - some-package

--- a/tests/core/fmf-id/test.sh
+++ b/tests/core/fmf-id/test.sh
@@ -23,8 +23,8 @@ rlJournalStart
 
         rlRun -s "tmt test -vvvv show /test-with-valid-ref"
         rlAssertNotGrep "warn:" $rlRun_LOG
-        rlRun "grep -Pzo \"(?s)- ref: branch-or-tag-ref.*?\\s*type: library\" $rlRun_LOG > /dev/null"
-        rlRun "grep -Pzo \"(?s)- ref: 8deadbeaf8.*?\\s*type: library\" $rlRun_LOG > /dev/null"
+        rlRun "grep -Pzo \"(?s)- url:.*?\\s*ref: branch-or-tag-ref.*?\\s*type: library\" $rlRun_LOG > /dev/null"
+        rlRun "grep -Pzo \"(?s)- url:.*?\\s*ref: 8deadbeaf8.*?\\s*type: library\" $rlRun_LOG > /dev/null"
         rlAssertGrep "- some-package" $rlRun_LOG
 
         rlRun -s "tmt test -vvvv show /test-with-invalid-ref" 2

--- a/tests/lint/test/data/library-missing-url-path.fmf
+++ b/tests/lint/test/data/library-missing-url-path.fmf
@@ -1,0 +1,5 @@
+summary: Library requirement missing both url and path
+test: /bin/true
+require:
+  - type: library
+    name: /some/library

--- a/tests/lint/test/test.sh
+++ b/tests/lint/test/test.sh
@@ -53,6 +53,9 @@ rlJournalStart
         rlAssertGrep "fail T001 unknown key \"serial_number\" is used" $rlRun_LOG
         rlRun -s "tmt test lint coverage" 1
         rlAssertGrep "fail T006 the 'coverage' field has been obsoleted by 'link'" $rlRun_LOG
+        rlRun -s "tmt test lint library-missing-url-path" 1
+        rlAssertGrep 'fail C000 fmf node failed schema validation' $rlRun_LOG
+        rlAssertGrep 'is not valid under any of the given schemas' $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Fix"

--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -146,6 +146,12 @@ definitions:
     required:
       - type
 
+    anyOf:
+      - required:
+          - url
+      - required:
+          - path
+
     # This would have been the easy way, understandable by newer jsonschema
     # packages.
     # url: true


### PR DESCRIPTION
Issue #3429 reported that `tmt lint` would pass for library requirements with `type: library` but missing both `url` and `path` fields. This would only fail later during `tmt run discover` with the error: "Need 'url' or 'path' to fetch a beakerlib library."

The schema definition for `beakerlib_library` only required the `type` field, unlike `require_file` which correctly requires both `type` and `pattern`. This fix adds an `anyOf` constraint to the schema requiring either `url` or `path` to be present for library requirements.

Now the issue is caught at schema validation time (C000 check), providing immediate feedback during `tmt lint` instead of failing at runtime.

Fixes #3429.