### PR TITLE
Step `__init__` shall accept list of raw step data only, no other types are allowed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,7 +167,7 @@ def _construct_fixture_guest(container: 'ContainerData', logger: Logger) -> Gues
     # functionality will not work correctly, e.g. dry-run detection.
     plan = Plan(node=fmf.base.Tree(data={'execute': {'how': 'tmt'}}), logger=logger)
 
-    step = Provision(plan=plan, data=[], logger=logger)
+    step = Provision(plan=plan, raw_data=[], logger=logger)
 
     guest_data = PodmanGuestData(image=container.image_url_or_id, container=container.container_id)
 

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -149,7 +149,7 @@ def test_multihost_name(root_logger: Logger) -> None:
 def test_execute_no_connection_closed(
     root_logger: Logger, stdout: str, expected: str, monkeypatch: Any
 ) -> None:
-    step = Provision(plan=MagicMock(name='mock<plan>'), data={}, logger=root_logger)
+    step = Provision(plan=MagicMock(name='mock<plan>'), raw_data=[{}], logger=root_logger)
     guest = GuestSsh(
         logger=root_logger, parent=step, name='foo', data=GuestSshData(primary_address='bar')
     )

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -342,40 +342,60 @@ class Plan(
             expand_node_data(node.data, self.fmf_context)  # pyright: ignore[reportUnknownVariableType, reportUnknownArgumentType]
 
         # Initialize test steps
+        def _normalize_raw_step_phases(
+            step_name: tmt.steps.StepName,
+        ) -> list[tmt.steps._RawStepData]:
+            raw_step_data = self.node.get(step_name)
+
+            # Create an empty step by default (can be updated from cli)
+            if raw_step_data is None:
+                return [{}]
+
+            # Convert to list if only a single config provided
+            if isinstance(raw_step_data, dict):
+                return [cast(tmt.steps._RawStepData, raw_step_data)]
+
+            # List is as good as it gets
+            if isinstance(raw_step_data, list):
+                return raw_step_data
+
+            # Shout about invalid configuration
+            raise tmt.utils.GeneralError(f"Invalid '{step_name}' config in '{self}'.")
+
         self.discover = tmt.steps.discover.Discover(
             logger=logger.descend(logger_name='discover'),
             plan=self,
-            data=self.node.get('discover'),  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            raw_data=_normalize_raw_step_phases('discover'),
         )
         self.provision = tmt.steps.provision.Provision(
             logger=logger.descend(logger_name='provision'),
             plan=self,
-            data=self.node.get('provision'),  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            raw_data=_normalize_raw_step_phases('provision'),
         )
         self.prepare = tmt.steps.prepare.Prepare(
             logger=logger.descend(logger_name='prepare'),
             plan=self,
-            data=self.node.get('prepare'),  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            raw_data=_normalize_raw_step_phases('prepare'),
         )
         self.execute = tmt.steps.execute.Execute(
             logger=logger.descend(logger_name='execute'),
             plan=self,
-            data=self.node.get('execute'),  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            raw_data=_normalize_raw_step_phases('execute'),
         )
         self.report = tmt.steps.report.Report(
             logger=logger.descend(logger_name='report'),
             plan=self,
-            data=self.node.get('report'),  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            raw_data=_normalize_raw_step_phases('report'),
         )
         self.finish = tmt.steps.finish.Finish(
             logger=logger.descend(logger_name='finish'),
             plan=self,
-            data=self.node.get('finish'),  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            raw_data=_normalize_raw_step_phases('finish'),
         )
         self.cleanup = tmt.steps.cleanup.Cleanup(
             logger=logger.descend(logger_name='cleanup'),
             plan=self,
-            data=self.node.get('cleanup'),  # pyright: ignore[reportUnknownVariableType, reportArgumentType]
+            raw_data=_normalize_raw_step_phases('cleanup'),
         )
 
         self._update_metadata()

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -345,7 +345,7 @@ class Plan(
         def _normalize_raw_step_phases(
             step_name: tmt.steps.StepName,
         ) -> list[tmt.steps._RawStepData]:
-            raw_step_data = self.node.get(step_name)
+            raw_step_data: Any = node.get(name=step_name)  # pyright: ignore[reportUnknownVariableType, reportUnknownArgumentType]
 
             # Create an empty step by default (can be updated from cli)
             if raw_step_data is None:
@@ -357,7 +357,7 @@ class Plan(
 
             # List is as good as it gets
             if isinstance(raw_step_data, list):
-                return raw_step_data
+                return cast(list[tmt.steps._RawStepData], raw_step_data)
 
             # Shout about invalid configuration
             raise tmt.utils.GeneralError(f"Invalid '{step_name}' config in '{self}'.")

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -364,9 +364,6 @@ class _RawStepData(TypedDict, total=False):
     order: Optional[int]
 
 
-RawStepDataArgument = Union[_RawStepData, list[_RawStepData]]
-
-
 StepDataT = TypeVar('StepDataT', bound='StepData')
 
 #: A type variable representing a return value of plugin's ``go()`` method.
@@ -537,7 +534,7 @@ class Step(
         self,
         *,
         plan: 'Plan',
-        data: Optional[RawStepDataArgument] = None,
+        raw_data: Optional[list[_RawStepData]] = None,
         name: Optional[str] = None,
         workdir: tmt.utils.WorkdirArgumentType = None,
         logger: tmt.log.Logger,
@@ -561,22 +558,7 @@ class Step(
         # NOTE: this is not a normalization step as performed by NormalizeKeysMixin.
         # Here we make sure the raw data can be consumed by the delegation code, we
         # do not modify any existing content of raw data items.
-
-        # Create an empty step by default (can be updated from cli)
-        if data is None:
-            raw_data: list[_RawStepData] = [{}]
-
-        # Convert to list if only a single config provided
-        elif isinstance(data, dict):
-            raw_data = [data]
-
-        # List is as good as it gets
-        elif isinstance(data, list):
-            raw_data = data
-
-        # Shout about invalid configuration
-        else:
-            raise tmt.utils.GeneralError(f"Invalid '{self}' config in '{self.plan}'.")
+        raw_data = raw_data or []
 
         raw_data = self._set_default_names(raw_data)
         raw_data = self._apply_cli_invocations(raw_data)

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -589,14 +589,14 @@ class Discover(tmt.steps.Step):
         self,
         *,
         plan: 'Plan',
-        data: tmt.steps.RawStepDataArgument,
+        raw_data: list[tmt.steps._RawStepData],
         logger: tmt.log.Logger,
     ) -> None:
         """
         Store supported attributes, check for sanity
         """
 
-        super().__init__(plan=plan, data=data, logger=logger)
+        super().__init__(plan=plan, raw_data=raw_data, logger=logger)
 
         # Collection of discovered tests
         self._tests: dict[str, list[tmt.Test]] = {}

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1055,14 +1055,14 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
         self,
         *,
         plan: "tmt.base.plan.Plan",
-        data: tmt.steps.RawStepDataArgument,
+        raw_data: list[tmt.steps._RawStepData],
         logger: tmt.log.Logger,
     ) -> None:
         """
         Initialize execute step data
         """
 
-        super().__init__(plan=plan, data=data, logger=logger)
+        super().__init__(plan=plan, raw_data=raw_data, logger=logger)
         # List of Result() objects representing test results
         self._results: list[tmt.Result] = []
         self._old_results: list[tmt.Result] = []

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -129,14 +129,14 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
         self,
         *,
         plan: 'Plan',
-        data: tmt.steps.RawStepDataArgument,
+        raw_data: list[tmt.steps._RawStepData],
         logger: tmt.log.Logger,
     ) -> None:
         """
         Initialize prepare step data
         """
 
-        super().__init__(plan=plan, data=data, logger=logger)
+        super().__init__(plan=plan, raw_data=raw_data, logger=logger)
 
         self.results = []
         self.preparations_applied = 0

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -346,14 +346,14 @@ class Provision(tmt.steps.Step):
         self,
         *,
         plan: 'tmt.Plan',
-        data: tmt.steps.RawStepDataArgument,
+        raw_data: list[tmt.steps._RawStepData],
         logger: tmt.log.Logger,
     ) -> None:
         """
         Initialize provision step data
         """
 
-        super().__init__(plan=plan, data=data, logger=logger)
+        super().__init__(plan=plan, raw_data=raw_data, logger=logger)
 
         self.guests = []
         self._guest_data: dict[str, tmt.guest.GuestData] = {}


### PR DESCRIPTION
This particular normalization happened inside the method, which opened its `_raw_data` and `data` operations to way more types than necessary. `Step.__init__` now accepts `list[_RawStepData]` and nothing else. Plus, the parameter name is now `raw_data` rather than `data` as `data` labels data classes and their instances rather than raw, unnormalized input.

Pull Request Checklist

* [x] implement the feature