### PR TITLE
Cache linkcheck results for the rough duration of the sprint

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -331,7 +331,7 @@ linkcheck_request_headers = {
 }
 
 # custom linkcheck cache variables
-linkcheck_cache_period = 1.0
+linkcheck_cache_period = 14.0
 
 # -- Options for sphinx_reredirects ---------------------------------------
 


### PR DESCRIPTION
Seems like we do get linkcheck failure roughly every day due to freedesktop. We could put it explicitly in the ignore list, but it recovers in the subsequent run, so would prefer not to.

On the other hand we would not be addressing these issues on a daily basis, so should be fine to check up on the state every sprint instead.
