### PR TITLE
Add support for exporting `extra-` keys in plan export

### DIFF
--- a/tests/plan/export/data/plan.fmf
+++ b/tests/plan/export/data/plan.fmf
@@ -36,3 +36,9 @@ execute:
     prepare:
       how: shell
       script: "$ENV_SCRIPT"
+
+/extra-keys:
+    summary: Plan with extra- keys
+    extra-reviewer: John Doe
+    extra-jira-id: TMT-123
+    extra-priority: high

--- a/tests/plan/export/test.sh
+++ b/tests/plan/export/test.sh
@@ -20,6 +20,7 @@ rlJournalStart
         rlAssertGrep "- name: /plan/context" $rlRun_LOG
         rlAssertGrep "- name: /plan/environment" $rlRun_LOG
         rlAssertGrep "- name: /plan/gate" $rlRun_LOG
+        rlAssertGrep "- name: /plan/extra-keys" $rlRun_LOG
         rlAssertGrep "discover:" $rlRun_LOG
         rlAssertGrep "execute:" $rlRun_LOG
         assert_internal_fields "$rlRun_LOG"
@@ -76,6 +77,16 @@ rlJournalStart
 
         rlRun -s "tmt plan export -e ENV_SCRIPT=dummy-script /plan/with-envvars" 0 "Export plan"
         rlAssertEquals "prepare script shall be an replaced" "$(yq '.[] | .prepare | .[] | .script' $rlRun_LOG)" "dummy-script"
+    rlPhaseEnd
+
+    rlPhaseStartTest "tmt plan export /plan/extra-keys"
+        rlRun -s "tmt plan export /plan/extra-keys" 0 "Export plan with extra- keys"
+        rlAssertGrep "- name: /plan/extra-keys" $rlRun_LOG
+        rlAssertGrep "summary: Plan with extra- keys" $rlRun_LOG
+        rlAssertGrep "extra-reviewer: John Doe" $rlRun_LOG
+        rlAssertGrep "extra-jira-id: TMT-123" $rlRun_LOG
+        rlAssertGrep "extra-priority: high" $rlRun_LOG
+        assert_internal_fields "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartTest "Invalid format"

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -3194,6 +3194,13 @@ class Plan(
             if value:
                 data[key] = value
 
+        # Export user-defined extra- keys from the node data
+        for key in self.node.data:
+            if key.startswith(EXTRA_KEYS_PREFIX):
+                value = self.node.data.get(key)
+                if value:
+                    data[key] = value
+
         data['context'] = self.fmf_context.to_spec()
 
         for step_name in tmt.steps.STEPS:


### PR DESCRIPTION
Fixes: #4265

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
