### PR TITLE
Enable basic functionality tests for secondary images

### DIFF
--- a/tests/images.sh
+++ b/tests/images.sh
@@ -22,11 +22,17 @@ TEST_CONTAINER_IMAGES="${TEST_CONTAINER_IMAGES:-$TEST_IMAGE_PREFIX/alpine:latest
 $TEST_IMAGE_PREFIX/centos/7/upstream:latest
 $TEST_IMAGE_PREFIX/centos/stream9/upstream:latest
 $TEST_IMAGE_PREFIX/centos/stream10/upstream:latest
+$TEST_IMAGE_PREFIX/fedora/42/upstream:latest
 $TEST_IMAGE_PREFIX/fedora/43/upstream:latest
 $TEST_IMAGE_PREFIX/fedora/rawhide/upstream:latest
 $TEST_IMAGE_PREFIX/ubi/8/upstream:latest
 $TEST_IMAGE_PREFIX/ubuntu/22.04/upstream:latest
 $TEST_IMAGE_PREFIX/debian/12.7/upstream:latest}"
+
+# For the following images we do not exercise all possible feature
+# combinations, just make sure the basic functionality works.
+TEST_CONTAINER_IMAGES_SECONDARY="${TEST_CONTAINER_IMAGES_SECONDARY:-$TEST_IMAGE_PREFIX/fedora/42/upstream:latest}"
+
 
 # Basic set of virtual images to test on.
 #
@@ -35,9 +41,14 @@ $TEST_IMAGE_PREFIX/debian/12.7/upstream:latest}"
 # TODO: enable centos-7 again with modified repo files
 TEST_VIRTUAL_IMAGES="${TEST_VIRTUAL_IMAGES:-centos-stream-9
 centos-stream-10
+fedora-42
 fedora-43
 fedora-rawhide
 fedora-coreos}"
+
+# For the following images we do not exercise all possible feature
+# combinations, just make sure the basic functionality works.
+TEST_VIRTUAL_IMAGES_SECONDARY="${TEST_VIRTUAL_IMAGES_SECONDARY:-fedora-42}"
 
 # A couple of "is image this?" helpers, to simplify conditions.
 function is_fedora_rawhide () {

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -36,11 +36,13 @@ rlJournalStart
 
         if [ "$PROVISION_HOW" = "container" ]; then
             rlRun "IMAGES='$TEST_CONTAINER_IMAGES'"
+            rlRun "SECONDARY_IMAGES='$TEST_CONTAINER_IMAGES_SECONDARY'"
 
             build_container_images
 
         elif [ "$PROVISION_HOW" = "virtual" ]; then
             rlRun "IMAGES='$TEST_VIRTUAL_IMAGES'"
+            rlRun "SECONDARY_IMAGES='$TEST_VIRTUAL_IMAGES_SECONDARY'"
 
         else
             rlRun "IMAGES="
@@ -62,6 +64,10 @@ rlJournalStart
 
             if is_fedora_rawhide "$image"; then
                 rlRun "distro=fedora-rawhide"
+                rlRun "package_manager=dnf5"
+
+            elif is_fedora_42 "$image"; then
+                rlRun "distro=fedora-42"
                 rlRun "package_manager=dnf5"
 
             elif is_fedora_43 "$image"; then
@@ -139,6 +145,11 @@ rlJournalStart
                 rlAssertGrep "summary: 2 preparations applied" $rlRun_LOG
             fi
         rlPhaseEnd
+
+        # Here the basic functionality check ends for the secondary distros.
+        if [[ "$SECONDARY_IMAGES" =~ "$image" ]]; then
+            continue
+        fi
 
         rlPhaseStartTest "$phase_prefix Install existing packages (CLI)"
             if is_ubi "$image"; then


### PR DESCRIPTION
Add `fedora-42` back to the list of tested images. Just make sure we don't exercise each and every feature combination again and again. For images listed in `TEST_CONTAINER_IMAGES_SECONDARY` and `TEST_VIRTUAL_IMAGES_SECONDARY` variables we just execute basic package installation check in `/tests/prepare/install`. In tests like `/tests/prepare/ansible` or `/tests/finish/ansible`, which are relatively fast, `fedora-42` is tested again fully.

Fix #4393.

Pull Request Checklist

* [x] extend the test coverage