### PR TITLE
Rework Github release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,5 @@ jobs:
         with:
           subject-path: "dist/*"
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Changes here:
- Replaced the `hatch` flow with the dedicated `hynek/build-and-inspect-python-package` action
- Added attestation signing for the package
- Hardened the permissions
- Publish the releases in the [packages](https://github.com/orgs/teemtee/packages?repo_name=tmt) tab as well

Workflow reference is from: https://github.com/scikit-build/scikit-build-core/blob/main/.github/workflows/cd.yml

Pull Request Checklist

* [x] implement the feature