### PR TITLE
Support FIPS prepare feature on RHEL-7

### DIFF
--- a/tests/prepare/feature/fips/test.sh
+++ b/tests/prepare/feature/fips/test.sh
@@ -29,7 +29,7 @@ rlJournalStart
             rlRun -s "tmt -vvv run -a plan --name /plans/fips/enabled provision --how virtual --image fedora-coreos" 2
             rlAssertGrep "FIPS prepare feature is not supported on ostree or container systems." $rlRun_LOG
             rlRun -s "tmt -vvv run -a plan --name /fips/enabled provision --how virtual --image fedora-rawhide" 2
-            rlAssertGrep "FIPS prepare feature is supported on RHEL/CentOS-Stream 8, 9 or 10." $rlRun_LOG
+            rlAssertGrep "FIPS prepare feature is supported on RHEL 7 and RHEL/CentOS-Stream 8, 9 or 10." $rlRun_LOG
         fi
     rlPhaseEnd
 

--- a/tmt/steps/prepare/feature/fips-enable.yaml
+++ b/tmt/steps/prepare/feature/fips-enable.yaml
@@ -1,3 +1,11 @@
+# On RHEL 7 FIPS is enabled as follows:
+#
+# 1. Install dracut-fips and grubby.
+# 2. Add fips=1 and boot= (if needed) to bootloader kernel arguments
+# 3. Reboot.
+#
+# https://access.redhat.com/solutions/137833
+#
 # On RHEL/CentosStream 8 and 9 FIPS is enabled as follows:
 #
 # 1. Install crypto-policies-scripts, dracut-fips and grubby
@@ -41,36 +49,42 @@
         or 'CentOS Stream release 8' in release_out.stdout
       changed_when: false
 
-- name: Enable FIPS mode on RHEL/CentosStream 8, 9 or 10
+- name: Enable FIPS mode on RHEL 7 or RHEL/CentosStream  8, 9 or 10
   hosts: all
 
   tasks:
 
-    - name: Install crypto-policies-scripts and dracut-fips
+    - name: Disable prelink
+      ansible.builtin.shell: |
+        if rpm -q prelink; then
+          sed -i '/^PRELINKING/s,yes,no,' /etc/sysconfig/prelink
+          prelink -uav
+        fi
+      register: output
+      changed_when: '"package prelink is not installed" not in output.stdout'
+
+    - name: Install dracut-fips and grubby on RHEL7
+      ansible.builtin.command: yum install -y dracut-fips grubby # noqa: command-instead-of-module
+      register: output
+      changed_when: output.rc == 0
+      when: ansible_distribution_major_version | int == 7
+
+    - name: Install crypto-policies-scripts, dracut-fips and grubby on RHEL8 and RHEL9
       ansible.builtin.dnf:
         name:
           - crypto-policies-scripts
           - dracut-fips
+          - grubby
         state: present
-      when:
-        - ansible_distribution_major_version | int < 10
-        - ansible_distribution_major_version | int != 8
-
-    - name: Install crypto-policies-scripts, dracut-fips and grubby on RHEL8
-      ansible.builtin.command: "dnf install -y crypto-policies-scripts dracut-fips grubby"
-      when:
-        - ansible_distribution_major_version | int == 8
-      register: output
-      changed_when: output.rc == 0
+      when: ansible_distribution_major_version | int in [8, 9]
 
     - name: Install grubby
       ansible.builtin.dnf:
         name: grubby
         state: present
-      when: ansible_distribution_major_version | int != 8
+      when: ansible_distribution_major_version | int == 10
 
     - name: Modify bootloader
-      when: ansible_distribution_major_version | int == 10
       block:
 
         - name: Add parameters fips and boot (if applicable)
@@ -107,12 +121,12 @@
       when: ansible_distribution_major_version | int == 10
 
     - name: Enable FIPS mode
-      ansible.builtin.command: fips-mode-setup --enable
+      ansible.builtin.command: fips-mode-setup --enable --no-bootcfg
       environment:
         FIPS_MODE_SETUP_SKIP_WARNING: "1"
       register: output
       changed_when: output.rc == 0
-      when: ansible_distribution_major_version | int < 10
+      when: ansible_distribution_major_version | int in [8, 9]
 
     - name: Reboot
       ansible.builtin.reboot:
@@ -129,8 +143,9 @@
     - name: FIPS mode is reported by fips-mode-setup
       ansible.builtin.command: fips-mode-setup --is-enabled
       changed_when: false
-      when: ansible_distribution_major_version | int < 10
+      when: ansible_distribution_major_version | int in [8, 9]
 
     - name: Check that FIPS policy is enabled
       ansible.builtin.shell: test "$(update-crypto-policies --show)" == "FIPS"
       changed_when: false
+      when: ansible_distribution_major_version | int > 7

--- a/tmt/steps/prepare/feature/fips.py
+++ b/tmt/steps/prepare/feature/fips.py
@@ -9,7 +9,7 @@ from tmt.steps.provision import Guest
 
 SUPPORTED_DISTRO_PATTERNS = tuple(
     re.compile(pattern)
-    for pattern in (r'Red Hat Enterprise Linux (8|9|10)', r'CentOS Stream (8|9|10)')
+    for pattern in (r'Red Hat Enterprise Linux .*(7|8|9|10)', r'CentOS Stream (8|9|10)')
 )
 
 
@@ -47,6 +47,6 @@ class Fips(ToggleableFeature):
             and any(pattern.match(guest.facts.distro) for pattern in SUPPORTED_DISTRO_PATTERNS)
         ):
             raise tmt.utils.GeneralError(
-                'FIPS prepare feature is supported on RHEL/CentOS-Stream 8, 9 or 10.'
+                'FIPS prepare feature is supported on RHEL 7 and RHEL/CentOS-Stream 8, 9 or 10.'
             )
         cls._run_playbook('enable', 'fips-enable.yaml', guest, logger)


### PR DESCRIPTION
Notice that this requires python-3.9 or newer to be present on guest that is not present by default on RHEL-7. Hence, a provisioning or previous prepare steps must handle this (e.g. testing-farm is doing this correctly). 

Changes:

1. *Disable prelink* - following** https://access.redhat.com/solutions/137833#initial  (Initial Common Steps) I added prelink disabling. Notice that this (by default) only affects RHEL-7 since RHEL-8 comes with prelink disabled already and RHEL-9 and 10 (as well as their Centos Stream variants) do not have prelink anymore. However, I did not limit this step to RHEL-7 just to be 100% sure there is either no prelink or that it is disabled. Prelinking would make FIPS 140 power-on-self-test fail for all cryptographic backends and make system unusable.

2. *Modify bootloader* - this step was previously only done on RHEL-10 but it was essentially happening also on RHEL-8 and RHEL-9 via "Enable FIPS mode" step (`fips-mode-setup --enable`). Now, this exact step is also needed for RHEL-7 and hence for clarify it makes sense to do the bootloader update the same way for all releases while excluding the change from "Enable FIPS mode" (see below).

3. *Enable FIPS mode* - `fips-mode-setup --enable` done on RHEL-8 and RHEL-9 updates bootloader settings (adding `fips=1` parameter and `boot=...` parameter if it is needed). Since we need do to bootloader update for RHEL-7 and RHEL-10 explicitly by "Modify bootloader" steps, why not to do it for all releases for simplicity? In order not to do it twice for RHEL-8 and RHEL-9 `--no-bootcfg` is added for `fips-mode-setup` to tell the tool that we don't want it to do the bootloader modifications.

Pull Request Checklist

* [x] implement the feature
