### PR TITLE
Simplify the `log._Formatter`

### DIFF
--- a/tmt/log.py
+++ b/tmt/log.py
@@ -45,7 +45,7 @@ from typing import (
 from ruamel.yaml import YAML
 
 from tmt._compat.pathlib import Path
-from tmt._compat.typing import Self, TypeAlias
+from tmt._compat.typing import Self, TypeAlias, override
 from tmt._compat.warnings import deprecated
 from tmt.container import SpecBasedContainer, container, simple_field
 
@@ -333,6 +333,7 @@ class _Formatter(logging.Formatter):
 
         self._decolorize = create_decolorizer(apply_colors)
 
+    @override
     def formatMessage(self, record: logging.LogRecord) -> str:
         return self._decolorize(super().formatMessage(record))
 


### PR DESCRIPTION
For reference the original code for Python3.9 that we still support is:
https://github.com/python/cpython/blob/0bbaf5de9744ae1acea3e2c9ad2257d1cc68e847/Lib/logging/__init__.py#L650-L680
```python
        record.message = record.getMessage()
        if self.usesTime():
            record.asctime = self.formatTime(record, self.datefmt)
        s = self.formatMessage(record)
        if record.exc_info:
            # Cache the traceback text to avoid converting it multiple times
            # (it's constant anyway)
            if not record.exc_text:
                record.exc_text = self.formatException(record.exc_info)
        if record.exc_text:
            if s[-1:] != "\n":
                s = s + "\n"
            s = s + record.exc_text
        if record.stack_info:
            if s[-1:] != "\n":
                s = s + "\n"
            s = s + self.formatStack(record.stack_info)
        return s
```
other than the check for `record.message` (which effectively makes no difference if it is re-rendered with `record.getMessage()`) I do not see any other functional change here.

Pull Request Checklist

* [x] implement the feature
