### PR TITLE
Fix typos and missing rendering of guest facts

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1070,7 +1070,6 @@ class GuestFacts(SerializableContainer):
         yield _flag('has_systemd', 'systemd')
         yield _flag('systemd_soft_reboot', 'systemd soft-reboot')
         yield _flag('has_rsync', 'rsync')
-        yield _flag('is_ostree', 'is ostree')
         yield _flag('is_superuser', 'is superuser')
         yield _flag('can_sudo', 'can sudo')
 


### PR DESCRIPTION
We collected several typos and some interesting items were not printed out. Polished that a bit, hopefully with `attrs` we will move this closer to the fields themselves.

Pull Request Checklist

* [x] implement the feature