### PR TITLE
Use `uv` in `make docs` to be aligned with RTD builds

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -51,7 +51,7 @@ jobs:
         if: ${{ matrix.builder == 'linkcheck' }}
 
       - name: Run sphinx builder ${{ matrix.sphinx_builder || matrix.builder }}
-        run: sphinx-build -b ${{ matrix.sphinx_builder || matrix.builder }} ${{ matrix.args }} docs/ docs/_build
+        run: sphinx-build -E -b ${{ matrix.sphinx_builder || matrix.builder }} ${{ matrix.args }} docs/ docs/_build
 
       # TODO: enable all checks
       # https://github.com/sphinx-contrib/sphinx-lint/issues/74

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ requre:  ## Regenerate test data for integration tests
 ##
 docs: clean  ## Build documentation
 	uv sync --frozen --extra docs
-	uv run sphinx-build -b html docs docs/_build
+	uv run sphinx-build -E -b html docs docs/_build
 
 man:  ## Build man page
 	hatch run docs:man


### PR DESCRIPTION
When building docs for RTD, Github action uses `uv` and its lockfile. Current `make docs` relies on `hatch`, and ends up with different Python environment, which hits errors we don't observe in Github. Let's use the same tooling for both so we can test things.

Pull Request Checklist

* [x] implement the feature