### PR TITLE
Fix FIPS prepare feature on CentOS Stream 8

### DIFF
--- a/tmt/steps/prepare/feature/fips-enable.yaml
+++ b/tmt/steps/prepare/feature/fips-enable.yaml
@@ -66,14 +66,14 @@
     - name: Install dracut-fips and grubby on RHEL7
       ansible.builtin.command: yum install -y dracut-fips grubby # noqa: command-instead-of-module
       register: output
-      changed_when: output.rc == 0
+      changed_when: "output.rc == 0 and 'Nothing to do' not in output.stdout"
       when: ansible_distribution_major_version | int == 7
 
     - name: Install crypto-policies-scripts, dracut-fips and grubby on RHEL8
       # noqa: command-instead-of-module
       ansible.builtin.command: dnf install -y crypto-policies-scripts dracut-fips grubby
       register: output
-      changed_when: output.rc == 0
+      changed_when: "output.rc == 0 and 'Nothing to do' not in output.stdout"
       when: ansible_distribution_major_version | int == 8
 
     - name: Install crypto-policies-scripts, dracut-fips and grubby on RHEL9


### PR DESCRIPTION
Python and Ansible versions on CentOS Stream 8 (ie. on RHEL-8 too) do no support dnf ansible module and we need to use command module to install the dependencies.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
