### PR TITLE
Adress some ansible deprecations

### DIFF
--- a/examples/redis/ansible/setup_server.yml
+++ b/examples/redis/ansible/setup_server.yml
@@ -2,7 +2,7 @@
 - name: Setup server
   hosts: all
   vars:
-    version: "{{ ansible_distribution_version }}"
+    version: "{{ ansible_facts['distribution_version'] }}"
   tasks:
     - name: Task redis
       ansible.builtin.import_tasks: tasks/redis.yml

--- a/tmt/steps/prepare/feature/epel-disable.yaml
+++ b/tmt/steps/prepare/feature/epel-disable.yaml
@@ -29,8 +29,8 @@
   tasks:
     - name: Disable EPEL repos on RHEL 7 or CentOS 7
       when:
-        - ansible_distribution in ["RedHat", "CentOS"]
-        - ansible_distribution_major_version | int == 7
+        - ansible_facts["distribution"] in ["RedHat", "CentOS"]
+        - ansible_facts["distribution_major_version"] | int == 7
       block:
         - name: Install package 'yum-utils'
           ansible.builtin.dnf:
@@ -51,8 +51,8 @@
 
     - name: Disable EPEL and EPEL-Next repos on RHEL 8+ or CentOS Stream 8+
       when:
-        - ansible_distribution in ["RedHat", "CentOS"]
-        - ansible_distribution_major_version | int >= 8
+        - ansible_facts["distribution"] in ["RedHat", "CentOS"]
+        - ansible_facts["distribution_major_version"] | int >= 8
       block:
         - name: Install 'dnf config-manager'
           ansible.builtin.command: dnf -y install 'dnf-command(config-manager)'

--- a/tmt/steps/prepare/feature/epel-enable.yaml
+++ b/tmt/steps/prepare/feature/epel-enable.yaml
@@ -29,12 +29,12 @@
   tasks:
     - name: Enable EPEL repos on RHEL 7
       when:
-        - ansible_distribution == "RedHat"
-        - ansible_distribution_major_version | int == 7
+        - ansible_facts["distribution"] == "RedHat"
+        - ansible_facts["distribution_major_version"] | int == 7
       block:
         - name: Install package 'epel-release'
           ansible.builtin.dnf:
-            name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"  # yamllint disable rule:line-length
+            name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"  # yamllint disable rule:line-length
             disable_gpg_check: true
             state: present
 
@@ -50,37 +50,37 @@
 
     - name: Enable EPEL and EPEL-Next repos on RHEL 8 and later
       when:
-        - ansible_distribution == "RedHat"
-        - ansible_distribution_major_version | int >= 8
+        - ansible_facts["distribution"] == "RedHat"
+        - ansible_facts["distribution_major_version"] | int >= 8
       block:
         - name: Install package 'epel-release'
           ansible.builtin.dnf:
-            name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"  # yamllint disable rule:line-length
+            name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"  # yamllint disable rule:line-length
             disable_gpg_check: true
             state: present
-          when: ansible_distribution_major_version | int >= 9
+          when: ansible_facts["distribution_major_version"] | int >= 9
 
         - name: Install package 'epel-release'
           ansible.builtin.shell: |
             set -e
             if ! rpm -q epel-release; then
-              rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+              rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm
               echo "CHANGED"
             fi
           # The dnf python module is not available with python3.9 installed on the host, do not use ansible.builtin.dnf module
-          when: ansible_distribution_major_version | int == 8
+          when: ansible_facts["distribution_major_version"] | int == 8
           register: output
           changed_when: "'CHANGED' in output.stdout"
 
 
         - name: Install package 'epel-next-release'
           ansible.builtin.dnf:
-            name: "https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"  # yamllint disable rule:line-length
+            name: "https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"  # yamllint disable rule:line-length
             disable_gpg_check: true
             state: present
           # EPEL Next is available for CentOS Stream 9
           # Enable for Stream 10 once epel-next is available
-          when: ansible_distribution_major_version | int == 9
+          when: ansible_facts["distribution_major_version"] | int == 9
 
         - name: Install 'dnf config-manager'
           ansible.builtin.command: dnf -y install 'dnf-command(config-manager)'
@@ -98,7 +98,7 @@
           changed_when: output.rc != 0
           # EPEL Next is available for CentOS Stream 9
           # Enable for Stream 10 once epel-next is available
-          when: ansible_distribution_major_version | int == 9
+          when: ansible_facts["distribution_major_version"] | int == 9
 
         - name: Enable the crb repository
           ansible.builtin.command: crb enable
@@ -110,8 +110,8 @@
 
     - name: Enable EPEL repos on CentOS 7
       when:
-        - ansible_distribution == "CentOS"
-        - ansible_distribution_major_version | int == 7
+        - ansible_facts["distribution"] == "CentOS"
+        - ansible_facts["distribution_major_version"] | int == 7
       block:
         - name: Install package 'epel-release'
           ansible.builtin.dnf:
@@ -130,8 +130,8 @@
 
     - name: Enable EPEL and EPEL-Next repos on CentOS Stream 8 and later
       when:
-        - ansible_distribution == "CentOS"
-        - ansible_distribution_major_version | int >= 8
+        - ansible_facts["distribution"] == "CentOS"
+        - ansible_facts["distribution_major_version"] | int >= 8
       block:
         - name: Install package 'epel-release'
           ansible.builtin.dnf:
@@ -144,7 +144,7 @@
             state: present
           # EPEL Next is available for CentOS Stream 9
           # Enable for Stream 10 once epel-next is available
-          when: ansible_distribution_major_version | int == 9
+          when: ansible_facts["distribution_major_version"] | int == 9
 
         - name: Install 'dnf config-manager'
           ansible.builtin.command: dnf -y install 'dnf-command(config-manager)'
@@ -162,7 +162,7 @@
           changed_when: output.rc != 0
           # EPEL Next is available for CentOS Stream 9
           # Enable for Stream 10 once epel-next is available
-          when: ansible_distribution_major_version | int == 9
+          when: ansible_facts["distribution_major_version"] | int == 9
 
         - name: Enable the crb repository
           ansible.builtin.command: crb enable

--- a/tmt/steps/prepare/feature/fips-enable.yaml
+++ b/tmt/steps/prepare/feature/fips-enable.yaml
@@ -67,14 +67,14 @@
       ansible.builtin.command: yum install -y dracut-fips grubby # noqa: command-instead-of-module
       register: output
       changed_when: "output.rc == 0 and 'Nothing to do' not in output.stdout"
-      when: ansible_distribution_major_version | int == 7
+      when: ansible_facts["distribution_major_version"] | int == 7
 
     - name: Install crypto-policies-scripts, dracut-fips and grubby on RHEL8
       # noqa: command-instead-of-module
       ansible.builtin.command: dnf install -y crypto-policies-scripts dracut-fips grubby
       register: output
       changed_when: "output.rc == 0 and 'Nothing to do' not in output.stdout"
-      when: ansible_distribution_major_version | int == 8
+      when: ansible_facts["distribution_major_version"] | int == 8
 
     - name: Install crypto-policies-scripts, dracut-fips and grubby on RHEL9
       ansible.builtin.dnf:
@@ -83,13 +83,13 @@
           - dracut-fips
           - grubby
         state: present
-      when: ansible_distribution_major_version | int == 9
+      when: ansible_facts["distribution_major_version"] | int == 9
 
     - name: Install grubby
       ansible.builtin.dnf:
         name: grubby
         state: present
-      when: ansible_distribution_major_version | int == 10
+      when: ansible_facts["distribution_major_version"] | int == 10
 
     - name: Modify bootloader
       block:
@@ -119,13 +119,13 @@
           ansible.builtin.command: zipl
           register: output
           changed_when: output.rc == 0
-          when: ansible_architecture == "s390x"
+          when: ansible_facts["architecture"] == "s390x"
 
     - name: Enable FIPS Policy
       ansible.builtin.command: update-crypto-policies --set FIPS
       register: output
       changed_when: "'is not sufficient for' in output.stderr"
-      when: ansible_distribution_major_version | int == 10
+      when: ansible_facts["distribution_major_version"] | int == 10
 
     - name: Enable FIPS mode
       ansible.builtin.command: fips-mode-setup --enable --no-bootcfg
@@ -133,7 +133,7 @@
         FIPS_MODE_SETUP_SKIP_WARNING: "1"
       register: output
       changed_when: output.rc == 0
-      when: ansible_distribution_major_version | int in [8, 9]
+      when: ansible_facts["distribution_major_version"] | int in [8, 9]
 
     - name: Reboot
       ansible.builtin.reboot:
@@ -145,14 +145,14 @@
     - name: Userspace is running in FIPS mode
       ansible.builtin.command: test -e /etc/system-fips
       changed_when: false
-      when: ansible_distribution_major_version | int < 10
+      when: ansible_facts["distribution_major_version"] | int < 10
 
     - name: FIPS mode is reported by fips-mode-setup
       ansible.builtin.command: fips-mode-setup --is-enabled
       changed_when: false
-      when: ansible_distribution_major_version | int in [8, 9]
+      when: ansible_facts["distribution_major_version"] | int in [8, 9]
 
     - name: Check that FIPS policy is enabled
       ansible.builtin.shell: test "$(update-crypto-policies --show)" == "FIPS"
       changed_when: false
-      when: ansible_distribution_major_version | int > 7
+      when: ansible_facts["distribution_major_version"] | int > 7


### PR DESCRIPTION
List of deprecations reported:
- `INJECT_FACTS_AS_VARS default to 'True' is deprecated`:
  - Converting the `ansible_*` to `ansible_facts[*]` should do the trick
- `Importing 'to_bytes' from 'ansible.module_utils._text' is deprecated`:
  - We don't control that one, but it seems related to `ansible.builtin.raw`, should be fixed in upstream?

Pull Request Checklist

* [ ] implement the feature

Closes #4424