### PR TITLE
Augment repository files with default priority when missing

### DIFF
--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -21,6 +21,7 @@ from tmt.utils import GeneralError, Path, PrepareError, RunError
 
 #: Default priority for repositories when priority is not specified.
 #: Lower values have higher priority in package managers.
+#: See https://dnf.readthedocs.io/en/latest/conf_ref.html#repo-options
 DEFAULT_REPOSITORY_PRIORITY = 50
 
 # Counter for generating unique repository names in the format ``tmt-repo-default-{n}``.


### PR DESCRIPTION
  1. **User-provided repository files** (via `repository-file` provider): These are treated as authoritative user input and installed verbatim. If the .repo file defines a priority, it is preserved; if not, no priority is added.

  2. **tmt-artifact-shared repository**: This is an internally-managed repository where downloaded artifacts are aggregated. It has a higher priority (lower numeric value) to have precedence over system repositories.
