### PR TITLE
Fix issues with `check-wheel-contents`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -486,3 +486,8 @@ skip = "tests/execute/weird/data/weird.txt,tests/lint/plan/data/invalid_attr.fmf
 [tool.djlint]
 use_gitignore=true
 ignore="H005,H030,H031"
+
+[tool.check-wheel-contents]
+# W002: Wheel contains duplicate files
+#   Minor issue for us, it is fine if we have a few duplicate files
+ignore = ["W002"]


### PR DESCRIPTION
Reported when the recent release workflow was run:
```
/tmp/baipp/dist/tmt-1.69.0-py3-none-any.whl: W002: Wheel contains duplicate files:
  tmt/steps/report/junit/templates/default.xml.j2
  tmt/steps/report/junit/templates/polarion.xml.j2
```

Pull Request Checklist

* [x] implement the feature
