### PR TITLE
  Add pending task tracking to Guest for workload monitoring

### DIFF
--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1716,6 +1716,21 @@ class Guest(
 
         return self.workdir
 
+    @property
+    def is_released(self) -> bool:
+        """
+        Check if guest was released early, safely querying the central provision step.
+
+        Returns:
+            bool: True if guest has been released and should be skipped for operations.
+                  False for active guests or when provision step is unavailable.
+        """
+        # The tmt runner guest (GuestLocal) parent is Run, not Step, so it lacks .plan
+        parent_plan = getattr(self.parent, 'plan', None)
+        if parent_plan is None:
+            return False
+        return bool(parent_plan.provision.is_guest_released(self.name))
+
     def _random_name(self, prefix: str = '', length: int = 16) -> str:
         """
         Generate a random name

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -3297,6 +3297,7 @@ class PhaseQueue(tmt.queue.Queue[Union[ActionTask, PluginTask[StepDataT, PluginR
         self.enqueue_task(PluginTask(phase, guests, phase._logger))
 
 
+@container
 class PushTask(tmt.queue.MultiGuestTask[None]):
     """
     Task performing a workdir push to a guest
@@ -3307,9 +3308,13 @@ class PushTask(tmt.queue.MultiGuestTask[None]):
         return f'push to {fmf.utils.listed(self.guest_ids)}'
 
     def run_on_guest(self, guest: 'Guest', logger: tmt.log.Logger) -> None:
+        if guest.is_released:
+            logger.debug(f"Skipping push to released guest '{guest.name}'")
+            return
         guest.push()
 
 
+@container
 class PullTask(tmt.queue.MultiGuestTask[None]):
     """
     Task performing a workdir pull from a guest
@@ -3329,6 +3334,9 @@ class PullTask(tmt.queue.MultiGuestTask[None]):
         return f'pull from {fmf.utils.listed(self.guest_ids)}'
 
     def run_on_guest(self, guest: 'Guest', logger: tmt.log.Logger) -> None:
+        if guest.is_released:
+            logger.debug(f"Skipping pull from released guest '{guest.name}'")
+            return
         guest.pull(source=self.source)
 
 

--- a/tmt/steps/cleanup/__init__.py
+++ b/tmt/steps/cleanup/__init__.py
@@ -165,6 +165,8 @@ class Cleanup(tmt.steps.Step):
         guest_copies: list[Guest] = []
 
         for guest in self.plan.provision.guests:
+            if guest.is_released:
+                continue
             # Create a guest copy and change its parent so that the
             # operations inside cleanup plugins on the guest use the
             # cleanup step config rather than provision step config.

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -157,6 +157,8 @@ class Finish(tmt.steps.Step):
             guest_copies: list[Guest] = []
 
             for guest in self.plan.provision.ready_guests:
+                if guest.is_released:
+                    continue
                 # Create a guest copy and change its parent so that the
                 # operations inside finish plugins on the guest use the
                 # finish step config rather than provision step config.

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1,4 +1,5 @@
 import functools
+import threading
 from collections.abc import Iterator
 from typing import (
     TYPE_CHECKING,
@@ -373,6 +374,19 @@ class Provision(tmt.steps.Step):
 
         self.guests = []
         self._guest_data: dict[str, tmt.guest.GuestData] = {}
+
+        # ADDED: Centralized, thread-safe tracking of released guests
+        self._released_guests: set[str] = set()
+        self._released_guests_lock = threading.Lock()
+
+    # ADDED: Helper methods for thread-safe state tracking
+    def mark_guest_released(self, guest_name: str) -> None:
+        with self._released_guests_lock:
+            self._released_guests.add(guest_name)
+
+    def is_guest_released(self, guest_name: str) -> bool:
+        with self._released_guests_lock:
+            return guest_name in self._released_guests
 
     @property
     def _preserved_workdir_members(self) -> set[str]:


### PR DESCRIPTION
       Add centralized guest release tracking and skip operations on released guests
    
      - Add is_released property to Guest class to safely check if guest was released early
      - Implement thread-safe guest release tracking in Provision step with _released_guests set
      - Skip push/pull operations on released guests to prevent errors
      - Skip cleanup and finish operations on released guests
      - Add @container decorators to PushTask and PullTask classes


Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
