### PR TITLE
Fix catastrophic regex backtracking in shell framework

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,6 @@ dependencies = [
     "pytest",
     "python-coveralls",
     "pytest-container",
-    "pytest-timeout",
     "pytest-xdist",
     "requre",
     "pre-commit",

--- a/tests/unit/test_shell.py
+++ b/tests/unit/test_shell.py
@@ -118,19 +118,8 @@ def test_extract_failures_file_error(invocation: MagicMock) -> None:
             ),
             id='long-line-word-boundary-no-false-positive',
         ),
-        pytest.param(
-            FailureCase(
-                log_content=(
-                    f'start\n{_LONG_SEGMENT} a b c d e f g h i j k l m n o p '
-                    f'{_LONG_SEGMENT}\nend\n'
-                ),
-                expected=[],
-            ),
-            id='long-line-many-word-boundaries-no-match',
-        ),
     ],
 )
-@pytest.mark.timeout(10)
 def test_extract_failures_long_lines(invocation: MagicMock, case: FailureCase) -> None:
     """
     Verify correct handling of very long lines (~50k characters).
@@ -141,20 +130,18 @@ def test_extract_failures_long_lines(invocation: MagicMock, case: FailureCase) -
 
     Benchmarks with 50k-character lines:
 
-    ====================================  ===========  ===========
-    Case                                  Old regex    New method
-    ====================================  ===========  ===========
-    long line, no match + error line      11.335 s     < 0.001 s
-    error embedded in long line           0.001 s      < 0.001 s
-    word boundary, no false positive      49.290 s     < 0.001 s
-    many word boundaries, no match        133.628 s    < 0.003 s
-    ====================================  ===========  ===========
+    ==================================  ===========  ===========
+    Case                                Old regex    New method
+    ==================================  ===========  ===========
+    long line, no match + error line    11.335 s     < 0.001 s
+    error embedded in long line         0.001 s      < 0.001 s
+    word boundary, no false positive    49.290 s     < 0.001 s
+    ==================================  ===========  ===========
 
     The new ``splitlines()`` + per-line ``re.search()`` runs in < 0.001 s
     for all cases. A 0.1 s threshold sits well between the two methods:
     any result above 0.1 s indicates a regression toward the old behavior.
-    The ``@pytest.mark.timeout(10)`` serves as an additional safety net
-    to prevent CI from hanging if a regression is catastrophic.
+    The explicit time assertion serves as a safeguard against regressions.
     """
     invocation.phase.step.plan.execute.read.return_value = case.log_content
 


### PR DESCRIPTION
## Summary

Fix `_extract_failures()` in `tmt/frameworks/shell.py` which causes tmt processes to hang for hours when test output contains very long lines.

- Replace `re.findall(r'.*\b(?:error|fail)\b.*', ...)` with a line-by-line `re.search()` approach that avoids catastrophic regex backtracking
- Add unit tests for `_extract_failures()` including a regression test with 1M-character lines

Fixes #4657

## Context

Testing Farm jobs from the [Hummingbird](https://gitlab.com/redhat/hummingbird) project were getting stuck in "running" state for hours. The test output files contained base64-encoded in-toto attestation payloads — single lines of 1M+ characters — causing the regex engine to backtrack indefinitely.

Detailed write-up: https://vadkerti.net/posts/debugging-stuck-tmt-processes-with-claude-code/

## Test plan

- [x] Unit tests pass (`hatch -e dev run -- python -m pytest tests/unit/test_shell.py -v`)
- [ ] Existing shell framework integration tests still pass
