### PR TITLE
To/from "state" helpers for tmt state files

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -620,6 +620,17 @@ TMT_POLICY_ROOT
 
 __ https://tmt.readthedocs.io/en/stable/spec/policy.html
 
+TMT_STATE_FORMAT
+    Which format should tmt use for its on-disk storage of various state
+    information like run or step data, or the collection of discovered
+    tests.
+
+    .. note::
+
+        This does not affect user-provided files, like test, plan and
+        story metadata in fmf files, as well as various exports and
+        conversions. It merely affects files tmt uses for its own needs.
+
 .. _step-variables:
 
 Step Variables

--- a/spec/results.fmf
+++ b/spec/results.fmf
@@ -3,6 +3,19 @@ story:
     document the format in which test results are saved on storage.
 
 description: |
+    .. note::
+
+        Name of the file holding results is affected by the choice of
+        the on-disk format of tmt state files. See
+        :ref:`TMT_STATE_FORMAT<command-variables>` environment variable
+        which controls the selection.
+
+        By default, YAML is used, and the file would be called
+        ``results.yaml``. The specification below will stick to this
+        setting, and will describe the format of results in terms of
+        YAML, but the specification is applicable to other formats
+        as well.
+
     The following text defines a YAML file structure tmt uses for storing
     results. tmt itself will use it when saving results of ``execute`` step,
     and custom test results are required to follow it when creating their

--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -77,7 +77,7 @@ rlJournalStart
     testName="/test/wrong-json-results-file"
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test provides 'results.json' in valid JSON but wrong results format"
-        rlAssertGrep "Expected list in json data, got 'dict'." $rlRun_LOG
+        rlAssertGrep "Expected list in JSON data, got 'dict'." $rlRun_LOG
     rlPhaseEnd
 
     testName="/test/invalid-yaml-results-file"
@@ -89,7 +89,7 @@ rlJournalStart
     testName="/test/invalid-json-results-file"
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test provides 'results.json' not in JSON format"
-        rlAssertGrep "Invalid json syntax" $rlRun_LOG
+        rlAssertGrep "Invalid JSON syntax." $rlRun_LOG
     rlPhaseEnd
 
     testName="/test/wrong-yaml-content"

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -80,6 +80,7 @@ from tmt.utils import (
     HasRunWorkdir,
     Path,
     ShellScript,
+    StateFormat,
     WorkdirArgumentType,
     normalize_shell_script,
     to_yaml,
@@ -2934,6 +2935,74 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
 
         return self.workdir
 
+    @functools.cached_property
+    def state_format_marker_filepath(self) -> Path:
+        return self.run_workdir / 'state-format'
+
+    @functools.cached_property
+    def state_format(self) -> StateFormat:
+        try:
+            format_name = self.state_format_marker_filepath.read_text().strip()
+
+        except FileNotFoundError:
+            state_format = tmt.utils.get_state_format()
+
+            self.debug(
+                "No state format marker file found,"
+                f" using the default state format '{state_format.name}'."
+            )
+
+            return state_format
+
+        except Exception as exc:
+            raise GeneralError('Failed to read state format marker.') from exc
+
+        state_format = tmt.utils.get_state_format(format=format_name)
+
+        self.debug(
+            f"State format marker file found, using the '{state_format.name}' state format."
+        )
+
+        return state_format
+
+    def read_state(self, filepath: Path) -> Any:
+        """
+        Read a stored state from the given file.
+
+        .. important::
+
+            No deserialization is performed, it is the responsibility of the
+            caller to turn loaded structure, consisting of built-in-like
+            types, into objects of desired classes, e.g. by the power of
+            :py:meth:`tmt.container.SerializableContainer.deserialize`.
+
+        :param filepath: file to read the state from.
+        :returns: stored state as Python data structure.
+        """
+
+        return self.state_format.from_state(
+            self.read_file(Path(f'{filepath}{self.state_format.suffix}'))
+        )
+
+    def write_state(self, filepath: Path, data: Any) -> None:
+        """
+        Write a state into the given file.
+
+        .. important::
+
+            No serialization is performed, it is the responsibility of the
+            caller to turn internal objects into built-in-like Python types,
+            e.g. by the power of
+            :py:meth:`tmt.container.SerializableContainer.serialize`.
+
+        :param filepath: file to write the state into.
+        :param data: state as Python data structure.
+        """
+
+        return self.write_file(
+            Path(f'{filepath}{self.state_format.suffix}'), self.state_format.to_state(data)
+        )
+
     def load_workdir(self, *, with_logfiles: bool = True) -> None:
         """
         Prepare the run workdir and associated.
@@ -3078,8 +3147,13 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
         """
         Save list of selected plans and enabled steps
         """
+
+        self.state_format_marker_filepath.unlink(missing_ok=True)
+        self.state_format_marker_filepath.write_text(self.state_format.name)
+
         assert self.tree is not None  # narrow type
         assert self._cli_context_object is not None  # narrow type
+        assert self.workdir is not None  # narrow type
         data = RunData(
             root=str(self.tree.root) if self.tree.root else None,
             plans=[plan.name for plan in self._plans] if self._plans is not None else None,
@@ -3087,7 +3161,7 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
             environment=self.environment,
             remove=self.remove,
         )
-        self.write_state('run', data.to_serialized())
+        self.write_state(self.workdir / 'run', data.to_serialized())
 
     def load_from_workdir(self) -> None:
         """
@@ -3105,8 +3179,11 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
         #  which in turn is only called by status and clean, both cases where we do not want
         #  to attach the logfile loggers to.
         self.load_workdir(with_logfiles=False)
+
+        assert self.workdir is not None  # narrow type
+
         try:
-            self.data = RunData.from_serialized(self.read_state('run'))
+            self.data = RunData.from_serialized(self.read_state(self.workdir / 'run'))
 
         except tmt.utils.FileError:
             self.debug('Run data not found.')
@@ -3136,8 +3213,10 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
         """
         from tmt.base.plan import Plan
 
+        assert self.workdir is not None  # narrow type
+
         try:
-            self.data = RunData.from_serialized(self.read_state('run'))
+            self.data = RunData.from_serialized(self.read_state(self.workdir / 'run'))
 
         except tmt.utils.FileError:
             self.debug('Run data not found.')

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -82,7 +82,6 @@ from tmt.utils import (
     ShellScript,
     WorkdirArgumentType,
     normalize_shell_script,
-    to_state,
     to_yaml,
     verdict,
 )

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -82,6 +82,7 @@ from tmt.utils import (
     ShellScript,
     WorkdirArgumentType,
     normalize_shell_script,
+    to_state,
     to_yaml,
     verdict,
 )
@@ -3087,7 +3088,7 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
             environment=self.environment,
             remove=self.remove,
         )
-        self.write(Path('run.yaml'), to_yaml(data.to_serialized()))
+        self.write_state('run', data.to_serialized())
 
     def load_from_workdir(self) -> None:
         """
@@ -3106,9 +3107,8 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
         #  to attach the logfile loggers to.
         self.load_workdir(with_logfiles=False)
         try:
-            self.data = RunData.from_serialized(
-                tmt.utils.yaml_to_dict(self.read(Path('run.yaml')))
-            )
+            self.data = RunData.from_serialized(self.read_state('run'))
+
         except tmt.utils.FileError:
             self.debug('Run data not found.')
             return
@@ -3138,9 +3138,8 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
         from tmt.base.plan import Plan
 
         try:
-            self.data = RunData.from_serialized(
-                tmt.utils.yaml_to_dict(self.read(Path('run.yaml')))
-            )
+            self.data = RunData.from_serialized(self.read_state('run'))
+
         except tmt.utils.FileError:
             self.debug('Run data not found.')
             return

--- a/tmt/cli/about.py
+++ b/tmt/cli/about.py
@@ -1,6 +1,5 @@
 """``tmt about`` implementation"""
 
-import json
 import re
 from typing import Any
 
@@ -73,7 +72,9 @@ def _ls(context: Context, how: str, content: Any) -> None:
         )
 
     elif how in ('json', 'yaml'):
-        context.obj.print(json.dumps(content) if how == 'json' else tmt.utils.to_yaml(content))
+        context.obj.print(
+            tmt.utils.to_json(content) if how == 'json' else tmt.utils.to_yaml(content)
+        )
 
 
 @about.group(invoke_without_command=True, cls=CustomGroup)

--- a/tmt/export/_json.py
+++ b/tmt/export/_json.py
@@ -12,4 +12,4 @@ import tmt.export
 class JSONExporter(tmt.export.TrivialExporter):
     @classmethod
     def _export(cls, data: tmt.export._RawExported) -> str:
-        return json.dumps(data)
+        return tmt.utils.to_json(data)

--- a/tmt/export/_json.py
+++ b/tmt/export/_json.py
@@ -1,5 +1,3 @@
-import json
-
 import tmt.base.core
 import tmt.base.plan
 import tmt.export

--- a/tmt/frameworks/beakerlib.py
+++ b/tmt/frameworks/beakerlib.py
@@ -174,7 +174,7 @@ class Beakerlib(TestFramework):
         beakerlib_results_filepath = invocation.path / 'TestResults'
 
         try:
-            beakerlib_results = invocation.phase.read(beakerlib_results_filepath, level=3)
+            beakerlib_results = invocation.phase.read(beakerlib_results_filepath, debug_level=3)
         except tmt.utils.FileError:
             logger.debug(f"Unable to read '{beakerlib_results_filepath}'.", level=3)
             note.append('beakerlib: TestResults FileError')

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -12,14 +12,7 @@ from tmt.package_managers import (
     PackageManagerEngine,
     provides_package_manager,
 )
-from tmt.utils import (
-    Command,
-    CommandOutput,
-    GeneralError,
-    Path,
-    RunError,
-    ShellScript,
-)
+from tmt.utils import Command, CommandOutput, GeneralError, Path, RunError, ShellScript, from_json
 
 LOCALHOST_BOOTC_IMAGE_PREFIX = "localhost/tmt"
 

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -12,7 +12,7 @@ from tmt.package_managers import (
     PackageManagerEngine,
     provides_package_manager,
 )
-from tmt.utils import Command, CommandOutput, GeneralError, Path, RunError, ShellScript, from_json
+from tmt.utils import Command, CommandOutput, GeneralError, Path, RunError, ShellScript
 
 LOCALHOST_BOOTC_IMAGE_PREFIX = "localhost/tmt"
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -598,7 +598,7 @@ class Step(
         A set of members of the step workdir that should not be removed during pruning.
         """
 
-        return {f'step{tmt.utils.STATE_FILENAME_SUFFIX}'}
+        return {f'step{tmt.utils.STATE_FORMAT.suffix}'}
 
     def _check_duplicate_names(self, raw_data: list[_RawStepData]) -> None:
         """
@@ -843,7 +843,9 @@ class Step(
         """
 
         try:
-            raw_step_data: dict[Any, Any] = self.read_state('step')
+            assert self.plan.my_run is not None  # narrow type
+
+            raw_step_data: dict[Any, Any] = self.plan.my_run.read_state(self.step_workdir / 'step')
 
         except tmt.utils.GeneralError:
             self.debug('Step data not found.', level=2)
@@ -871,7 +873,9 @@ class Step(
             'status': self.status(),
             'data': [datum.to_serialized() for datum in self.data],
         }
-        self.write_state('step', content)
+
+        assert self.plan.my_run is not None  # narrow type
+        self.plan.my_run.write_state(self.step_workdir / 'step', content)
 
     def _load_results(
         self,
@@ -882,8 +886,10 @@ class Step(
         Load results of this step from the workdir
         """
 
+        assert self.plan.my_run is not None  # narrow type
+
         try:
-            raw_results: list[Any] = self.read_state('results')
+            raw_results: list[Any] = self.plan.my_run.read_state(self.step_workdir / 'results')
 
             return [result_class.from_serialized(raw_result) for raw_result in raw_results]
 
@@ -902,10 +908,12 @@ class Step(
         Save results of this step to the workdir
         """
 
+        assert self.plan.my_run is not None  # narrow type
+
         try:
             raw_results = [result.to_serialized() for result in results]
 
-            self.write_state('results', raw_results)
+            self.plan.my_run.write_state(self.step_workdir / 'results', raw_results)
 
         except Exception as exc:
             raise GeneralError('Cannot save step results.') from exc

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -598,7 +598,12 @@ class Step(
         A set of members of the step workdir that should not be removed during pruning.
         """
 
-        return {f'step{tmt.utils.STATE_FORMAT.suffix}'}
+        members: set[str] = set()
+
+        if self.plan.my_run:
+            members = {*members, f'step{self.plan.my_run.state_format.suffix}'}
+
+        return members
 
     def _check_duplicate_names(self, raw_data: list[_RawStepData]) -> None:
         """

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -843,7 +843,7 @@ class Step(
         """
 
         try:
-            raw_step_data: dict[Any, Any] = tmt.utils.yaml_to_dict(self.read_state('step'))
+            raw_step_data: dict[Any, Any] = self.read_state('step')
 
         except tmt.utils.GeneralError:
             self.debug('Step data not found.', level=2)
@@ -883,7 +883,7 @@ class Step(
         """
 
         try:
-            raw_results: list[Any] = tmt.utils.yaml_to_list(self.read_state('results'))
+            raw_results: list[Any] = self.read_state('results')
 
             return [result_class.from_serialized(raw_result) for raw_result in raw_results]
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -598,7 +598,7 @@ class Step(
         A set of members of the step workdir that should not be removed during pruning.
         """
 
-        return {'step.yaml'}
+        return {f'step{tmt.utils.STATE_FILENAME_SUFFIX}'}
 
     def _check_duplicate_names(self, raw_data: list[_RawStepData]) -> None:
         """
@@ -843,7 +843,7 @@ class Step(
         """
 
         try:
-            raw_step_data: dict[Any, Any] = tmt.utils.yaml_to_dict(self.read(Path('step.yaml')))
+            raw_step_data: dict[Any, Any] = tmt.utils.yaml_to_dict(self.read_state('step'))
 
         except tmt.utils.GeneralError:
             self.debug('Step data not found.', level=2)
@@ -871,7 +871,7 @@ class Step(
             'status': self.status(),
             'data': [datum.to_serialized() for datum in self.data],
         }
-        self.write(Path('step.yaml'), tmt.utils.to_yaml(content))
+        self.write_state('step', content)
 
     def _load_results(
         self,
@@ -883,7 +883,7 @@ class Step(
         """
 
         try:
-            raw_results: list[Any] = tmt.utils.yaml_to_list(self.read(Path('results.yaml')))
+            raw_results: list[Any] = tmt.utils.yaml_to_list(self.read_state('results'))
 
             return [result_class.from_serialized(raw_result) for raw_result in raw_results]
 
@@ -905,7 +905,7 @@ class Step(
         try:
             raw_results = [result.to_serialized() for result in results]
 
-            self.write(Path('results.yaml'), tmt.utils.to_yaml(raw_results))
+            self.write_state('results', raw_results)
 
         except Exception as exc:
             raise GeneralError('Cannot save step results.') from exc

--- a/tmt/steps/cleanup/__init__.py
+++ b/tmt/steps/cleanup/__init__.py
@@ -77,7 +77,7 @@ class Cleanup(tmt.steps.StepWithQueue[CleanupStepData, PluginOutcome]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, 'results.yaml'}
+        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FILENAME_SUFFIX}'}
 
     def wake(self) -> None:
         """

--- a/tmt/steps/cleanup/__init__.py
+++ b/tmt/steps/cleanup/__init__.py
@@ -77,7 +77,14 @@ class Cleanup(tmt.steps.StepWithQueue[CleanupStepData, PluginOutcome]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FORMAT.suffix}'}
+        members = {
+            *super()._preserved_workdir_members,
+        }
+
+        if self.plan.my_run:
+            members = {*members, f'results{self.plan.my_run.state_format.suffix}'}
+
+        return members
 
     def wake(self) -> None:
         """

--- a/tmt/steps/cleanup/__init__.py
+++ b/tmt/steps/cleanup/__init__.py
@@ -77,7 +77,7 @@ class Cleanup(tmt.steps.StepWithQueue[CleanupStepData, PluginOutcome]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FILENAME_SUFFIX}'}
+        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FORMAT.suffix}'}
 
     def wake(self) -> None:
         """

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -630,7 +630,14 @@ class Discover(tmt.steps.Step):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, f'tests{tmt.utils.STATE_FORMAT.suffix}'}
+        members = {
+            *super()._preserved_workdir_members,
+        }
+
+        if self.plan.my_run:
+            members = {*members, f'tests{self.plan.my_run.state_format.suffix}'}
+
+        return members
 
     @property
     def required_tests(self) -> list[TestOrigin]:

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -630,7 +630,7 @@ class Discover(tmt.steps.Step):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, 'tests.yaml'}
+        return {*super()._preserved_workdir_members, f'tests{tmt.utils.STATE_FILENAME_SUFFIX}'}
 
     @property
     def required_tests(self) -> list[TestOrigin]:
@@ -722,7 +722,7 @@ class Discover(tmt.steps.Step):
 
         try:
             raw_test_data: list[tmt.export._RawExportedInstance] = tmt.utils.yaml_to_list(
-                self.read(Path('tests.yaml'))
+                self.read_state('tests')
             )
 
             self._tests = {}
@@ -782,7 +782,7 @@ class Discover(tmt.steps.Step):
 
                 raw_test_data.append(exported_test)
 
-        self.write(Path('tests.yaml'), tmt.utils.to_yaml(raw_test_data))
+        self.write_state('tests', raw_test_data)
 
     def _discover_from_execute(self) -> None:
         """

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -721,9 +721,7 @@ class Discover(tmt.steps.Step):
             super().load()
 
         try:
-            raw_test_data: list[tmt.export._RawExportedInstance] = tmt.utils.yaml_to_list(
-                self.read_state('tests')
-            )
+            raw_test_data: list[tmt.export._RawExportedInstance] = self.read_state('tests')
 
             self._tests = {}
 

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -630,7 +630,7 @@ class Discover(tmt.steps.Step):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, f'tests{tmt.utils.STATE_FILENAME_SUFFIX}'}
+        return {*super()._preserved_workdir_members, f'tests{tmt.utils.STATE_FORMAT.suffix}'}
 
     @property
     def required_tests(self) -> list[TestOrigin]:
@@ -720,8 +720,12 @@ class Discover(tmt.steps.Step):
         else:
             super().load()
 
+        assert self.plan.my_run is not None  # narrow type
+
         try:
-            raw_test_data: list[tmt.export._RawExportedInstance] = self.read_state('tests')
+            raw_test_data: list[tmt.export._RawExportedInstance] = self.plan.my_run.read_state(
+                self.step_workdir / 'tests'
+            )
 
             self._tests = {}
 
@@ -780,7 +784,8 @@ class Discover(tmt.steps.Step):
 
                 raw_test_data.append(exported_test)
 
-        self.write_state('tests', raw_test_data)
+        assert self.plan.my_run is not None  # narrow type
+        self.plan.my_run.write_state(self.step_workdir / 'tests', raw_test_data)
 
     def _discover_from_execute(self) -> None:
         """

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1079,7 +1079,7 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
         return {
             *super()._preserved_workdir_members,
             'data',
-            f'results{tmt.utils.STATE_FILENAME_SUFFIX}',
+            f'results{tmt.utils.STATE_FORMAT.suffix}',
         }
 
     def load(self) -> None:

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1076,11 +1076,15 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {
+        members = {
             *super()._preserved_workdir_members,
             'data',
-            f'results{tmt.utils.STATE_FORMAT.suffix}',
         }
+
+        if self.plan.my_run:
+            members = {*members, f'results{self.plan.my_run.state_format.suffix}'}
+
+        return members
 
     def load(self) -> None:
         """

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1019,7 +1019,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
             f"Adjust the test 'duration' attribute if necessary.\n"
             f"https://tmt.readthedocs.io/en/stable/spec/tests.html#duration\n",
             mode='a',
-            level=3,
+            debug_level=3,
         )
 
     @property
@@ -1076,7 +1076,11 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, 'data', 'results.yaml'}
+        return {
+            *super()._preserved_workdir_members,
+            'data',
+            f'results{tmt.utils.STATE_FILENAME_SUFFIX}',
+        }
 
     def load(self) -> None:
         """

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -441,7 +441,9 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
 
         # Save the captured output. Do not let the follow-up pulls
         # overwrite it.
-        self.write(invocation.path / TEST_OUTPUT_FILENAME, output.stdout or '', mode='a', level=3)
+        self.write(
+            invocation.path / TEST_OUTPUT_FILENAME, output.stdout or '', mode='a', debug_level=3
+        )
 
         # Reset `has-rsync` fact: tmt is expected to install rsync if it
         # is missing after a test. To achieve that, pretend we don't

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -67,10 +67,17 @@ class Finish(tmt.steps.StepWithQueue[FinishStepData, PluginOutcome]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {
+        members = {
             *super()._preserved_workdir_members,
-            f'results{tmt.utils.DEFAULT_STATE_FORMAT.suffix}',
         }
+
+        if self.plan.my_run is not None:
+            members = {
+                *members,
+                f'results{self.plan.my_run.state_format.suffix}',
+            }
+
+        return members
 
     def wake(self) -> None:
         """

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -67,7 +67,7 @@ class Finish(tmt.steps.StepWithQueue[FinishStepData, PluginOutcome]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, 'results.yaml'}
+        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FILENAME_SUFFIX}'}
 
     def wake(self) -> None:
         """

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -67,7 +67,10 @@ class Finish(tmt.steps.StepWithQueue[FinishStepData, PluginOutcome]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FORMAT.suffix}'}
+        return {
+            *super()._preserved_workdir_members,
+            f'results{tmt.utils.DEFAULT_STATE_FORMAT.suffix}',
+        }
 
     def wake(self) -> None:
         """

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -67,7 +67,7 @@ class Finish(tmt.steps.StepWithQueue[FinishStepData, PluginOutcome]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FILENAME_SUFFIX}'}
+        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FORMAT.suffix}'}
 
     def wake(self) -> None:
         """

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -123,7 +123,7 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FILENAME_SUFFIX}'}
+        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FORMAT.suffix}'}
 
     def __init__(
         self,

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -123,7 +123,14 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FORMAT.suffix}'}
+        members = {
+            *super()._preserved_workdir_members,
+        }
+
+        if self.plan.my_run:
+            members = {*members, f'results{self.plan.my_run.state_format.suffix}'}
+
+        return members
 
     def __init__(
         self,

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -123,7 +123,7 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, 'results.yaml'}
+        return {*super()._preserved_workdir_members, f'results{tmt.utils.STATE_FILENAME_SUFFIX}'}
 
     def __init__(
         self,

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -393,9 +393,7 @@ class Provision(tmt.steps.Step):
 
         super().load()
         try:
-            raw_guest_data: dict[str, dict[str, Any]] = tmt.utils.yaml_to_dict(
-                self.read_state('guests')
-            )
+            raw_guest_data: dict[str, dict[str, Any]] = self.read_state('guests')
 
             self._guest_data = {
                 name: SerializableContainer.unserialize(guest_data, self._logger)

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -364,11 +364,15 @@ class Provision(tmt.steps.Step):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {
+        members = {
             *super()._preserved_workdir_members,
-            f'guests{tmt.utils.STATE_FORMAT.suffix}',
             'inventory.yaml',
         }
+
+        if self.plan.my_run:
+            members = {*members, f'guests{self.plan.my_run.state_format.suffix}'}
+
+        return members
 
     @property
     def is_multihost(self) -> bool:

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -366,7 +366,7 @@ class Provision(tmt.steps.Step):
 
         return {
             *super()._preserved_workdir_members,
-            f'guests{tmt.utils.STATE_FILENAME_SUFFIX}',
+            f'guests{tmt.utils.STATE_FORMAT.suffix}',
             'inventory.yaml',
         }
 
@@ -392,8 +392,13 @@ class Provision(tmt.steps.Step):
         """
 
         super().load()
+
+        assert self.plan.my_run is not None  # narrow type
+
         try:
-            raw_guest_data: dict[str, dict[str, Any]] = self.read_state('guests')
+            raw_guest_data: dict[str, dict[str, Any]] = self.plan.my_run.read_state(
+                self.step_workdir / 'guests'
+            )
 
             self._guest_data = {
                 name: SerializableContainer.unserialize(guest_data, self._logger)
@@ -409,12 +414,15 @@ class Provision(tmt.steps.Step):
         """
 
         super().save()
+
+        assert self.plan.my_run is not None  # narrow type
+
         try:
             raw_guest_data = {
                 guest.name: guest.save().to_serialized() for guest in self.ready_guests
             }
 
-            self.write_state('guests', raw_guest_data)
+            self.plan.my_run.write_state(self.step_workdir / 'guests', raw_guest_data)
         except tmt.utils.FileError:
             self.debug('Failed to save provisioned guests.')
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -364,7 +364,11 @@ class Provision(tmt.steps.Step):
         A set of members of the step workdir that should not be removed.
         """
 
-        return {*super()._preserved_workdir_members, 'guests.yaml', 'inventory.yaml'}
+        return {
+            *super()._preserved_workdir_members,
+            f'guests{tmt.utils.STATE_FILENAME_SUFFIX}',
+            'inventory.yaml',
+        }
 
     @property
     def is_multihost(self) -> bool:
@@ -390,7 +394,7 @@ class Provision(tmt.steps.Step):
         super().load()
         try:
             raw_guest_data: dict[str, dict[str, Any]] = tmt.utils.yaml_to_dict(
-                self.read(Path('guests.yaml'))
+                self.read_state('guests')
             )
 
             self._guest_data = {
@@ -412,7 +416,7 @@ class Provision(tmt.steps.Step):
                 guest.name: guest.save().to_serialized() for guest in self.ready_guests
             }
 
-            self.write(Path('guests.yaml'), tmt.utils.to_yaml(raw_guest_data))
+            self.write_state('guests', raw_guest_data)
         except tmt.utils.FileError:
             self.debug('Failed to save provisioned guests.')
 

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -4,7 +4,6 @@ import dataclasses
 import datetime
 import functools
 import importlib.metadata
-import json
 import logging
 import re
 import threading

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1071,7 +1071,7 @@ ostreecontainer --url {host.bootc_image_url}
 %pre
 #!/bin/sh
 cat > /etc/ostree/auth.json <<EOF
-{json.dumps(host.bootc_credentials)}
+{tmt.utils.to_json(host.bootc_credentials)}
 EOF
 %end
 """

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -392,7 +392,7 @@ class Try(tmt.utils.Common):
             environment=self.environment,
             remove=self.opt('remove'),
         )
-        self.write(Path('run.yaml'), tmt.utils.to_yaml(data.to_serialized()))
+        self.write_state('run', data.to_serialized())
 
     def choose_action(self) -> 'Action':
         """

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -385,6 +385,7 @@ class Try(tmt.utils.Common):
         """
         assert self.tree is not None  # narrow type
         assert self._cli_context_object is not None  # narrow type
+        assert self.workdir is not None  # narrow type
         data = RunData(
             root=str(self.tree.root) if self.tree.root else None,
             plans=[plan.name for plan in self.plans],
@@ -392,7 +393,7 @@ class Try(tmt.utils.Common):
             environment=self.environment,
             remove=self.opt('remove'),
         )
-        self.write_state('run', data.to_serialized())
+        tmt.utils.write_state(self.workdir / 'run', data.to_serialized())
 
     def choose_action(self) -> 'Action':
         """

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -3869,7 +3869,7 @@ def get_state_format(format: Optional[str] = None) -> StateFormat:
 
     :param format: if set, the format of matching name is looked up.
     :returns: state format by the name of ``format``, or the default
-        format, :py:data:`STATE_FORMAT`.
+        format, :py:data:`DEFAULT_STATE_FORMAT`.
     """
 
     if format is None:
@@ -3898,7 +3898,7 @@ def from_state(state: str, format_name: Optional[str] = None) -> Any:
         No deserialization is performed, it is the responsibility of the
         caller to turn loaded structure, consisting of built-in-like
         types, into objects of desired classes, e.g. by the power of
-        :py:meth:`tmt.container.SerializableContainer.deserialize`.
+        :py:meth:`tmt.container.SerializableContainer.from_serialized`.
 
     :param state: state written down in the ``format`` format.
     :param format_name: if set, use this format instead of the default
@@ -3911,7 +3911,7 @@ def from_state(state: str, format_name: Optional[str] = None) -> Any:
     return state_format.from_state(state)
 
 
-def to_state(state: Any, format_name: Optional[str] = None) -> str:
+def to_state(data: Any, format_name: Optional[str] = None) -> str:
     """
     Turn Python data structure into a stored state.
 
@@ -3920,7 +3920,7 @@ def to_state(state: Any, format_name: Optional[str] = None) -> str:
         No serialization is performed, it is the responsibility of the
         caller to turn internal objects into built-in-like Python types,
         e.g. by the power of
-        :py:meth:`tmt.container.SerializableContainer.serialize`.
+        :py:meth:`tmt.container.SerializableContainer.to_serialized`.
 
     :param data: Python data structure.
     :param format_name: if set, use this format instead of the default
@@ -3930,7 +3930,7 @@ def to_state(state: Any, format_name: Optional[str] = None) -> str:
 
     state_format = get_state_format(format=format_name)
 
-    return state_format.to_state(state)
+    return state_format.to_state(data)
 
 
 def read_state(filepath: Path, format_name: Optional[str] = None) -> Any:
@@ -3942,7 +3942,7 @@ def read_state(filepath: Path, format_name: Optional[str] = None) -> Any:
         No deserialization is performed, it is the responsibility of the
         caller to turn loaded structure, consisting of built-in-like
         types, into objects of desired classes, e.g. by the power of
-        :py:meth:`tmt.container.SerializableContainer.deserialize`.
+        :py:meth:`tmt.container.SerializableContainer.from_serialized`.
 
     :param filepath: file to read the state from.
     :param format_name: if set, use this format instead of the default
@@ -3955,7 +3955,7 @@ def read_state(filepath: Path, format_name: Optional[str] = None) -> Any:
     return state_format.from_state(Path(f'{filepath}{state_format.suffix}').read_text())
 
 
-def write_state(filepath: Path, data: Any, format: Optional[str] = None) -> None:
+def write_state(filepath: Path, data: Any, format_name: Optional[str] = None) -> None:
     """
     Write a state into the given file.
 
@@ -3964,7 +3964,7 @@ def write_state(filepath: Path, data: Any, format: Optional[str] = None) -> None
         No serialization is performed, it is the responsibility of the
         caller to turn internal objects into built-in-like Python types,
         e.g. by the power of
-        :py:meth:`tmt.container.SerializableContainer.serialize`.
+        :py:meth:`tmt.container.SerializableContainer.to_serialized`.
 
     :param filepath: file to write the state into.
     :param data: state as Python data structure.
@@ -3972,7 +3972,7 @@ def write_state(filepath: Path, data: Any, format: Optional[str] = None) -> None
         one.
     """
 
-    state_format = get_state_format(format=format)
+    state_format = get_state_format(format=format_name)
 
     Path(f'{filepath}{state_format.suffix}').write_text(state_format.to_state(data))
 

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -3857,7 +3857,7 @@ class StateFormat:
 #: state information. It is a mapping between format name and three
 #: items, a file suffix for files holding the state, and Python-to-format
 #: and format-to-Python converters.
-_STATE_FORMATS: dict[str, StateFormat] = {
+_SUPPORTED_STATE_FORMATS: dict[str, StateFormat] = {
     'json': StateFormat('json', '.json', to_json, from_json),
     'yaml': StateFormat('yaml', '.yaml', to_yaml, from_yaml),
 }
@@ -3873,10 +3873,10 @@ def get_state_format(format: Optional[str] = None) -> StateFormat:
     """
 
     if format is None:
-        return STATE_FORMAT
+        return DEFAULT_STATE_FORMAT
 
     try:
-        return _STATE_FORMATS[format]
+        return _SUPPORTED_STATE_FORMATS[format]
 
     except Exception as exc:
         raise GeneralError(f"tmt state file format '{format}' is not supported.") from exc
@@ -3884,7 +3884,7 @@ def get_state_format(format: Optional[str] = None) -> StateFormat:
 
 #: The default state format. It is initialized via ``TMT_STATE_FORMAT``
 #: environment variable.
-STATE_FORMAT: Final[StateFormat] = get_state_format(
+DEFAULT_STATE_FORMAT: Final[StateFormat] = get_state_format(
     format=os.environ.get('TMT_STATE_FORMAT', 'yaml').lower()
 )
 

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -2395,47 +2395,111 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             logger=self._logger,
         )
 
-    def read(self, path: Path, level: int = 2) -> str:
+    def read_file(self, filepath: Path, debug_level: int = 2) -> str:
         """
-        Read a file from the workdir
+        Read a file from the workdir of this object.
+
+        :param filepath: file to read. It will be treated as relative to
+            :py:attr:`workdir`.
+        :param debug_level: a level of ``debug`` verbosity to use when
+            logging the operation.
+        :returns: content of the file.
         """
 
         if self.workdir:
-            path = self.workdir / path
-        self.debug(f"Read file '{path}'.", level=level)
+            filepath = self.workdir / filepath
+
+        self.debug(f"Read file '{filepath}'.", level=debug_level)
+
         try:
-            return path.read_text(encoding='utf-8', errors='replace')
+            return filepath.read_text(encoding='utf-8', errors='replace')
 
         except OSError as error:
-            raise FileError(f"Failed to read from '{path}'.") from error
+            raise FileError(f"Failed to read from '{filepath}'.") from error
 
-    def write(
+    def write_file(
         self,
-        path: Path,
+        filepath: Path,
         data: str,
         mode: WriteMode = 'w',
-        level: int = 2,
+        debug_level: int = 2,
     ) -> None:
         """
-        Write a file to the workdir
+        Write into a file in the workdir of this object.
+
+        :param filepath: file to modify. It will be treated as relative to
+            :py:attr:`workdir`.
+        :param data: content to write into the file.
+        :param mode: whether the file should be open for writing, ``w``,
+            or for appending, ``a``.
+        :param debug_level: a level of ``debug`` verbosity to use when
+            logging the operation.
         """
 
         if self.workdir:
-            path = self.workdir / path
-        action = 'Append to' if mode == 'a' else 'Write'
-        self.debug(f"{action} file '{path}'.", level=level)
-        # Dry mode
+            filepath = self.workdir / filepath
+
+        self.debug(
+            f"{'Append to' if mode == 'a' else 'Write'} file '{filepath}'.", level=debug_level
+        )
+
         if self.is_dry_run:
             return
+
         try:
             if mode == 'a':
-                path.append_text(data, encoding='utf-8', errors='replace')
+                filepath.append_text(data, encoding='utf-8', errors='replace')
 
             else:
-                path.write_text(data, encoding='utf-8', errors='replace')
+                filepath.write_text(data, encoding='utf-8', errors='replace')
 
         except OSError as error:
-            raise FileError(f"Failed to write into '{path}' file.") from error
+            raise FileError(f"Failed to write into '{filepath}'.") from error
+
+    # TODO: too many of these in the code, let's get rid of them later.
+    read = read_file
+    write = write_file
+
+    def read_state(self, name: str) -> Any:
+        """
+        Read a state from the workdir of this object.
+
+        State is stored in a file in the workdir, using the state ``name``
+        to construct the file name.
+
+        .. important::
+
+            This method performs no deserialization, it is the
+            responsibility of the caller to turn loaded structure,
+            consisting of built-in-like types, into objects of desired
+            classes, e.g. by the power of
+            :py:meth:`tmt.container.SerializableContainer.deserialize`.
+
+        :param name: name of the state info to read.
+        :returns: stored state as Python data structure.
+        """
+
+        return from_state(self.read_file(Path(f'{name}{STATE_FILENAME_SUFFIX}')))
+
+    def write_state(self, name: str, data: Any) -> None:
+        """
+        Write a state into the workdir of this object.
+
+        State is stored in a file in the workdir, using the state ``name``
+        to construct the file name.
+
+        .. important::
+
+            This method performs no serialization, it is the
+            responsibility of the caller to turn internal objects into
+            built-in-like Python types, e.g. by the power of
+            :py:meth:`tmt.container.SerializableContainer.serialize`.
+
+        :param name: name of the state info to write.
+        :param data: content to save.
+        """
+
+        return self.write_file(Path(f'{name}{STATE_FILENAME_SUFFIX}'), to_state(data))
 
     def _workdir_init(self, id_: WorkdirArgumentType = None) -> None:
         """
@@ -3483,11 +3547,19 @@ def filter_paths(directory: Path, searching: list[str], files_only: bool = False
 YamlTypType = Literal['rt', 'safe', 'unsafe', 'base']
 
 
+# Custom representers of various classes tmt puts into data structures.
+# TODO: it would be nice if this could be pluggable, dynamic, or owned
+# by 3rd party library, but for now we can get away with static mappings
+# for different formats.
 def _yaml_represent_path(representer: Representer, path: Path) -> Any:
     return representer.represent_scalar('tag:yaml.org,2002:str', str(path))
 
 
-#: Custom representers for common classes tmt puts into data structures.
+def _json_represent_path(path: Path) -> Any:
+    return str(path)
+
+
+#: Custom representers of various classes for YAML output.
 _YAML_REPRESENTERS: dict[Any, Callable[[Representer, Any], Any]] = {
     # Various path-like classes.
     pathlib.Path: _yaml_represent_path,  # noqa: TID251
@@ -3498,6 +3570,18 @@ _YAML_REPRESENTERS: dict[Any, Callable[[Representer, Any], Any]] = {
     Environment: lambda representer, environment: representer.represent_mapping(
         'tag:yaml.org,2002:map', environment.to_fmf_spec()
     ),
+}
+
+
+#: Custom representers of various classes for JSON output.
+_JSON_REPRESENTERS: dict[Any, Callable[[Any], Any]] = {
+    # Various path-like classes.
+    pathlib.Path: _json_represent_path,  # noqa: TID251
+    pathlib.PosixPath: _json_represent_path,  # noqa: TID251
+    Path: _json_represent_path,
+    # Environment representation, which is basically nothing but
+    # a key:value mapping.
+    Environment: lambda environment: environment.to_fmf_spec(),
 }
 
 
@@ -3727,19 +3811,89 @@ def yaml_to_list(data: str, *, yaml_type: YamlTypType = 'safe') -> list[Any]:
     return loaded_data
 
 
-def json_to_list(data: Any) -> list[Any]:
+def _custom_json_encoder(obj: Any) -> Any:
+    for klass, representer in _JSON_REPRESENTERS.items():
+        if isinstance(obj, klass):
+            return representer(obj)
+
+    raise TypeError(f'Cannot serialize object of {type(obj)}')
+
+
+def to_json(
+    data: Any,
+    *,
+    sort: bool = False,
+) -> str:
     """
-    Convert json into list
+    Convert a Python data structure into its JSON representation.
+
+    :param data: Python data structure to convert into JSON.
+    :param sort: if set, sort dictionary keys in the JSON output.
+    :returns: a JSON representation of ``data``.
+    """
+
+    return json.dumps(data, sort_keys=sort, default=_custom_json_encoder)
+
+
+def from_json(data: str) -> Any:
+    """
+    Convert a JSON content into the corresponding Python data structures.
+
+    :param data: JSON content to convert into Python data structures.
+    :returns: Python representation of ``data`` JSON content.
     """
 
     try:
-        loaded_data = json.loads(data)
-    except json.decoder.JSONDecodeError as error:
-        raise GeneralError("Invalid json syntax.") from error
+        return json.loads(data)
+
+    except json.JSONDecodeError as error:
+        raise GeneralError('Invalid JSON syntax.') from error
+
+
+def json_to_list(data: str) -> list[T]:
+    """
+    Convert a JSON content into a Python list.
+
+    :param data: JSON content to convert into Python list.
+    :returns: Python representation of ``data`` JSON content. If the JSON
+        contains no data, empty list is returned.
+    :raises GeneralError: when the JSON content does not represent a list.
+    """
+
+    loaded_data = from_json(data)
+
+    if loaded_data is None:
+        return []
 
     if not isinstance(loaded_data, list):
-        raise GeneralError(f"Expected list in json data, got '{type(loaded_data).__name__}'.")
+        raise GeneralError(f"Expected list in JSON data, got '{type(loaded_data).__name__}'.")
+
     return loaded_data
+
+
+#: Format conversions tmt can use for storing and reading its on-disk
+#: state information. It is a mapping between format name and three
+#: items, a file suffix for files holding the state, and Python-to-format
+#: and format-to-Python converters.
+_STATE_FORMATS: dict[
+    str,
+    tuple[
+        str,
+        Callable[[Any], str],
+        Callable[[str], Any],
+    ],
+] = {
+    'json': ('.json', to_json, from_json),
+    'yaml': ('.yaml', to_yaml, from_yaml),
+}
+
+try:
+    STATE_FILENAME_SUFFIX, to_state, from_state = _STATE_FORMATS[
+        os.environ.get('TMT_STATE_FORMAT', 'yaml').lower()
+    ]
+
+except Exception as exc:
+    raise GeneralError("Unknown format of tmt state files.") from exc
 
 
 def markdown_to_html(filename: Path) -> str:
@@ -4770,7 +4924,7 @@ class RetryStrategy(urllib3.util.retry.Retry):
         # Handle other 403 cases
         elif 'X-GitHub-Request-Id' in headers:
             try:
-                error_msg = json.loads(response.data.decode('utf-8')).get('message', '').lower()
+                error_msg = from_json(response.data.decode('utf-8')).get('message', '').lower()
                 if self.logger:
                     self.logger.warning(f"GitHub API error: {error_msg}")
             except (ValueError, AttributeError) as e:

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -38,6 +38,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Final,
     Generic,
     Literal,
     Optional,
@@ -2399,14 +2400,14 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         """
         Read a file from the workdir of this object.
 
-        :param filepath: file to read. It will be treated as relative to
-            :py:attr:`workdir`.
+        :param filepath: file to read. If the path is not absolute, it
+            will be treated as relative to :py:attr:`workdir`.
         :param debug_level: a level of ``debug`` verbosity to use when
             logging the operation.
         :returns: content of the file.
         """
 
-        if self.workdir:
+        if self.workdir and not filepath.is_absolute():
             filepath = self.workdir / filepath
 
         self.debug(f"Read file '{filepath}'.", level=debug_level)
@@ -2427,8 +2428,8 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         """
         Write into a file in the workdir of this object.
 
-        :param filepath: file to modify. It will be treated as relative to
-            :py:attr:`workdir`.
+        :param filepath: file to read. If the path is not absolute, it
+            will be treated as relative to :py:attr:`workdir`.
         :param data: content to write into the file.
         :param mode: whether the file should be open for writing, ``w``,
             or for appending, ``a``.
@@ -2436,7 +2437,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             logging the operation.
         """
 
-        if self.workdir:
+        if self.workdir and not filepath.is_absolute():
             filepath = self.workdir / filepath
 
         self.debug(
@@ -2459,47 +2460,6 @@ class Common(_CommonBase, metaclass=_CommonMeta):
     # TODO: too many of these in the code, let's get rid of them later.
     read = read_file
     write = write_file
-
-    def read_state(self, name: str) -> Any:
-        """
-        Read a state from the workdir of this object.
-
-        State is stored in a file in the workdir, using the state ``name``
-        to construct the file name.
-
-        .. important::
-
-            This method performs no deserialization, it is the
-            responsibility of the caller to turn loaded structure,
-            consisting of built-in-like types, into objects of desired
-            classes, e.g. by the power of
-            :py:meth:`tmt.container.SerializableContainer.deserialize`.
-
-        :param name: name of the state info to read.
-        :returns: stored state as Python data structure.
-        """
-
-        return from_state(self.read_file(Path(f'{name}{STATE_FILENAME_SUFFIX}')))
-
-    def write_state(self, name: str, data: Any) -> None:
-        """
-        Write a state into the workdir of this object.
-
-        State is stored in a file in the workdir, using the state ``name``
-        to construct the file name.
-
-        .. important::
-
-            This method performs no serialization, it is the
-            responsibility of the caller to turn internal objects into
-            built-in-like Python types, e.g. by the power of
-            :py:meth:`tmt.container.SerializableContainer.serialize`.
-
-        :param name: name of the state info to write.
-        :param data: content to save.
-        """
-
-        return self.write_file(Path(f'{name}{STATE_FILENAME_SUFFIX}'), to_state(data))
 
     def _workdir_init(self, id_: WorkdirArgumentType = None) -> None:
         """
@@ -3871,29 +3831,150 @@ def json_to_list(data: str) -> list[T]:
     return loaded_data
 
 
+#
+# State info tmt stores in various state files.
+#
+
+
+@container
+class StateFormat:
+    #: Format name
+    name: str
+
+    #: Format suffix
+    suffix: str
+
+    #: Convert data structure to string containing the structure
+    #: representation in this format.
+    to_state: Callable[[Any], str]
+
+    #: Convert data structure representation in this format into Python
+    #: data structure.
+    from_state: Callable[[str], Any]
+
+
 #: Format conversions tmt can use for storing and reading its on-disk
 #: state information. It is a mapping between format name and three
 #: items, a file suffix for files holding the state, and Python-to-format
 #: and format-to-Python converters.
-_STATE_FORMATS: dict[
-    str,
-    tuple[
-        str,
-        Callable[[Any], str],
-        Callable[[str], Any],
-    ],
-] = {
-    'json': ('.json', to_json, from_json),
-    'yaml': ('.yaml', to_yaml, from_yaml),
+_STATE_FORMATS: dict[str, StateFormat] = {
+    'json': StateFormat('json', '.json', to_json, from_json),
+    'yaml': StateFormat('yaml', '.yaml', to_yaml, from_yaml),
 }
 
-try:
-    STATE_FILENAME_SUFFIX, to_state, from_state = _STATE_FORMATS[
-        os.environ.get('TMT_STATE_FORMAT', 'yaml').lower()
-    ]
 
-except Exception as exc:
-    raise GeneralError("Unknown format of tmt state files.") from exc
+def get_state_format(format: Optional[str] = None) -> StateFormat:
+    """
+    Get a state format by the given name.
+
+    :param format: if set, the format of matching name is looked up.
+    :returns: state format by the name of ``format``, or the default
+        format, :py:data:`STATE_FORMAT`.
+    """
+
+    if format is None:
+        return STATE_FORMAT
+
+    try:
+        return _STATE_FORMATS[format]
+
+    except Exception as exc:
+        raise GeneralError(f"tmt state file format '{format}' is not supported.") from exc
+
+
+#: The default state format. It is initialized via ``TMT_STATE_FORMAT``
+#: environment variable.
+STATE_FORMAT: Final[StateFormat] = get_state_format(
+    format=os.environ.get('TMT_STATE_FORMAT', 'yaml').lower()
+)
+
+
+def from_state(state: str, format_name: Optional[str] = None) -> Any:
+    """
+    Turn stored state into Python data structure.
+
+    .. important::
+
+        No deserialization is performed, it is the responsibility of the
+        caller to turn loaded structure, consisting of built-in-like
+        types, into objects of desired classes, e.g. by the power of
+        :py:meth:`tmt.container.SerializableContainer.deserialize`.
+
+    :param state: state written down in the ``format`` format.
+    :param format_name: if set, use this format instead of the default
+        one.
+    :returns: stored state as Python data structure.
+    """
+
+    state_format = get_state_format(format=format_name)
+
+    return state_format.from_state(state)
+
+
+def to_state(state: Any, format_name: Optional[str] = None) -> str:
+    """
+    Turn Python data structure into a stored state.
+
+    .. important::
+
+        No serialization is performed, it is the responsibility of the
+        caller to turn internal objects into built-in-like Python types,
+        e.g. by the power of
+        :py:meth:`tmt.container.SerializableContainer.serialize`.
+
+    :param data: Python data structure.
+    :param format_name: if set, use this format instead of the default
+        one.
+    :returns: Python data structure as stored state.
+    """
+
+    state_format = get_state_format(format=format_name)
+
+    return state_format.to_state(state)
+
+
+def read_state(filepath: Path, format_name: Optional[str] = None) -> Any:
+    """
+    Read a stored state from the given file.
+
+    .. important::
+
+        No deserialization is performed, it is the responsibility of the
+        caller to turn loaded structure, consisting of built-in-like
+        types, into objects of desired classes, e.g. by the power of
+        :py:meth:`tmt.container.SerializableContainer.deserialize`.
+
+    :param filepath: file to read the state from.
+    :param format_name: if set, use this format instead of the default
+        one.
+    :returns: stored state as Python data structure.
+    """
+
+    state_format = get_state_format(format=format_name)
+
+    return state_format.from_state(Path(f'{filepath}{state_format.suffix}').read_text())
+
+
+def write_state(filepath: Path, data: Any, format: Optional[str] = None) -> None:
+    """
+    Write a state into the given file.
+
+    .. important::
+
+        No serialization is performed, it is the responsibility of the
+        caller to turn internal objects into built-in-like Python types,
+        e.g. by the power of
+        :py:meth:`tmt.container.SerializableContainer.serialize`.
+
+    :param filepath: file to write the state into.
+    :param data: state as Python data structure.
+    :param format_name: if set, use this format instead of the default
+        one.
+    """
+
+    state_format = get_state_format(format=format)
+
+    Path(f'{filepath}{state_format.suffix}').write_text(state_format.to_state(data))
 
 
 def markdown_to_html(filename: Path) -> str:


### PR DESCRIPTION
tmt saves its state info - step data, test data, guest data, etc. - in YAML format, plent yof `*.yaml` files in a workdir. It's fine, it's readable by both machines and humans, it works.

It turns out YAML is not necessarily the best format out there, as YAML can be costly to generate when dealing with large structures and large collections.

Two things happen in this PR:

* To allow some experimentation, `TMT_STATE_FORMAT` environment variable tells tmt which format to use when storing its data. As of now, only `yaml` is supported.
* "to/from JSON" helpers are refactored to align with recent changes to "to/from YAML" helpers, to provide similar function names, annotations and so on, and they are made available for selection via `TMT_STATE_FORMAT`, making JSON the second supported format for tmt state files.

Moar formats, moar fun!

A set of simple helpers, `to_state` and `from_state` is defined, based on the aforementioned envvar, and patch changes all places where tmt stores state on disk to use them instead of `{to,from}_yaml`. `Common.{read,write}_state()` will help with that, instead of `Common.{read,write}()` methods.

Now we can play with different format, and even if we learn the format is not the culprit of ineffective storage of large collections of results, we will have nice and tidy internal API to work with.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [ ] extend the test coverage
* [ ] include a release note