### PR TITLE
Split the doc-tests into multiple jobs

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -17,14 +17,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: [ linkcheck, html ]
+        builder: [ linkcheck, html, lint ]
         include:
           # Run default html builder with warnings as error
           - builder: html
             args: -W
+          - builder: lint
+            sphinx_builder: html
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
@@ -34,6 +38,11 @@ jobs:
       - name: Install tmt[docs]
         run: uv sync --frozen --extra docs
 
+      # TODO: Move this to its own extra/group
+      - name: Install other test dependencies
+        run: uv pip install sphinx-lint
+        if: ${{ matrix.builder == 'lint' }}
+
       - name: Cache linkcheck results
         uses: actions/cache@v5
         with:
@@ -41,16 +50,11 @@ jobs:
           key: linkcheck
         if: ${{ matrix.builder == 'linkcheck' }}
 
-      - name: Run sphinx builder ${{ matrix.builder }}
-        run: sphinx-build -b ${{ matrix.builder }} ${{ matrix.args }} docs/ docs/_build
-
-      # TODO: Move this to its own extra/group
-      - name: Install other test dependencies
-        run: uv pip install sphinx-lint
-        if: ${{ matrix.builder == 'html' }}
+      - name: Run sphinx builder ${{ matrix.sphinx_builder || matrix.builder }}
+        run: sphinx-build -b ${{ matrix.sphinx_builder || matrix.builder }} ${{ matrix.args }} docs/ docs/_build
 
       # TODO: enable all checks
       # https://github.com/sphinx-contrib/sphinx-lint/issues/74
       - name: Run Sphinx ReST linter
         run: sphinx-lint --ignore=docs/_build docs tmt tests
-        if: ${{ matrix.builder == 'html' }}
+        if: ${{ matrix.builder == 'lint' }}


### PR DESCRIPTION
Sometimes these jobs are failing and blocks the other checks in the queue. But these jobs are not really gating so we could just run them in parallel. The GH actions for us is cheap by comparison anyway.

Pull Request Checklist

* [x] implement the feature
