### PR TITLE
Fix `TestJiraLink` unit tests failing with HTTP 503

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1666,6 +1666,8 @@ def test_invocation_terminate_process_not_running_anymore(
     )
 
 
+@unittest.mock.patch('jira.JIRA')
+@unittest.mock.patch('tmt.config.Config.fmf_tree', new_callable=unittest.mock.PropertyMock)
 class TestJiraLink(unittest.TestCase):
     def setUp(self):
         self.logger = tmt.log.Logger(actual_logger=logging.getLogger('tmt'))
@@ -1695,8 +1697,6 @@ class TestJiraLink(unittest.TestCase):
         # Cleanup the created files of tmt objects
         shutil.rmtree(self.tmp)
 
-    @unittest.mock.patch('jira.JIRA')
-    @unittest.mock.patch('tmt.config.Config.fmf_tree', new_callable=unittest.mock.PropertyMock)
     def test_jira_link_test_only(self, mock_config_tree, mock_jira) -> None:
         mock_config_tree.return_value = self.config_tree
         test = tmt.Tree(logger=self.logger, path=self.tmp).tests(names=['tmp/test'])[0]
@@ -1711,8 +1711,6 @@ class TestJiraLink(unittest.TestCase):
         assert '&test-name=%2Ftmp%2Ftest' in result['url']
         assert '&test-path=%2Ftests%2Funit%2Ftmp' in result['url']
 
-    @unittest.mock.patch('jira.JIRA')
-    @unittest.mock.patch('tmt.config.Config.fmf_tree', new_callable=unittest.mock.PropertyMock)
     def test_jira_link_test_plan_story(self, mock_config_tree, mock_jira) -> None:
         mock_config_tree.return_value = self.config_tree
         test = tmt.Tree(logger=self.logger, path=self.tmp).tests(names=['tmp/test'])[0]
@@ -1738,8 +1736,6 @@ class TestJiraLink(unittest.TestCase):
         assert '&story-name=%2Ftmp%2Fstory' in result['url']
         assert '&story-path=%2Ftests%2Funit%2Ftmp' in result['url']
 
-    @unittest.mock.patch('jira.JIRA')
-    @unittest.mock.patch('tmt.config.Config.fmf_tree', new_callable=unittest.mock.PropertyMock)
     def test_create_link_relation(self, mock_config_tree, mock_jira) -> None:
         mock_config_tree.return_value = self.config_tree
         test = tmt.Tree(logger=self.logger, path=self.tmp).tests(names=['tmp/test'])[0]


### PR DESCRIPTION
The three TestJiraLink tests were making real network requests to https://issues.redhat.com/rest/api/2/serverInfo because the jira.JIRA() constructor validates the connection on init. Only add_simple_link was mocked, so the constructor hit the live server and failed with 503.

Fix by mocking the entire jira.JIRA class instead of individual methods. This prevents the constructor from running at all, fully isolates the tests from the network, and removes the need for a separate __init__ mock.

Tests on pull request were failing :
1. https://github.com/teemtee/tmt/pull/4676
2. https://github.com/teemtee/tmt/pull/4660


