### PR TITLE
Require `setuptools` until `beaker-client` drops `pkg_resources`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,6 @@ dependencies = [
     "pygments>=2.7.4",
     "requests>=2.25.1",
     "ruamel.yaml>=0.16.6",
-    # Needed because beaker-client uses pkg_resources which are deprecated
-    # https://github.com/beaker-project/beaker/issues/232
-    "setuptools<81",
     "urllib3>=1.26.5, <3.0",
     "typing-extensions>=4; python_version < '3.13'",
     ]
@@ -74,6 +71,9 @@ prepare-artifact = [
     ]
 provision-beaker = [
     "mrack>=1.25.0",
+    # Needed because beaker-client uses pkg_resources which are deprecated
+    # https://github.com/beaker-project/beaker/issues/232
+    "setuptools<81",
     ]
 provision-mock = [
     # mockbuild

--- a/uv.lock
+++ b/uv.lock
@@ -3446,7 +3446,6 @@ dependencies = [
     { name = "pygments" },
     { name = "requests" },
     { name = "ruamel-yaml" },
-    { name = "setuptools" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -3466,6 +3465,7 @@ all = [
     { name = "nitrate" },
     { name = "pylero" },
     { name = "python-bugzilla" },
+    { name = "setuptools" },
     { name = "testcloud" },
 ]
 ansible = [
@@ -3498,6 +3498,7 @@ prepare-artifact = [
 ]
 provision-beaker = [
     { name = "mrack" },
+    { name = "setuptools" },
 ]
 provision-bootc = [
     { name = "testcloud" },
@@ -3562,7 +3563,8 @@ requires-dist = [
     { name = "renku-sphinx-theme", marker = "extra == 'docs'" },
     { name = "requests", specifier = ">=2.25.1" },
     { name = "ruamel-yaml", specifier = ">=0.16.6" },
-    { name = "setuptools", specifier = "<81" },
+    { name = "setuptools", marker = "extra == 'all'", specifier = "<81" },
+    { name = "setuptools", marker = "extra == 'provision-beaker'", specifier = "<81" },
     { name = "sphinx", marker = "extra == 'docs'" },
     { name = "sphinx-reredirects", marker = "extra == 'docs'" },
     { name = "testcloud", marker = "extra == 'all'", specifier = ">=0.11.7" },


### PR DESCRIPTION
In the newest `setutools` the `pkg_resources` has been deprecated:

    UserWarning: pkg_resources is deprecated as an API. See
    https://setuptools.pypa.io/en/latest/pkg_resources.html. The
    pkg_resources package is slated for removal as early as 2025-11-30.
    Refrain from using this package or pin to Setuptools<81.

Let's temporarily require specific version of `setuptools` until `beaker-client` fixes the problem:

 * https://github.com/beaker-project/beaker/issues/232