### PR TITLE
Prefer `Stopwatch.measure` over context manager

### DIFF
--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -3,7 +3,7 @@ import re
 import textwrap
 import time
 from re import Pattern
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 import jinja2
 
@@ -19,6 +19,7 @@ from tmt.utils import (
     ShellScript,
     Stopwatch,
     render_command_report,
+    safe_call,
 )
 from tmt.utils.hints import hints_as_notes
 
@@ -119,7 +120,7 @@ def _run_script(
     script: ShellScript,
     needs_sudo: bool = False,
     logger: tmt.log.Logger,
-) -> Union[tuple[CommandOutput, None], tuple[None, tmt.utils.RunError]]:
+) -> CommandOutput:
     """
     A helper to run a script on the guest.
 
@@ -154,13 +155,7 @@ def _run_script(
             stacklevel=stacklevel + 1,
         )
 
-    try:
-        output = invocation.guest.execute(script, log=_output_logger, silent=True)
-
-        return output, None
-
-    except tmt.utils.RunError as exc:
-        return None, exc
+    return invocation.guest.execute(script, log=_output_logger, silent=True)
 
 
 def create_ausearch_mark(
@@ -187,8 +182,9 @@ def create_ausearch_mark(
         ).strip()
     )
 
-    with Stopwatch() as timer:
-        output, exc = _run_script(invocation=invocation, script=script, logger=logger)
+    output, exc, timer = Stopwatch.measure(
+        _run_script, invocation=invocation, script=script, logger=logger
+    )
 
     if exc is None:
         assert output is not None
@@ -237,7 +233,9 @@ def create_final_report(
     got_sestatus, got_rpm, got_ausearch, got_denials = False, False, False, False
 
     # Get the `sestatus` output.
-    output, exc = _run_script(invocation=invocation, script=ShellScript('sestatus'), logger=logger)
+    output, exc = safe_call(
+        _run_script, invocation=invocation, script=ShellScript('sestatus'), logger=logger
+    )
 
     if exc is None:
         assert output is not None
@@ -253,8 +251,11 @@ def create_final_report(
 
     # Record NVRs of interesting packages.
     interesting_packages = ' '.join(INTERESTING_PACKAGES)
-    output, exc = _run_script(
-        invocation=invocation, script=ShellScript(f'rpm -q {interesting_packages}'), logger=logger
+    output, exc = safe_call(
+        _run_script,
+        invocation=invocation,
+        script=ShellScript(f'rpm -q {interesting_packages}'),
+        logger=logger,
     )
 
     if exc is None:
@@ -278,10 +279,9 @@ def create_final_report(
         ).strip()
     )
 
-    with Stopwatch() as timer:
-        output, exc = _run_script(
-            invocation=invocation, script=script, needs_sudo=True, logger=logger
-        )
+    output, exc, timer = Stopwatch.measure(
+        _run_script, invocation=invocation, script=script, needs_sudo=True, logger=logger
+    )
 
     # `ausearch` outcome evaluation is a bit more complicated than the one for a simple
     # `rpm -q`, because not all non-zero exit codes mean error.
@@ -328,7 +328,12 @@ def create_final_report(
         failure = list(render_command_report(label='ausearch', exc=exc))
         report += failure
 
-        if exc.returncode == 1 and exc.stderr and '<no matches>' in exc.stderr.strip():
+        if (
+            isinstance(exc, tmt.utils.RunError)
+            and exc.returncode == 1
+            and exc.stderr
+            and '<no matches>' in exc.stderr.strip()
+        ):
             got_ausearch = True
         else:
             failures.append('\n'.join(failure))

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -40,7 +40,6 @@ from tmt.utils import (
     CommandOutput,
     Environment,
     EnvVarValue,
-    GeneralError,
     HasEnvironment,
     HasStepWorkdir,
     Path,
@@ -401,22 +400,28 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
         return environment
 
     def invoke_check(self, event: CheckEvent, check: Check) -> list[CheckResult]:
-        with Stopwatch() as timer:
-            results = check.go(
-                event=event,
-                invocation=self,
-                environment=self.environment,
-                logger=self.logger,
-            )
+        results, exc, timer = Stopwatch.measure(
+            check.go,
+            event=event,
+            invocation=self,
+            environment=self.environment,
+            logger=self.logger,
+        )
 
-        for result in results:
-            result.event = event
+        if exc is not None:
+            raise exc
 
-            result.start_time = timer.start_time_formatted
-            result.end_time = timer.end_time_formatted
-            result.duration = timer.duration_formatted
+        if results is not None:
+            for result in results:
+                result.event = event
 
-        return results
+                result.start_time = timer.start_time_formatted
+                result.end_time = timer.end_time_formatted
+                result.duration = timer.duration_formatted
+
+            return results
+
+        raise tmt.utils.GeneralError('Check produced no results but raised no exception.')
 
     def invoke_checks(self, event: CheckEvent, checks: Sequence[Check]) -> list[CheckResult]:
         return list(
@@ -538,21 +543,19 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
             if error is not None:
                 self.exceptions.append(error)
 
-                if isinstance(error, tmt.utils.RunError):
-                    output = error.output
-
-                    self.return_code = error.returncode
-
-                else:
+                if not isinstance(error, tmt.utils.RunError):
                     raise error
 
-            elif output is not None:
+                self.return_code = error.returncode
+
+                return error.output
+
+            if output is not None:
                 self.return_code = tmt.utils.ProcessExitCodes.SUCCESS
 
-            else:
-                raise GeneralError('Command produced no output but raised no exception.')
+                return output
 
-            return output
+            raise tmt.utils.GeneralError('Test produced no output but raised no exception')
 
         if deadline is None:
             output = _invoke()

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -6310,6 +6310,26 @@ def resource_files(
     return resource_path
 
 
+def safe_call(
+    fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs
+) -> tuple[Optional[T], Optional[Exception]]:
+    """
+    Run a function and capture possible exceptions raised during the call.
+
+    :param fn: a function to call. It will be invoked with all
+        positional and keyword arguments given to ``safe_call``.
+    :returns: a tuple of two items: the return value of ``fn`` and
+        ``None``, on success, i.e. when no exception was raised, or
+        ``None`` and the raised exception when ``fn`` raised an exception.
+    """
+
+    try:
+        return (fn(*args, **kwargs), None)
+
+    except Exception as exc:
+        return (None, exc)
+
+
 class Stopwatch(contextlib.AbstractContextManager['Stopwatch']):
     start_time: datetime.datetime
     end_time: datetime.datetime
@@ -6357,11 +6377,7 @@ class Stopwatch(contextlib.AbstractContextManager['Stopwatch']):
         """
 
         with cls() as timer:
-            try:
-                return (fn(*args, **kwargs), None, timer)
-
-            except Exception as exc:
-                return (None, exc, timer)
+            return (*safe_call(fn, *args, **kwargs), timer)
 
 
 def format_timestamp(timestamp: datetime.datetime) -> str:


### PR DESCRIPTION
It allows explicit control over return value and exceptions raised by the code. `with` + `try` allows that two, but it's two extra levels of indentation - or we do not bother capturing exceptions, letting them bubble up, but that is a bad policy when we are slowly moving towards capturing results and reporting errors consistently.

Pull Request Checklist

* [x] implement the feature