### PR TITLE
Rename Packit checks with names containing `:`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -172,11 +172,11 @@ jobs:
 
   # Test provision plugins
   - <<: *internal-provision
-    identifier: 'provision:bootc'
+    identifier: provision-bootc
     tmt_plan: /plans/provision/bootc
 
   - <<: *internal-provision
-    identifier: 'provision:virtual'
+    identifier: provision-virtual
     tmt_plan: /plans/provision/virtual
 
   # Test internal plugins


### PR DESCRIPTION
`:` is recognized by Packit as a separator of fields in the check name, and by using we fool Packit into making incorrect decissions, or even failing to find our checks.

Pull Request Checklist

* [x] implement the feature