### PR TITLE
Instruct `rpminspect` to ignore xml jinja templates

### DIFF
--- a/packaging/rpm/rpminspect.yaml
+++ b/packaging/rpm/rpminspect.yaml
@@ -7,4 +7,4 @@ xml:
   ignore:
     # rpminspect is unable to detect jinja templates
     # https://github.com/rpminspect/rpminspect/issues/1545
-    - /usr/lib/python*/site-packages/tmt/steps/report/junit/templates/*.xml.j2
+    - /usr/lib/python3*/site-packages/tmt/steps/report/junit/templates/*.xml.j2


### PR DESCRIPTION
The `_base.xml.j2` template is incorrectly detected as `xml` and then always reported as a problem when releasing a new `tmt` in Fedora. Let's get rid of the false warning.

* https://github.com/rpminspect/rpminspect/issues/1545