### PR TITLE
Add a glossary section

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,0 +1,16 @@
+========
+Glossary
+========
+
+Here you can find some common terms used throughout the tmt project.
+
+Machines
+--------
+
+.. glossary::
+
+   guest
+      The machine where the tests are being run.
+
+   runner
+      The machine that is running the ``tmt`` command.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,5 +35,5 @@ Table of Contents
     Questions <questions>
     Contribute <contribute>
     Code <code/index>
-    Releases <releases/index>
     glossary
+    Releases <releases/index>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,3 +36,4 @@ Table of Contents
     Contribute <contribute>
     Code <code/index>
     Releases <releases/index>
+    glossary


### PR DESCRIPTION
This serves as a place where we can dump all definitions of the terms that we use across the project. During the documentation, this can then be consumed with the `:term:` role giving a reference link to the definition of the term. If we combine this with [sphinx-tippy](https://sphinx-tippy.readthedocs.io/en/latest/index.html) we get a nice pop-up with the contents.

Currently the glossary is not meant to be alphabetically ordered to be able to group together similarly related terms. We should also be able to use multiple `.. glossary` and group them via sections if a meaningful separation is available