### PR TITLE
Use `ruamel.yaml.clib` as default

### DIFF
--- a/pylock.toml
+++ b/pylock.toml
@@ -1924,6 +1924,7 @@ name = "pylero"
 version = "0.1.1"
 index = "https://pypi.org/simple"
 sdist = { url = "https://files.pythonhosted.org/packages/88/38/0c0ccaafbb8594cf50af8d2376a5afee9e7279b7715a928558e7b52eb6f6/pylero-0.1.1.tar.gz", upload-time = 2025-05-30T13:38:52Z, size = 309121, hashes = { sha256 = "de0ccd37da69e50993fe403eca5d093d70c57319640d6af6403ab9a3496ae16c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/0b/79/4a7ff895325f7226f846cf4e274be9bbeedcd2d9804027c5025e72134ff4/pylero-0.1.1-py3-none-any.whl", upload-time = 2025-12-19T15:11:28Z, size = 101338, hashes = { sha256 = "ada04668e36adaaed950e213699f8442466994142c127a3f07b5e4d19fc9709f" } }]
 
 [[packages]]
 name = "python-bugzilla"
@@ -2402,7 +2403,6 @@ wheels = [{ name = "ruamel_yaml-0.18.16-py3-none-any.whl", url = "https://files.
 [[packages]]
 name = "ruamel-yaml-clib"
 version = "0.2.15"
-marker = "python_full_version < '3.14' and platform_python_implementation == 'CPython'"
 index = "https://pypi.org/simple"
 sdist = { url = "https://files.pythonhosted.org/packages/ea/97/60fda20e2fb54b83a61ae14648b0817c8f5d84a3821e40bfbdae1437026a/ruamel_yaml_clib-0.2.15.tar.gz", upload-time = 2025-11-16T16:12:59Z, size = 225794, hashes = { sha256 = "46e4cc8c43ef6a94885f72512094e482114a8a706d3c555a34ed4b0d20200600" } }
 wheels = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "pygments>=2.7.4",
     "requests>=2.25.1",
     "ruamel.yaml>=0.16.6",
+    "ruamel-yaml-clib",
     "urllib3>=1.26.5, <3.0",
     "typing-extensions>=4; python_version < '3.13'",
     ]

--- a/tests/plan/export/test.sh
+++ b/tests/plan/export/test.sh
@@ -16,11 +16,11 @@ rlJournalStart
 
     rlPhaseStartTest
         rlRun -s "tmt plan export ." 0 "Export plan"
-        rlAssertGrep "- name: /plan/basic" $rlRun_LOG
-        rlAssertGrep "- name: /plan/context" $rlRun_LOG
-        rlAssertGrep "- name: /plan/environment" $rlRun_LOG
-        rlAssertGrep "- name: /plan/gate" $rlRun_LOG
-        rlAssertGrep "- name: /plan/extra-keys" $rlRun_LOG
+        rlAssertGrep "name: /plan/basic" $rlRun_LOG
+        rlAssertGrep "name: /plan/context" $rlRun_LOG
+        rlAssertGrep "name: /plan/environment" $rlRun_LOG
+        rlAssertGrep "name: /plan/gate" $rlRun_LOG
+        rlAssertGrep "name: /plan/extra-keys" $rlRun_LOG
         rlAssertGrep "discover:" $rlRun_LOG
         rlAssertGrep "execute:" $rlRun_LOG
         assert_internal_fields "$rlRun_LOG"
@@ -28,7 +28,7 @@ rlJournalStart
 
     rlPhaseStartTest "tmt plan export /plan/basic"
         rlRun -s "tmt plan export /plan/basic" 0 "Export plan"
-        rlAssertGrep "- name: /plan/basic" $rlRun_LOG
+        rlAssertGrep "name: /plan/basic" $rlRun_LOG
         rlAssertGrep "summary: Just basic keys." $rlRun_LOG
         rlAssertGrep "discover:" $rlRun_LOG
         rlAssertGrep "execute:" $rlRun_LOG
@@ -37,7 +37,7 @@ rlJournalStart
 
     rlPhaseStartTest "tmt plan export /plan/context"
         rlRun -s "tmt --context cmd-context=value plan export /plan/context" 0 "Export plan"
-        rlAssertGrep "- name: /plan/context" $rlRun_LOG
+        rlAssertGrep "name: /plan/context" $rlRun_LOG
         rlAssertGrep "summary: Define context" $rlRun_LOG
         rlAssertGrep "discover:" $rlRun_LOG
         rlAssertGrep "execute:" $rlRun_LOG
@@ -49,7 +49,7 @@ rlJournalStart
 
     rlPhaseStartTest "tmt plan export /plan/environment"
         rlRun -s "tmt plan export /plan/environment" 0 "Export plan"
-        rlAssertGrep "- name: /plan/environment" $rlRun_LOG
+        rlAssertGrep "name: /plan/environment" $rlRun_LOG
         rlAssertGrep "summary: Define environment" $rlRun_LOG
         rlAssertGrep "discover:" $rlRun_LOG
         rlAssertGrep "execute:" $rlRun_LOG
@@ -60,7 +60,7 @@ rlJournalStart
 
     rlPhaseStartTest "tmt plan export /plan/gate"
         rlRun -s "tmt plan export /plan/gate" 0 "Export plan"
-        rlAssertGrep "- name: /plan/gate" $rlRun_LOG
+        rlAssertGrep "name: /plan/gate" $rlRun_LOG
         rlAssertGrep "summary: Define gate" $rlRun_LOG
         rlAssertGrep "discover:" $rlRun_LOG
         rlAssertGrep "execute:" $rlRun_LOG
@@ -81,7 +81,7 @@ rlJournalStart
 
     rlPhaseStartTest "tmt plan export /plan/extra-keys"
         rlRun -s "tmt plan export /plan/extra-keys" 0 "Export plan with extra- keys"
-        rlAssertGrep "- name: /plan/extra-keys" $rlRun_LOG
+        rlAssertGrep "name: /plan/extra-keys" $rlRun_LOG
         rlAssertGrep "summary: Plan with extra- keys" $rlRun_LOG
         rlAssertGrep "extra-reviewer: John Doe" $rlRun_LOG
         rlAssertGrep "extra-jira-id: TMT-123" $rlRun_LOG

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -1712,6 +1712,7 @@ class Test(
             return
 
         filename = self.fmf_sources[-1]
+        # `rt` mode is needed here to preserve comments during the `fix`, see comment in `_yaml`
         metadata: dict[str, Any] = tmt.utils.yaml_to_dict(self.read(filename), yaml_type="rt")
 
         metadata['adjust'] = tmt.convert.relevancy_to_adjust(
@@ -1812,6 +1813,7 @@ class Test(
             return
 
         filename = self.fmf_sources[-1]
+        # `rt` mode is needed here to preserve comments during the `fix`, see comment in `_yaml`
         metadata: dict[str, Any] = tmt.utils.yaml_to_dict(self.read(filename), yaml_type="rt")
 
         if not tmt.utils.is_key_origin(self.node, 'require') and all(

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -1712,12 +1712,12 @@ class Test(
             return
 
         filename = self.fmf_sources[-1]
-        metadata: dict[str, Any] = tmt.utils.yaml_to_dict(self.read(filename))
+        metadata: dict[str, Any] = tmt.utils.yaml_to_dict(self.read(filename), yaml_type="rt")
 
         metadata['adjust'] = tmt.convert.relevancy_to_adjust(
             metadata.pop('relevancy'), self._logger
         )
-        self.write(filename, to_yaml(metadata))
+        self.write(filename, to_yaml(metadata, yaml_type="rt"))
 
         yield LinterOutcome.FIXED, 'relevancy converted into adjust'
 
@@ -1812,7 +1812,7 @@ class Test(
             return
 
         filename = self.fmf_sources[-1]
-        metadata: dict[str, Any] = tmt.utils.yaml_to_dict(self.read(filename))
+        metadata: dict[str, Any] = tmt.utils.yaml_to_dict(self.read(filename), yaml_type="rt")
 
         if not tmt.utils.is_key_origin(self.node, 'require') and all(
             dependency in metadata.get('require', []) for dependency in missing_type
@@ -1832,7 +1832,7 @@ class Test(
 
             dependency['type'] = 'file' if dependency.get('pattern') else 'library'
 
-        self.write(filename, to_yaml(metadata))
+        self.write(filename, to_yaml(metadata, yaml_type="rt"))
 
         yield LinterOutcome.FIXED, 'added type to requirements'
 

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -47,7 +47,7 @@ DEFAULT_LOG_PATTERNS: list[Pattern[str]] = [
 ]
 
 
-def yaml_to_dict(data: str, yaml_type: Optional[tmt.utils.YamlTypType] = None) -> dict[str, Any]:
+def yaml_to_dict(data: str, yaml_type: tmt.utils.YamlTypType = "safe") -> dict[str, Any]:
     d: dict[str, Any] = _yaml_to_dict(data, yaml_type=yaml_type)
 
     return d

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -3522,6 +3522,8 @@ def _yaml(
     :returns: a loader/dumper instance.
     """
 
+    # We use the safe mode as default in order to use CParser from ruamel.yaml.clib
+    yaml_type = yaml_type or "safe"
     yaml = YAML(typ=yaml_type)
 
     # Setting `mapping` and `offset` may lead to a subpar-looking YAML

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -62,7 +62,6 @@ import urllib3.exceptions
 import urllib3.util.retry
 from click import echo, wrap_text
 from ruamel.yaml import YAML
-from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml.parser import ParserError
 from ruamel.yaml.representer import Representer
 from urllib3.response import HTTPResponse
@@ -3524,6 +3523,8 @@ def _yaml(
 
     # We use the safe mode as default in order to use CParser from ruamel.yaml.clib
     yaml_type = yaml_type or "safe"
+    # Note that we cannot mix yaml_type loader and dumper because roundtrip data is not
+    # serializable to safe.
     yaml = YAML(typ=yaml_type)
 
     # Setting `mapping` and `offset` may lead to a subpar-looking YAML
@@ -3594,7 +3595,9 @@ def _sanitize_yaml_tree(value: Any, sort_keys: bool) -> Any:
     if isinstance(value, MutableMapping):
         if sort_keys:
             # Sort the data https://stackoverflow.com/a/40227545
-            sorted_value = CommentedMap()
+            # TODO: This needs to be CommentedMap if using roundtrip, but it is incompatible with
+            #  safe yaml mode.
+            sorted_value = {}
 
             for key in sorted(value):
                 sorted_value[key] = value[key]

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -3503,7 +3503,7 @@ _YAML_REPRESENTERS: dict[Any, Callable[[Representer, Any], Any]] = {
 
 def _yaml(
     *,
-    yaml_type: Optional[YamlTypType] = None,
+    yaml_type: YamlTypType = "safe",
     width: Optional[int] = None,
     start: bool = False,
 ) -> YAML:
@@ -3522,7 +3522,6 @@ def _yaml(
     """
 
     # We use the safe mode as default in order to use CParser from ruamel.yaml.clib
-    yaml_type = yaml_type or "safe"
     # Note that we cannot mix yaml_type loader and dumper because roundtrip data is not
     # serializable to safe.
     yaml = YAML(typ=yaml_type)
@@ -3632,7 +3631,7 @@ def _sanitize_yaml_tree(value: Any, sort_keys: bool) -> Any:
 def to_yaml(
     data: Any,
     *,
-    yaml_type: Optional[YamlTypType] = None,
+    yaml_type: YamlTypType = "safe",
     width: Optional[int] = None,
     sort: bool = False,
     start: bool = False,
@@ -3662,7 +3661,7 @@ def to_yaml(
     return output.getvalue()
 
 
-def from_yaml(data: str, *, yaml_type: Optional[YamlTypType] = None) -> Any:
+def from_yaml(data: str, *, yaml_type: YamlTypType = "safe") -> Any:
     """
     Convert a YAML content into the corresponding Python data structures.
 
@@ -3679,7 +3678,7 @@ def from_yaml(data: str, *, yaml_type: Optional[YamlTypType] = None) -> Any:
         raise GeneralError('Invalid YAML syntax.') from error
 
 
-def yaml_to_dict(data: str, *, yaml_type: Optional[YamlTypType] = None) -> dict[Any, Any]:
+def yaml_to_dict(data: str, *, yaml_type: YamlTypType = "safe") -> dict[Any, Any]:
     """
     Convert a YAML content into a Python dictionary.
 
@@ -3705,7 +3704,7 @@ def yaml_to_dict(data: str, *, yaml_type: Optional[YamlTypType] = None) -> dict[
     return loaded_data
 
 
-def yaml_to_list(data: str, *, yaml_type: Optional[YamlTypType] = 'safe') -> list[Any]:
+def yaml_to_list(data: str, *, yaml_type: YamlTypType = 'safe') -> list[Any]:
     """
     Convert a YAML content into a Python list.
 

--- a/uv.lock
+++ b/uv.lock
@@ -2455,6 +2455,9 @@ dependencies = [
     { name = "suds" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/38/0c0ccaafbb8594cf50af8d2376a5afee9e7279b7715a928558e7b52eb6f6/pylero-0.1.1.tar.gz", hash = "sha256:de0ccd37da69e50993fe403eca5d093d70c57319640d6af6403ab9a3496ae16c", size = 309121, upload-time = "2025-05-30T13:38:52.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/79/4a7ff895325f7226f846cf4e274be9bbeedcd2d9804027c5025e72134ff4/pylero-0.1.1-py3-none-any.whl", hash = "sha256:ada04668e36adaaed950e213699f8442466994142c127a3f07b5e4d19fc9709f", size = 101338, upload-time = "2025-12-19T15:11:28.422Z" },
+]
 
 [[package]]
 name = "python-bugzilla"
@@ -3446,6 +3449,7 @@ dependencies = [
     { name = "pygments" },
     { name = "requests" },
     { name = "ruamel-yaml" },
+    { name = "ruamel-yaml-clib" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -3563,6 +3567,7 @@ requires-dist = [
     { name = "renku-sphinx-theme", marker = "extra == 'docs'" },
     { name = "requests", specifier = ">=2.25.1" },
     { name = "ruamel-yaml", specifier = ">=0.16.6" },
+    { name = "ruamel-yaml-clib" },
     { name = "setuptools", marker = "extra == 'all'", specifier = "<81" },
     { name = "setuptools", marker = "extra == 'provision-beaker'", specifier = "<81" },
     { name = "sphinx", marker = "extra == 'docs'" },


### PR DESCRIPTION
It seems the only thing we need to do to enable this is to pull in this dependency and switch to using `safe` type by default. This would be a better apple-to-apple comparison with #4486 since that one uses a C library for handling json.

Note that the clib does not respect `.indent` formatting hints

> ### Indenting using typ="safe"
>
> The C based emitter doesn’t have the fine control, distinguishing between block mappings and sequences. Do only use the pure Python versions of the dumper if you want to have that sort of control.

Reference:
- Upstream documentation: https://yaml.dev/doc/ruamel.yaml/
- Note about `yaml.indent` https://yaml.dev/doc/ruamel.yaml/detail

---

Pull Request Checklist

* [x] implement the feature
* [ ] include a release note

Related to #4406