### PR TITLE
Add `tini` init to container images to prevent zombie processes

### DIFF
--- a/containers/Containerfile.full
+++ b/containers/Containerfile.full
@@ -5,13 +5,16 @@ RUN set -ex && \
     sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf && \
     echo "Set disable_coredump false" >> /etc/sudo.conf && \
     # Install necessary packages
-    dnf install -y dnf-plugins-core && \
+    dnf install -y dnf-plugins-core tini && \
     dnf copr enable -y @teemtee/stable && \
     dnf install -y tmt+all beakerlib && \
     dnf autoremove -y && \
     dnf clean all && \
     # Prepare a directory for experimenting
     mkdir /tmt
+
+# Use tini as init to properly handle signals and reap zombie processes
+ENTRYPOINT ["/usr/bin/tini", "--"]
 
 # Prepare files for experimenting
 COPY .fmf /tmt/.fmf

--- a/containers/Containerfile.mini
+++ b/containers/Containerfile.mini
@@ -5,13 +5,16 @@ RUN set -ex && \
     sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf && \
     echo "Set disable_coredump false" >> /etc/sudo.conf && \
     # Install necessary packages
-    dnf install -y dnf-plugins-core && \
+    dnf install -y dnf-plugins-core tini && \
     dnf copr enable -y @teemtee/stable && \
     dnf install -y tmt && \
     dnf autoremove -y && \
     dnf clean all && \
     # Prepare a directory for experimenting
     mkdir /tmt
+
+# Use tini as init to properly handle signals and reap zombie processes
+ENTRYPOINT ["/usr/bin/tini", "--"]
 
 # Prepare files for experimenting
 COPY .fmf /tmt/.fmf

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -284,6 +284,13 @@ easily inside a container::
     podman run -it --rm quay.io/teemtee/tmt bash
     podman run -it --rm quay.io/teemtee/tmt-all bash
 
+The official tmt container images include `tini <https://github.com/krallin/tini>`_
+as an init process to properly handle signals and reap zombie processes.
+If you are using a custom container image without a built-in init, use
+the ``--init`` flag to prevent zombie processes::
+
+    podman run --init -it --rm your-custom-image bash
+
 .. _pip_install:
 
 When installing using ``pip`` you might need to install additional

--- a/docs/releases/pending/4480.fmf
+++ b/docs/releases/pending/4480.fmf
@@ -1,0 +1,3 @@
+description: |
+    The official tmt container images now include ``tini`` as an init
+    process to properly handle signals and reap zombie processes.


### PR DESCRIPTION
The official tmt container images now include `tini` as the entrypoint to properly handle signals and reap zombie processes. Documentation has been updated to explain this and guide users with custom images to use the `--init` flag.

Generated-by: Claude Code

Resolves #4480 

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] include a release note
