### PR TITLE
Try to get a more reasonable stacklevel

### DIFF
--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -144,7 +144,6 @@ def _run_script(
         topic: Optional[tmt.log.Topic] = None,
         stacklevel: int = 1,
     ) -> None:
-        stacklevel += 1
         logger.verbose(
             key=key,
             value=value,
@@ -152,7 +151,7 @@ def _run_script(
             shift=shift,
             level=level,
             topic=topic,
-            stacklevel=stacklevel,
+            stacklevel=stacklevel + 1,
         )
 
     try:

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -80,7 +80,6 @@ class DmesgCheck(Check):
             topic: Optional[tmt.log.Topic] = None,
             stacklevel: int = 1,
         ) -> None:
-            stacklevel += 1
             logger.verbose(
                 key=key,
                 value=value,
@@ -88,7 +87,7 @@ class DmesgCheck(Check):
                 shift=shift,
                 level=level,
                 topic=topic,
-                stacklevel=stacklevel,
+                stacklevel=stacklevel + 1,
             )
 
         script = tmt.utils.ShellScript(f'{guest.facts.sudo_prefix} dmesg')

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -775,12 +775,6 @@ class Logger:
         workflow and carrying extra information for our custom filters and handlers.
         """
 
-        # This function is never called directly, instead it is called by one level higher
-        # e.g. `info`. So we escape at least 2 levels of the stack (this function, and its
-        # caller) + the requested stacklevel of the caller (default is the current caller of
-        # `info`)
-        stacklevel += 2
-
         details.logger_labels = self.labels
         details.logger_labels_padding = self.labels_padding
 
@@ -802,7 +796,17 @@ class Logger:
                 labels_padding=self.labels_padding,
             )
 
-        self._logger._log(level, message, (), extra={'details': details}, stacklevel=stacklevel)
+        # stacklevel: This function is never called directly, instead it is called by one level
+        # higher e.g. `info`. So we escape at least 2 levels of the stack (this function, and its
+        # caller) + the requested stacklevel of the caller (default is the current caller of
+        # `info`)
+        self._logger._log(
+            level,
+            message,
+            (),
+            extra={'details': details},
+            stacklevel=stacklevel + 2,
+        )
 
     def print_format(
         self,
@@ -917,8 +921,7 @@ class Logger:
         shift: int,
         stacklevel: int = 1,
     ) -> None:
-        stacklevel += 1
-        return self.warning(message, shift, stacklevel=stacklevel)
+        return self.warning(message, shift, stacklevel=stacklevel + 1)
 
     def fail(
         self,

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -377,7 +377,6 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
             topic: Optional[tmt.log.Topic] = None,
             stacklevel: int = 1,
         ) -> None:
-            stacklevel += 1
             logger.verbose(
                 key=key,
                 value=value,
@@ -385,7 +384,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                 shift=shift,
                 level=level,
                 topic=topic,
-                stacklevel=stacklevel,
+                stacklevel=stacklevel + 1,
             )
 
         # TODO: do we want timestamps? Yes, we do, leaving that for refactoring later,

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -2194,14 +2194,13 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         Show a message unless in quiet mode
         """
 
-        stacklevel += 1
         self._logger.info(
             key,
             value=value,
             color=color,
             shift=shift,
             topic=topic,
-            stacklevel=stacklevel,
+            stacklevel=stacklevel + 1,
         )
 
     def verbose(
@@ -2220,7 +2219,6 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         In quiet mode verbose messages are not displayed.
         """
 
-        stacklevel += 1
         self._logger.verbose(
             key,
             value=value,
@@ -2228,7 +2226,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             shift=shift,
             level=level,
             topic=topic,
-            stacklevel=stacklevel,
+            stacklevel=stacklevel + 1,
         )
 
     def debug(
@@ -2247,7 +2245,6 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         In quiet mode debug messages are not displayed.
         """
 
-        stacklevel += 1
         self._logger.debug(
             key,
             value=value,
@@ -2255,7 +2252,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             shift=shift,
             level=level,
             topic=topic,
-            stacklevel=stacklevel,
+            stacklevel=stacklevel + 1,
         )
 
     def warn(self, message: str, shift: int = 0, stacklevel: int = 1) -> None:
@@ -2263,16 +2260,14 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         Show a yellow warning message on info level, send to stderr
         """
 
-        stacklevel += 1
-        self._logger.warning(message, shift=shift, stacklevel=stacklevel)
+        self._logger.warning(message, shift=shift, stacklevel=stacklevel + 1)
 
     def fail(self, message: str, shift: int = 0, stacklevel: int = 1) -> None:
         """
         Show a red failure message on info level, send to stderr
         """
 
-        stacklevel += 1
-        self._logger.fail(message, shift=shift, stacklevel=stacklevel)
+        self._logger.fail(message, shift=shift, stacklevel=stacklevel + 1)
 
     def _command_verbose_logger(
         self,
@@ -2291,7 +2286,6 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         default parameters are adjusted (to preserve the function type).
         """
 
-        stacklevel += 1
         self.verbose(
             key=key,
             value=value,
@@ -2299,7 +2293,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             shift=shift,
             level=level,
             topic=topic,
-            stacklevel=stacklevel,
+            stacklevel=stacklevel + 1,
         )
 
     def run(


### PR DESCRIPTION
Try to provide a more reasonable `stacklevel` to the inner `logging.Logger._log`, skipping any functions that are wrappers around the loggers. The references in the logger's record should point to the most relevant function that requested the log command, or any such indirect commands like the `guest.run`.

---

Found that this would be useful in #4642 for getting a more accurate source of the caller and I split it out from there to simplify the review.

The stack can be further improved as it goes, as shown in the second commit of this PR, but that can be gradually addressed.

Pull Request Checklist

* [x] implement the feature
