### PR TITLE
Remove outdated `rhel-8` workarounds and comments

### DIFF
--- a/tests/plan/export/test.sh
+++ b/tests/plan/export/test.sh
@@ -91,14 +91,7 @@ rlJournalStart
 
     rlPhaseStartTest "Invalid format"
         rlRun -s "tmt plan export --how weird" 2
-
-        if rlIsRHELLike "=8"; then
-            # RHEL-8 and Centos stream 8 usually offer an older Click package that has slightly
-            # different wording & quotes.
-            rlAssertgrep "Error: Invalid value for \"-h\" / \"--how\": invalid choice: weird. (choose from dict, json, yaml)" $rlRun_LOG
-        else
-            rlAssertGrep "Error: Invalid value for '-h' / '--how': 'weird' is not one of 'dict', 'json', 'template', 'yaml'." $rlRun_LOG
-        fi
+        rlAssertGrep "Error: Invalid value for '-h' / '--how': 'weird' is not one of 'dict', 'json', 'template', 'yaml'." $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/test/export/test.sh
+++ b/tests/test/export/test.sh
@@ -58,13 +58,7 @@ rlJournalStart
     # 2 - (negative) format testing
     rlPhaseStartTest "Invalid format"
         rlRun -s "tmt tests export --how weird" 2
-        if rlIsRHELLike "=8"; then
-            # RHEL-8 and Centos stream 8 usually offer an older Click package that has slightly
-            # different wording & quotes.
-            rlAssertgrep "Error: Invalid value for \"-h\" / \"--how\": invalid choice: weird. (choose from dict, json, nitrate, polarion, yaml)" $rlRun_LOG
-        else
-            rlAssertGrep "Error: Invalid value for '-h' / '--how': 'weird' is not one of 'dict', 'json', 'nitrate', 'polarion', 'template', 'yaml'." $rlRun_LOG
-        fi
+        rlAssertGrep "Error: Invalid value for '-h' / '--how': 'weird' is not one of 'dict', 'json', 'nitrate', 'polarion', 'template', 'yaml'." $rlRun_LOG
     rlPhaseEnd
 
     # 3 - fmf-id testing

--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -121,12 +121,24 @@ definitions:
     additionalProperties: false
 
     properties:
-      url: true
-      ref: true
-      path: true
-      name: true
-      nick: true
-      type: true
+      url:
+        type: string
+
+      ref:
+        type: string
+
+      path:
+        type: string
+
+      name:
+        type: string
+        pattern: "^/"
+
+      nick:
+        type: string
+
+      type:
+        $ref: "/schemas/common#/definitions/require_type"
 
     required:
       - type
@@ -243,20 +255,36 @@ definitions:
     additionalProperties: false
 
     properties:
-      url: true
-      ref: true
-      path: true
-      name: true
+      url:
+        type: string
+
+      ref:
+        type: string
+
+      path:
+        type: string
+
+      name:
+        type: string
+        pattern: "^/"
 
   # helper used by beakerlib_library and fmf_id
   fmf_id_base:
     type: object
     minProperties: 1
     properties:
-      url: true
-      ref: true
-      path: true
-      name: true
+      url:
+        type: string
+
+      ref:
+        type: string
+
+      path:
+        type: string
+
+      name:
+        type: string
+        pattern: "^/"
 
   require_file:
     type: object

--- a/tmt/schemas/plan.yaml
+++ b/tmt/schemas/plan.yaml
@@ -136,11 +136,19 @@ properties:
         additionalProperties: false
 
         properties:
-          # https://github.com/teemtee/tmt/issues/1258
-          url: true
-          ref: true
-          path: true
-          name: true
+          url:
+            # https://github.com/teemtee/tmt/issues/1258
+            type: string
+
+          ref:
+            type: string
+
+          path:
+            type: string
+
+          name:
+            type: string
+            format: regex
 
           importing:
             type: string


### PR DESCRIPTION
As tmt running in RHEL 8 is no longer supported, remove the schema workarounds referencing RHEL-8

Fixes #3705 

* [x] modify the json schema