### PR TITLE
Get rid of the irrelevant `sudo` check messages

### DIFF
--- a/docs/releases/pending/4465.fmf
+++ b/docs/releases/pending/4465.fmf
@@ -1,0 +1,3 @@
+description: |
+    Irrelevant and confusing `sudo -n true` messages polluting the verbose
+    output of ``tmt run`` and ``tmt try`` commands have been removed.

--- a/tests/execute/output/test.sh
+++ b/tests/execute/output/test.sh
@@ -15,6 +15,7 @@ rlJournalStart
         # Helper script actions should not appear in the verbose output
         rlAssertNotGrep "mkdir -p /usr/local/bin" $rlRun_LOG
         rlAssertNotGrep "rsync.*--version" $rlRun_LOG
+        rlAssertNotGrep "cmd: sudo -n true" $rlRun_LOG
     rlPhaseEnd
 
     # TODO Move verbosity level checks from /tests/execute/basic here

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -902,7 +902,7 @@ class GuestFacts(SerializableContainer):
 
     def _query_can_sudo(self, guest: 'Guest') -> Optional[bool]:
         try:
-            guest.execute(Command("sudo", "-n", "true"))
+            guest.execute(Command("sudo", "-n", "true"), silent=True)
         except tmt.utils.RunError:
             # Failed non-interactive sudo, so we can't sudo
             return False


### PR DESCRIPTION
Recently irrelevant `sudo` messages started to be appearing in the verbose output of common commands such as `tmt try` or `tmt run`:

    cmd: sudo -n true
    err: sudo: a password is required

Let's silence the `sudo` check in a similar way as we do with the other query commands.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] include a release note