### PR TITLE
Check for the presence of sudo before querying is_image_mode

### DIFF
--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -942,10 +942,11 @@ class GuestFacts(SerializableContainer):
         # function for now
         sudo_prefix = self._query_sudo_prefix(guest)
 
-        image = self._query(
-            guest,
-            [(Command(sudo_prefix, "bootc", "status", "--format", "yaml"), r'image: (.+)')],
-        )
+        command = Command("bootc", "status", "--format", "yaml")
+        if sudo_prefix:
+            command = Command(sudo_prefix) + command
+
+        image = self._query(guest, [(command, r'image: (.+)')])
 
         # if bootc reports status and the image is not `image: null`, we are in image mode
         if image and image != "null":


### PR DESCRIPTION
The reason for introducing the specific `sudo_prefix` fact was to avoid tmt getting stuck while querying for `sudo`, but it seems we forgot about this in `is_image_mode`. This should get it back on track.

Pull Request Checklist

* [x] implement the feature

Fixes #4609
Fixes #3945