### PR TITLE
Fix Testing Farm API docs link

### DIFF
--- a/docs/guide/test-runner.inc.rst
+++ b/docs/guide/test-runner.inc.rst
@@ -57,7 +57,7 @@ ansible collections`__ are available on the test runner and can be
 used in user playbooks.
 
 __ https://docs.testing-farm.io/
-__ https://api.testing-farm.io/redoc
+__ https://api.testing-farm.io
 __ https://docs.testing-farm.io/Testing%20Farm/0.1/cli.html
 __ https://docs.testing-farm.io/Testing%20Farm/0.1/onboarding.html
 __ https://docs.testing-farm.io/Testing%20Farm/0.1/test-environment.html#_composes


### PR DESCRIPTION
Since the 2026-01.1 release, the API link without a path redirects to the documentation, which is now available under the /docs path. Remove the /redoc suffix as it's no longer needed.