### PR TITLE
Partially revert #4396

### DIFF
--- a/tests/provision/mock/fedora-rawhide-x86_64/multiple-tests/main.fmf
+++ b/tests/provision/mock/fedora-rawhide-x86_64/multiple-tests/main.fmf
@@ -1,10 +1,3 @@
 summary: Test Fedora Rawhide mock container
 description:
     A simple test to see if the provision handles multiple tests.
-
-adjust+:
-  - when: distro >= fedora-44
-    check:
-      - how: avc
-        result: xfail
-    because: https://bugzilla.redhat.com/show_bug.cgi?id=2415701

--- a/tests/test/check/main.fmf
+++ b/tests/test/check/main.fmf
@@ -49,7 +49,10 @@ duration: 20m
       - when: distro >= fedora-44
         check:
           - how: avc
-            result: xfail
+            ignore-pattern:
+              - "type=AVC.*comm=systemd-coredum.*scontext=system_u:system_r:systemd_coredump_t"
+              # From default pattern
+              - "type=USER_AVC.*received policyload notice"
         because: https://bugzilla.redhat.com/show_bug.cgi?id=2418343
 
 /internal:


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=2415701 has been resolved in `selinux-policy-43.1-1.fc43`
- https://bugzilla.redhat.com/show_bug.cgi?id=2418343 is also tracked in that PR, but it used a too broad xfail