### PR TITLE
Run only basic tests under the `podman` friends plan

### DIFF
--- a/tests/provision/container/environment/main.fmf
+++ b/tests/provision/container/environment/main.fmf
@@ -3,5 +3,3 @@ description:
     Verify that plan environment variables are passed to podman
     using ``--env-file`` option. Variables containing newline
     are skipped and a warning is emitted.
-tag+:
-  - podman


### PR DESCRIPTION
Recent addition of the new environment test caused many failures in the podman repository as the change is not released yet. Let's keep the friends plan focused on the essential features only.

Pull Request Checklist

* [x] adjust the test coverage