### PR TITLE
Deprecate and internalize discover/fmf fields

### DIFF
--- a/tmt/container/__init__.py
+++ b/tmt/container/__init__.py
@@ -345,6 +345,29 @@ class DataContainer:
 
         return {key: value for key, value in self.items() if value is not None}
 
+    def check_deprecated_keys(self, raw_data: dict[str, Any], logger: 'tmt.log.Logger') -> None:
+        """
+        Check for deprecated keys and emit warnings if they are used.
+
+        This method iterates through all fields in the container and checks their
+        metadata for deprecation information. If a deprecated field is present in
+        the raw data, a warning is emitted.
+        """
+
+        for field in container_fields(self):
+            _, option, _, _, metadata = container_field(self, field.name)
+
+            if metadata.deprecated is None:
+                continue
+
+            if option not in raw_data:
+                continue
+
+            logger.warning(
+                f"Field '{option}' is deprecated since {metadata.deprecated.since}"
+                f"{', ' + metadata.deprecated.hint if metadata.deprecated.hint else ''}."
+            )
+
     # This method should remain a class-method: 1. list of keys is known
     # already, therefore it's not necessary to create an instance, and
     # 2. some functionality makes use of this knowledge.

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -435,6 +435,7 @@ class StepData(
         """
         Called after normalization, useful for tweaking normalized data
         """
+        self.check_deprecated_keys(cast(dict[str, Any], raw_data), logger)
 
     # ignore[override]: expected, we need to accept one extra parameter, `logger`.
     @classmethod

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -217,11 +217,19 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
     )
 
     # Upgrade plan path so the plan is not pruned
-    upgrade_path: Optional[str] = None
+    upgrade_path: Optional[str] = field(default=None, internal=True)
 
     # Legacy fields
-    repository: Optional[str] = None
-    revision: Optional[str] = None
+    repository: Optional[str] = field(
+        default=None,
+        option='--repository',
+        deprecated=tmt.options.Deprecated(since="1.66", hint="use 'url' instead"),
+    )
+    revision: Optional[str] = field(
+        default=None,
+        option='--revision',
+        deprecated=tmt.options.Deprecated(since="1.66", hint="use 'ref' instead"),
+    )
 
     def post_normalization(
         self,


### PR DESCRIPTION
Makes the `upgrade_path` field internal and deprecates the `repository` and `revision` fields. Also adds a new `check_deprecated_keys` method to the `DataContainer` class that emits a warning if any deprecated field is specified.

Resolves #4493

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
