### PR TITLE
Move `/plans/provision/container` into its own Packit job

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -183,6 +183,10 @@ jobs:
     tmt_plan: /plans/provision/bootc
 
   - <<: *provision
+    identifier: 'provision-container'
+    tmt_plan: /plans/provision/container
+
+  - <<: *provision
     identifier: provision-virtual
     tmt_plan: /plans/provision/virtual
 

--- a/plans/provision/container.fmf
+++ b/plans/provision/container.fmf
@@ -24,7 +24,9 @@ context+:
 environment:
     PROVISION_HOW: container
 
-enabled: true
+adjust+:
+  - enabled: true
+    when: how == provision
 
 /install:
     discover+:


### PR DESCRIPTION
That makes it aligned with other provision-focused plans, bootc and
virtual. More will follow in the future, together with test changes and
moves.

Pull Request Checklist

* [x] implement the feature