### PR TITLE
Disable `eln` container building & testing for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,6 @@ TMT_TEST_CONTAINER_IMAGES := $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine:late
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/centos/stream10/upstream:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/coreos:stable \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/coreos/ostree:stable \
-                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/eln:latest \
-                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/eln/upstream:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest/upstream:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest/unprivileged:latest \
@@ -138,6 +136,12 @@ TMT_TEST_CONTAINER_IMAGES := $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine:late
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/ubuntu/22.04/upstream:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/debian/12.7/upstream:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest/bootc:latest
+
+# TODO: Disabled for now to unblock testing/merging
+# https://github.com/teemtee/tmt/pull/4552
+#                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/eln:latest \
+#                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/eln/upstream:latest \
+#                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/eln/unprivileged:latest \
 
 UNAME_M := $(shell uname -m)  # Get the machine architecture
 
@@ -233,9 +237,8 @@ $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/e
 $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/eln/upstream\:latest:
 	$(call build-test-container-image,$@,fedora/eln/Containerfile.upstream)
 
-# Disable for now to unblock testing/merging
-#$(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/eln/unprivileged\:latest:
-#	$(call build-test-container-image,$@,fedora/eln/Containerfile.unprivileged)
+$(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/eln/unprivileged\:latest:
+	$(call build-test-container-image,$@,fedora/eln/Containerfile.unprivileged)
 
 $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/rawhide\:latest:
 	$(call build-test-container-image,$@,fedora/rawhide/Containerfile)

--- a/tests/images.sh
+++ b/tests/images.sh
@@ -25,10 +25,13 @@ $TEST_IMAGE_PREFIX/centos/stream10/upstream:latest
 $TEST_IMAGE_PREFIX/fedora/42/upstream:latest
 $TEST_IMAGE_PREFIX/fedora/43/upstream:latest
 $TEST_IMAGE_PREFIX/fedora/rawhide/upstream:latest
-$TEST_IMAGE_PREFIX/fedora/eln:latest
 $TEST_IMAGE_PREFIX/ubi/8/upstream:latest
 $TEST_IMAGE_PREFIX/ubuntu/22.04/upstream:latest
 $TEST_IMAGE_PREFIX/debian/12.7/upstream:latest}"
+
+# TODO: Disabled for now to unblock testing/merging
+# https://github.com/teemtee/tmt/pull/4552
+#$TEST_IMAGE_PREFIX/fedora/eln:latest
 
 # For the following images we do not exercise all possible feature
 # combinations, just make sure the basic functionality works.


### PR DESCRIPTION
The build fails with:

    Transaction failed: Signature verification failed.
    OpenPGP check for package "shadow-utils-2:4.19.0-6.eln154.x86_64"
    (/var/cache/libdnf5/eln-baseos-a1f2cae0598f9cea/packages/shadow-utils-4.19.0-6.eln154.x86_64.rpm)
    from repo "eln-baseos" has failed: Import of the key didn't help,
    wrong key?
    Error: building at STEP "RUN <<EOF": while running runtime: exit status 1

Note from yselkowitz:

    this seems to be a timing issue with the F44 branching.  some ELN
    builds are signed with only the F45 key (this switch happens right
    before branching) but fedora-repos hasn't been updated yet because
    branching was delayed a day due to other issues.

Let's disable it for now to unblock testing & merging. Btw, it seems the container is not used by any test.