### PR TITLE
Drop plan environment from the default command environment

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,14 @@ from typing import TYPE_CHECKING, Any
 
 import _pytest.logging
 import _pytest.tmpdir
+import fmf.base
 import py.path
 import pytest
 
 from tests import CliRunner, RunTmt
+from tmt.base.plan import Plan
 from tmt.log import Logger
+from tmt.steps.provision import Provision
 from tmt.steps.provision.podman import GuestContainer, PodmanGuestData
 from tmt.utils import Path
 
@@ -149,27 +152,39 @@ def target_dir(tmppath_factory: TempPathFactory) -> Path:
     return tmppath_factory.mktemp('target')
 
 
-@pytest.fixture(name='guest')
-def fixture_guest(container: 'ContainerData', root_logger: Logger) -> GuestContainer:
+def _construct_fixture_guest(container: 'ContainerData', logger: Logger) -> GuestContainer:
+    """
+    Construct a container guest for ``guest`` and ``guest_per_test`` fixtures.
+
+    Guest is created to wrap an existing, running container provided to
+    us by :py:mod:`pytest_container`.
+
+    :param container: object describing a running container.
+    """
+
+    # We need a significant group of internal objects: a plan to host
+    # the `provision` step to hold the guest. Without this, some
+    # functionality will not work correctly, e.g. dry-run detection.
+    plan = Plan(node=fmf.base.Tree(data={'execute': {'how': 'tmt'}}), logger=logger)
+
+    step = Provision(plan=plan, data=[], logger=logger)
+
     guest_data = PodmanGuestData(image=container.image_url_or_id, container=container.container_id)
 
-    guest = GuestContainer(logger=root_logger, data=guest_data, name='dummy-container')
+    guest = GuestContainer(logger=logger, data=guest_data, name='dummy-container', parent=step)
 
     guest.start()
 
     return guest
+
+
+@pytest.fixture(name='guest')
+def fixture_guest(container: 'ContainerData', root_logger: Logger) -> GuestContainer:
+    return _construct_fixture_guest(container, root_logger)
 
 
 @pytest.fixture(name='guest_per_test')
 def fixture_guest_per_test(
     container_per_test: 'ContainerData', root_logger: Logger
 ) -> GuestContainer:
-    guest_data = PodmanGuestData(
-        image=container_per_test.image_url_or_id, container=container_per_test.container_id
-    )
-
-    guest = GuestContainer(logger=root_logger, data=guest_data, name='dummy-container')
-
-    guest.start()
-
-    return guest
+    return _construct_fixture_guest(container_per_test, root_logger)

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -179,7 +179,7 @@ def create_package_manager(
     )
 
     guest = tmt.steps.provision.podman.GuestContainer(
-        logger=logger, data=guest_data, name='dummy-container'
+        logger=logger, data=guest_data, name='dummy-container', parent=guest.parent
     )
     guest.start()
     guest.show()
@@ -193,6 +193,17 @@ def create_package_manager(
             guest.execute(ShellScript('dnf install --nogpgcheck -y dnf5'))
 
     return package_manager_class(guest=guest, logger=logger)
+
+
+def assert_expected_command(
+    caplog: _pytest.logging.LogCaptureFixture, expected_command_pattern: str
+) -> None:
+    assert_log(
+        caplog,
+        message=MATCH(
+            rf"(?sm)Run command: podman exec .+? /bin/bash -c '(?:export [A-Z_]+=.*; )*{expected_command_pattern}'"  # noqa: E501
+        ),
+    )
 
 
 def _parametrize_test_discovery() -> Iterator[tuple[ContainerData, PackageManagerClass]]:
@@ -384,10 +395,7 @@ def test_install(
 
     output = package_manager.install(package)
 
-    assert_log(
-        caplog,
-        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
-    )
+    assert_expected_command(caplog, expected_command)
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -463,9 +471,7 @@ def test_refresh_metadata(
 
     output = package_manager.refresh_metadata()
 
-    assert_log(
-        caplog, message=MATCH(rf"Run command: podman exec .+? /bin/bash -c '{expected_command}'")
-    )
+    assert_expected_command(caplog, expected_command)
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -583,10 +589,7 @@ def test_install_nonexistent(
     with pytest.raises(tmt.utils.RunError) as excinfo:
         package_manager.install(Package('tree-but-spelled-wrong'))
 
-    assert_log(
-        caplog,
-        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
-    )
+    assert_expected_command(caplog, expected_command)
 
     assert excinfo.type is tmt.utils.RunError
     assert excinfo.value.returncode != 0
@@ -699,10 +702,7 @@ def test_install_nonexistent_skip(
         Package('tree-but-spelled-wrong'), options=Options(skip_missing=True)
     )
 
-    assert_log(
-        caplog,
-        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
-    )
+    assert_expected_command(caplog, expected_command)
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -811,10 +811,7 @@ def test_install_dont_check_first(
 
     output = package_manager.install(package, options=Options(check_first=False))
 
-    assert_log(
-        caplog,
-        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
-    )
+    assert_expected_command(caplog, expected_command)
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -925,10 +922,7 @@ def test_reinstall(
 
         output = package_manager.reinstall(package)
 
-        assert_log(
-            caplog,
-            message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
-        )
+        assert_expected_command(caplog, expected_command)
 
     else:
         with pytest.raises(tmt.utils.GeneralError) as excinfo:
@@ -1040,10 +1034,7 @@ def test_reinstall_nonexistent(
         with pytest.raises(tmt.utils.RunError) as excinfo:
             package_manager.reinstall(Package('tree-but-spelled-wrong'))
 
-        assert_log(
-            caplog,
-            message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
-        )
+        assert_expected_command(caplog, expected_command)
 
         assert excinfo.type is tmt.utils.RunError
         assert excinfo.value.returncode != 0
@@ -1390,10 +1381,7 @@ def test_check_presence(
 
     assert package_manager.check_presence(installable) == {installable: expected_result}
 
-    assert_log(
-        caplog,
-        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
-    )
+    assert_expected_command(caplog, expected_command)
 
     if expected_output:
         assert_log(caplog, remove_colors=True, message=MATCH(expected_output))
@@ -1500,10 +1488,7 @@ def test_install_filesystempath(
 
     output = package_manager.install(installable)
 
-    assert_log(
-        caplog,
-        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
-    )
+    assert_expected_command(caplog, expected_command)
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -1637,10 +1622,7 @@ def test_install_multiple(
 
     output = package_manager.install(*packages)
 
-    assert_log(
-        caplog,
-        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
-    )
+    assert_expected_command(caplog, expected_command)
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -1831,10 +1813,7 @@ def test_install_downloaded(
     else:
         output = package_manager.install(*installables, options=Options(check_first=False))
 
-    assert_log(
-        caplog,
-        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
-    )
+    assert_expected_command(caplog, expected_command)
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -1972,9 +1951,7 @@ def test_install_debuginfo(
 
     output = package_manager.install_debuginfo(*installables)
 
-    assert_log(
-        caplog, message=MATCH(rf"Run command: podman exec .+? /bin/bash -c '{expected_command}'")
-    )
+    assert_expected_command(caplog, expected_command)
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -2058,9 +2035,7 @@ def test_install_debuginfo_nonexistent(
     with pytest.raises(tmt.utils.RunError) as excinfo:
         package_manager.install_debuginfo(*installables)
 
-    assert_log(
-        caplog, message=MATCH(rf"Run command: podman exec .+? /bin/bash -c '{expected_command}'")
-    )
+    assert_expected_command(caplog, expected_command)
 
     assert excinfo.type is tmt.utils.RunError
     assert excinfo.value.returncode != 0
@@ -2183,8 +2158,6 @@ def test_install_debuginfo_nonexistent_skip(
 
     output = package_manager.install_debuginfo(*installables, options=Options(skip_missing=True))
 
-    assert_log(
-        caplog, message=MATCH(rf"Run command: podman exec .+? /bin/bash -c '{expected_command}'")
-    )
+    assert_expected_command(caplog, expected_command)
 
     assert_output(expected_output, output.stdout, output.stderr)

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2123,22 +2123,33 @@ class Guest(
 
         raise GeneralError(f"Unknown Ansible object type, '{type(playbook)}'.")
 
-    def _prepare_environment(
-        self, execute_environment: Optional[tmt.utils.Environment] = None
+    def _prepare_command_environment(
+        self, environment: Optional[tmt.utils.Environment] = None
     ) -> tmt.utils.Environment:
         """
-        Prepare dict of environment variables
+        Prepare meaningful environment for a command.
+
+        When the environment is unset, construct a basic environment
+        from the plan and run. Otherwise, the environment is left
+        unmodified.
         """
-        # Prepare environment variables so they can be correctly passed
-        # to shell. Create a copy to prevent modifying source.
-        environment = tmt.utils.Environment()
-        environment.update(execute_environment or {})
-        # Plan environment and variables provided on the command line
-        # override environment provided to execute().
-        # FIXME: cast() - https://github.com/teemtee/tmt/issues/1372
-        if self.parent:
-            parent = cast('Provision', self.parent)
-            environment.update(parent.plan.environment)
+
+        if environment is None:
+            # narrow type
+            assert isinstance(self.parent, tmt.steps.Step)
+
+            environment = tmt.utils.Environment()
+
+            environment.update(
+                self.environment,
+                self.parent.plan.environment,
+            )
+
+        else:
+            # Create a copy of given environment - this prevents any
+            # accidental modification of the given environment.
+            environment = environment.copy()
+
         return environment
 
     def _run_guest_command(
@@ -2871,7 +2882,7 @@ class GuestSsh(Guest, CommandCollector):
         # Build the command script using the same approach as execute()
         # Start with environment exports
         collected_commands: ShellScript = ShellScript.from_scripts(
-            self._prepare_environment(env).to_shell_exports()
+            self._prepare_command_environment(env).to_shell_exports()
         )
 
         # Add working directory change (properly quoted like in execute())
@@ -3247,7 +3258,7 @@ class GuestSsh(Guest, CommandCollector):
                 friendly_command=friendly_command,
                 silent=silent,
                 cwd=parent.plan.worktree,
-                env=self._prepare_environment(),
+                env=self._prepare_command_environment(),
                 log=log,
             )
         except tmt.utils.RunError as exc:
@@ -3402,7 +3413,7 @@ class GuestSsh(Guest, CommandCollector):
         # Accumulate all necessary commands - they will form a "shell" script, a single
         # string passed to SSH to execute on the remote machine.
         remote_commands: ShellScript = ShellScript.from_scripts(
-            self._prepare_environment(env).to_shell_exports()
+            self._prepare_command_environment(env).to_shell_exports()
         )
 
         # Change to given directory on guest if cwd provided

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2123,15 +2123,19 @@ class Guest(
 
         raise GeneralError(f"Unknown Ansible object type, '{type(playbook)}'.")
 
+    # TODO: the existence of this method is very questionable, it may
+    # go away while works on https://github.com/teemtee/tmt/pull/4364
+    # continue.
     def _prepare_command_environment(
         self, environment: Optional[tmt.utils.Environment] = None
     ) -> tmt.utils.Environment:
         """
         Prepare meaningful environment for a command.
 
-        When the environment is unset, construct a basic environment
-        from the plan and run. Otherwise, the environment is left
-        unmodified.
+        :param environment: if set, it is considered the desired command
+            environment, and used without modification.
+        :returns: either a copy of ``environment``, or a new environment
+            constructed from guest and plan environments
         """
 
         if environment is None:

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -94,7 +94,7 @@ class GuestLocal(tmt.Guest):
                     '-i', 'localhost,',
                     playbook,
                 ),
-                env=self._prepare_environment(),
+                env=self._prepare_command_environment(),
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -454,7 +454,7 @@ class GuestContainer(tmt.Guest):
             return self._run_guest_command(
                 podman_command,
                 cwd=self.parent.plan.worktree,
-                env=self._prepare_environment(),
+                env=self._prepare_command_environment(),
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,
@@ -519,7 +519,9 @@ class GuestContainer(tmt.Guest):
 
         # Accumulate all necessary commands - they will form a "shell" script, a single
         # string passed to a shell executed inside the container.
-        script = ShellScript.from_scripts(self._prepare_environment(env).to_shell_exports())
+        script = ShellScript.from_scripts(
+            self._prepare_command_environment(env).to_shell_exports()
+        )
 
         # Change to given directory on guest if cwd provided
         if cwd is not None:


### PR DESCRIPTION
When guests execute commands, plan environment is passed to all commands. This spoils the order of precedence. Patch removes this environment source, which is only used when `Guest.execute()` did not provide any environment of its own.

As a side-effect, `TMT_VERSION` is now exposed to more commands than before, which 1. is harmless, 2. is correct, 3. is desired, and 4. requires some minor changes to guest-related unit tests that look for expected commands.

Pull Request Checklist

* [x] implement the feature