### PR TITLE
Fix `/tests/execute/unresponsive` expected message

### DIFF
--- a/tests/execute/unresponsive/test.sh
+++ b/tests/execute/unresponsive/test.sh
@@ -4,11 +4,12 @@
 rlJournalStart
     rlPhaseStartSetup
         rlRun "pushd data"
+        rlRun "PROVISION_HOW=${PROVISION_HOW:-virtual}"
     rlPhaseEnd
 
     rlPhaseStartTest "Test must error out if machine becomes unresponsive during execution (#3647)."
         rlRun -s "tmt run -vv -a provision -h $PROVISION_HOW" "2"
-        rlAssertGrep 'Failed to verify rsync presence on the guest.' $rlRun_LOG '-F'
+        rlAssertGrep 'Failed to verify rsync presence|Failed to push workdir' $rlRun_LOG '-E'
         rlAssertGrep 'errr /unresponsive/test/error' $rlRun_LOG '-F'
         rlAssertGrep 'pending /unresponsive/test/pending' $rlRun_LOG '-F'
     rlPhaseEnd


### PR DESCRIPTION
The main test purpose is to verify that error is correctly reported. There can be different error messages when the guest becomes unresponsive, let's check for both to prevent random flakes.

Pull Request Checklist

* [x] adjust the test coverage