### PR TITLE
Do not check for journal.xml presence, temporarily

### DIFF
--- a/tests/execute/basic/test.sh
+++ b/tests/execute/basic/test.sh
@@ -72,8 +72,8 @@ rlJournalStart
             0 "Check output.txt log exists in $results"
         rlRun "yq  -e '.[] | select(.name == \"/test/beakerlib/good\") | .log | any_c(test(\"^data/.+/journal.txt$\"))' $results" \
             0 "Check journal.txt log exists in $results"
-        rlRun "yq  -e '.[] | select(.name == \"/test/beakerlib/good\") | .log | any_c(test(\"^data/.+/journal.xml$\"))' $results" \
-            0 "Check journal.xml log exists in $results"
+#        rlRun "yq  -e '.[] | select(.name == \"/test/beakerlib/good\") | .log | any_c(test(\"^data/.+/journal.xml$\"))' $results" \
+#            0 "Check journal.xml log exists in $results"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/execute/result/subresults.sh
+++ b/tests/execute/result/subresults.sh
@@ -140,7 +140,7 @@ rlJournalStart
         rlAssertExists "$log_dir/beakerlib-1/data/extra-tmt-report-result_weird/bkr_weird_log.txt"
         rlAssertExists "$log_dir/beakerlib-1/data/extra-rhts-report-result_bad-with-compat/resultoutputfile.log"
         rlAssertExists "$log_dir/beakerlib-1/data/extra-rhts-report-result_bad-without-compat/output.txt"
-        rlAssertExists "$log_dir/beakerlib-1/journal.xml"
+        # rlAssertExists "$log_dir/beakerlib-1/journal.xml"
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
Missing dependency causes beakerlib to not save the file. Once [1] gets widely available, we can re-enable the silenced tests.

[1] https://github.com/beakerlib/beakerlib/issues/202