### PR TITLE
Bump duration of some provision virtual tests

### DIFF
--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -14,3 +14,8 @@ adjust:
     because:
         we don't want to run the avc check for local testing as it
         needs root and we're executing tests under a regular user
+  - when: provision_how == virtual
+    duration+: "*2"
+    because: >
+      Virtual provision have started to be quite slow, will investigate
+      what caused the slowdown with the test /tests/execute/unresponsive


### PR DESCRIPTION
This test caused some flakyness. Not sure what caused the provision to become so slower, maybe this just became the first test that was preparing testcloud?

Pull Request Checklist

* [x] implement the feature