### PR TITLE
Move `TMT_SOURCE_DIR` envvar setting out of the `discover` step

### DIFF
--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -531,9 +531,6 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT, None]):
             # Propagate 'where' condition from discover phase to the test
             test.where = self.data.where
 
-            if bool(self.get('dist-git-source', False)):
-                test.environment['TMT_SOURCE_DIR'] = EnvVarValue(self.source_dir)
-
     def apply_phase_prefix(self, prefix: str) -> None:
         """
         Apply phase name prefix to discovered tests

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -177,7 +177,9 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
             if discover_phase.name == self.phase.discover_phase:
                 return discover_phase
 
-        raise tmt.utils.GeneralError('Failed to find discover phase for the test.')
+        raise tmt.utils.GeneralError(
+            f"Failed to find discover phase '{self.phase.discover_phase}' for the test."
+        )
 
     @property
     def step_workdir(self) -> Path:

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -163,6 +163,23 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
     exceptions: list[Exception] = simple_field(default_factory=list)
 
     @property
+    def discovery_phase(self) -> DiscoverPlugin[Any]:
+        """
+        Discovery phase the test comes from.
+        """
+
+        if isinstance(self.phase.discover, DiscoverPlugin):
+            return self.phase.discover
+
+        for discover_phase in self.phase.discover.phases(
+            classes=DiscoverPlugin,  # type: ignore[type-abstract]
+        ):
+            if discover_phase.name == self.phase.discover_phase:
+                return discover_phase
+
+        raise tmt.utils.GeneralError('Failed to find discover phase for the test.')
+
+    @property
     def step_workdir(self) -> Path:
         return self.phase.step_workdir
 
@@ -359,6 +376,8 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
             environment['TMT_TEST_ITERATION_ID'] = EnvVarValue(
                 f"{self.phase.parent.plan.my_run.unique_id}-{self.test.serial_number}"
             )
+
+            environment['TMT_SOURCE_DIR'] = EnvVarValue(self.discovery_phase.source_dir)
 
         else:
             environment = self._environment

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -163,9 +163,9 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
     exceptions: list[Exception] = simple_field(default_factory=list)
 
     @property
-    def discovery_phase(self) -> DiscoverPlugin[Any]:
+    def discover_phase(self) -> DiscoverPlugin[Any]:
         """
-        Discovery phase the test comes from.
+        Discover phase the test comes from.
         """
 
         if isinstance(self.phase.discover, DiscoverPlugin):
@@ -379,7 +379,7 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
                 f"{self.phase.parent.plan.my_run.unique_id}-{self.test.serial_number}"
             )
 
-            environment['TMT_SOURCE_DIR'] = EnvVarValue(self.discovery_phase.source_dir)
+            environment['TMT_SOURCE_DIR'] = EnvVarValue(self.discover_phase.source_dir)
 
         else:
             environment = self._environment


### PR DESCRIPTION
It is added to test environment, spoiling it and making it harder for us and users to think about envvar precedence order.

Variable is now set unconditionaly for all tests, by the execute plugin. That makes it present for all tests, but used by subset only.

Pull Request Checklist

* [x] implement the feature