### PR TITLE
proposal: Make `PluginRegistry` auto-load plugins on first access

### DIFF
--- a/tests/unit/artifact/conftest.py
+++ b/tests/unit/artifact/conftest.py
@@ -2,17 +2,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import tmt.plugins
 from tmt.steps.prepare import install
 from tmt.steps.prepare.artifact import get_artifact_provider
 from tmt.steps.prepare.artifact.providers import koji as koji_module
 from tmt.steps.prepare.artifact.providers.brew import BrewArtifactProvider
 from tmt.steps.prepare.artifact.providers.koji import KojiArtifactProvider
-
-
-@pytest.fixture(scope='session')
-def _load_plugins():
-    tmt.plugins.explore(tmt.Logger.create())
 
 
 @pytest.fixture
@@ -52,7 +46,7 @@ def mock_brew(mock_koji):
 
 
 @pytest.fixture
-def artifact_provider(root_logger, _load_plugins):
+def artifact_provider(root_logger):
     def get_provider(provider_id: str, repository_priority: int = 50):
         provider_class = get_artifact_provider(provider_id)
         return provider_class(

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -435,15 +435,19 @@ class PluginRegistry(Generic[RegisterableT]):
         :returns: plugin or ``None`` if no such id has been registered.
         """
 
+        explore(Logger.get_bootstrap_logger())
         return self._plugins.get(plugin_id, None)
 
     def iter_plugin_ids(self) -> Iterator[str]:
+        explore(Logger.get_bootstrap_logger())
         yield from self._plugins.keys()
 
     def iter_plugins(self) -> Iterator[RegisterableT]:
+        explore(Logger.get_bootstrap_logger())
         yield from self._plugins.values()
 
     def items(self) -> Iterator[tuple[str, RegisterableT]]:
+        explore(Logger.get_bootstrap_logger())
         yield from self._plugins.items()
 
     def __len__(self) -> int:


### PR DESCRIPTION
Currently, plugins are only loaded when `tmt.plugins.explore()` is explicitly called, which happens automatically in `tmt run` but not for unit tests. See discussion: https://github.com/teemtee/tmt/pull/4526#discussion_r2789144462

This tries to make `PluginRegistry` automatically trigger plugin discovery on first access. Also, `ALREADY_EXPLORED` makes the `explore()` call idempotent. 