### PR TITLE
Do not inject plan environment into test environment

### DIFF
--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -483,8 +483,7 @@ class Discover(tmt.steps.Step):
 
                     test.name = f"{prefix}{test.name}"
                     test.path = Path(f"/{phase.safe_name}{test.path}")
-                    # Update test environment with plan environment
-                    test.environment.update(self.plan.environment)
+
                     self._tests[phase.name].append(test)
 
             else:

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -1007,8 +1007,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
 
             test.name = f"{prefix}{test.name}"
             test.path = Path(f"/{self.safe_name}{test.path}")
-            # Update test environment with plan environment
-            test.environment.update(self.step.plan.environment)
+
             self.step.plan.discover._tests[self.name].append(test)
             test.serial_number = self.step.plan.draw_test_serial_number(test)
         self.step.save()

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -339,11 +339,18 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
     @property
     def environment(self) -> Environment:
         if self._environment is None:
+            # narrow type
+            assert isinstance(self.phase.parent, Execute)
+
+            # narrow type
+            assert isinstance(self.phase.parent.plan.my_run, tmt.base.Run)
+
             environment = Environment()
 
             environment.update(
                 self.guest.environment,
                 self.test.environment,
+                self.phase.parent.plan.environment,
             )
 
             environment["TMT_TEST_NAME"] = EnvVarValue(self.test.name)
@@ -352,9 +359,6 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
             environment["TMT_TEST_SUBMITTED_FILES"] = EnvVarValue(self.submission_log_path)
             environment['TMT_TEST_SERIAL_NUMBER'] = EnvVarValue(str(self.test.serial_number))
             environment["TMT_TEST_METADATA"] = EnvVarValue(self.path / TEST_METADATA_FILENAME)
-
-            assert isinstance(self.phase.parent, Execute)
-            assert self.phase.parent.plan.my_run is not None
 
             environment['TMT_TEST_ITERATION_ID'] = EnvVarValue(
                 f"{self.phase.parent.plan.my_run.unique_id}-{self.test.serial_number}"


### PR DESCRIPTION
It is no longer merged into test environment. That leaves the test environment untainted and with its original content. The plan environment is then exposed to test when invoked, as any other environment component.

Related to #4241.

Pull Request Checklist

* [x] implement the feature