### PR TITLE
Fix name of the `repository-file` provider

### DIFF
--- a/tests/core/about/test.sh
+++ b/tests/core/about/test.sh
@@ -8,7 +8,7 @@ export.story: dict json rst template yaml
 export.test: dict json nitrate polarion template yaml
 package_managers: apk apt bootc dnf dnf5 mock-dnf mock-dnf5 mock-yum rpm-ostree yum
 plan_shapers: max-tests repeat
-prepare.artifact.providers: brew.build brew.nvr brew.task copr.build file koji.build koji.nvr koji.task repository-url
+prepare.artifact.providers: brew.build brew.nvr brew.task copr.build file koji.build koji.nvr koji.task repository-file
 prepare.feature: crb epel fips profile
 step.cleanup: tmt
 step.discover: fmf shell

--- a/tests/prepare/artifact/test.sh
+++ b/tests/prepare/artifact/test.sh
@@ -40,7 +40,7 @@ rlJournalStart
             provision -h $PROVISION_HOW --image $TEST_IMAGE_PREFIX/fedora/${fedora_release}:latest \
             prepare --insert --how artifact \
                --provide koji.build:$make_buildid \
-               --provide repository-url:https://download.docker.com/linux/fedora/docker-ce.repo" 0 "Run tmt with artifact providers"
+               --provide repository-file:https://download.docker.com/linux/fedora/docker-ce.repo" 0 "Run tmt with artifact providers"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/unit/artifact/test_repository.py
+++ b/tests/unit/artifact/test_repository.py
@@ -361,7 +361,7 @@ def test_id_extraction(root_logger):
     """Test provider ID extraction from raw provider ID"""
 
     # Valid provider ID
-    raw_id = "repository-url:https://download.docker.com/linux/centos/docker-ce.repo"
+    raw_id = "repository-file:https://download.docker.com/linux/centos/docker-ce.repo"
     provider = RepositoryFileProvider(raw_id, root_logger)
     assert provider.id == "https://download.docker.com/linux/centos/docker-ce.repo"
 
@@ -369,7 +369,7 @@ def test_id_extraction(root_logger):
 def test_artifacts_before_fetch(mock_repo_file_fetch, root_logger):
     """Test that repository provider artifacts returns empty list"""
 
-    provider = RepositoryFileProvider("repository-url:https://example.com/test.repo", root_logger)
+    provider = RepositoryFileProvider("repository-file:https://example.com/test.repo", root_logger)
 
     # Repository providers don't enumerate individual artifacts
     # They provide repositories that the package manager uses
@@ -382,7 +382,7 @@ def test_fetch_contents(mock_repo_file_fetch, mock_guest_and_pm, root_logger, tm
     mock_guest, mock_package_manager = mock_guest_and_pm
 
     provider = RepositoryFileProvider(
-        "repository-url:https://download.docker.com/linux/centos/docker-ce.repo", root_logger
+        "repository-file:https://download.docker.com/linux/centos/docker-ce.repo", root_logger
     )
 
     # Call fetch_contents
@@ -406,7 +406,7 @@ def test_contribute_to_shared_repo(mock_repo_file_fetch, mock_guest_and_pm, root
     mock_guest, mock_package_manager = mock_guest_and_pm
 
     provider = RepositoryFileProvider(
-        "repository-url:https://download.docker.com/linux/centos/docker-ce.repo", root_logger
+        "repository-file:https://download.docker.com/linux/centos/docker-ce.repo", root_logger
     )
 
     # Call contribute_to_shared_repo
@@ -430,7 +430,7 @@ def test_get_repositories(mock_repo_file_fetch, mock_guest_and_pm, root_logger, 
     mock_guest, _ = mock_guest_and_pm
 
     provider = RepositoryFileProvider(
-        "repository-url:https://download.docker.com/linux/centos/docker-ce.repo", root_logger
+        "repository-file:https://download.docker.com/linux/centos/docker-ce.repo", root_logger
     )
 
     # First, fetch_contents must be called to initialize the repository

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -25,19 +25,19 @@ _REPO_NAME_GENERATOR = DefaultNameGenerator(known_names=[])
 
 # ignore[type-arg]: TypeVar in provider registry annotations is
 # puzzling for type checkers. And not a good idea in general, probably.
-@provides_artifact_provider('repository-url')  # type: ignore[arg-type]
+@provides_artifact_provider('repository-file')  # type: ignore[arg-type]
 class RepositoryFileProvider(ArtifactProvider[RpmArtifactInfo]):
     """
     Provider for making RPM artifacts from a repository discoverable without downloading them.
 
-    The provider identifier should start with 'repository-url:' followed by a URL to a .repo file,
-    e.g., "repository-url:https://download.docker.com/linux/centos/docker-ce.repo".
+    The provider identifier should start with 'repository-file:' followed by a URL to a .repo file,
+    e.g., "repository-file:https://download.docker.com/linux/centos/docker-ce.repo".
 
     The provider downloads the .repo file to the guest's ``/etc/yum.repos.d/`` directory,
     and lists RPMs available in the defined repositories without downloading them, acting as a
     discovery-only provider. Artifacts are all available RPM packages listed in the repository.
 
-    :param raw_provider_id: The full provider identifier, starting with 'repository-url:'.
+    :param raw_provider_id: The full provider identifier, starting with 'repository-file:'.
     :param logger: Logger instance for outputting messages.
     :raises GeneralError: If the .repo file URL is invalid.
     """
@@ -49,7 +49,7 @@ class RepositoryFileProvider(ArtifactProvider[RpmArtifactInfo]):
 
     @classmethod
     def _extract_provider_id(cls, raw_provider_id: str) -> ArtifactProviderId:
-        prefix = 'repository-url:'
+        prefix = 'repository-file:'
         if not raw_provider_id.startswith(prefix):
             raise ValueError(f"Invalid repository provider format: '{raw_provider_id}'.")
         value = raw_provider_id[len(prefix) :]


### PR DESCRIPTION
  - Renames the `repository-url` artifact provider to `repository-file`
  - Updates all references throughout the codebase including tests and documentation