### PR TITLE
Prevent file globbing when removing `tmt` packages

### DIFF
--- a/plans/install/pip.fmf
+++ b/plans/install/pip.fmf
@@ -1,7 +1,7 @@
 summary: Verify that the pip install works
 prepare:
   - summary: Remove any rpm packages if present
-    script: rpm -q tmt && dnf remove -y tmt* || true
+    script: rpm -q tmt && dnf remove -y 'tmt*' || true
   - summary: Prepare the virtual environment
     script: python3 -m venv /tmp/venv && /tmp/venv/bin/pip install --upgrade pip
     order: 80


### PR DESCRIPTION
Currently when removing `tmt` from the system in order to check the full pip installation a `dnf remove -y tmt*` command would match local file names if present. Prevent the file globbing and let the pattern matching work on `dnf` itself.

Pull Request Checklist

* [x] adjust the test coverage