### PR TITLE
Update the sprints section and the releaser role

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -818,6 +818,8 @@ The team works in biweekly sprints with the following schedule:
 * Sprint day 0, Thursday ... retrospective & planning meeting
 * Sprint day 3, Tuesday ... hacking session, progress check
 * Sprint day 4, Wednesday ... issue triage
+* Sprint day 6, Friday ... the ``must`` items are ideally done,
+  or at least ready for review
 * Sprint day 8, Tuesday ... hacking session, pre-release sync
 * Sprint day 9, Wednesday ... issue triage, new version released
 


### PR DESCRIPTION
Incorporate feedback from the last retrospective into the sprint and releaser documentation, among others:

* regularly review pull request comments and address them
* limited number of `must` have issues in the sprint
* releaser should dedicate some time every day

Pull Request Checklist

* [x] write the documentation