### PR TITLE
Pin hatch version

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -29,7 +29,7 @@ jobs:
           cache: 'pip'
 
       - name: Install hatch
-        run: pip install hatch
+        run: pip install hatch==1.15.1
 
       - name: Run sphinx html builder
         run: hatch run docs:html -W


### PR DESCRIPTION
1.16.0 seems to have broken something in how `sphinx-build` executable is detected
