### PR TITLE
Extend tmt-report-result with a bit of logging

### DIFF
--- a/tmt/steps/scripts/tmt-report-result
+++ b/tmt/steps/scripts/tmt-report-result
@@ -65,7 +65,7 @@ copy_outputfile_to_data_dir () {
     # make sure the directory exists.
     if ! mkdir -p "$finalOutputDir"; then
         echo "tmt-report-result: failed to create the output directory $finalOutputDir"
-        echo "tmt-report-result: this may happen when the test created a file/directory named by the test phase"
+        echo "tmt-report-result: this may happen when the test created a file/directory named after a test phase"
 
         exit 1
     fi


### PR DESCRIPTION
We saw a conflict when the test saves a file under the name of the test phase, `tmt-report-result` cannot create the directory of the same name to hold phase output file. Adding a few lines of logging for easier investigation of such a scenario.