### PR TITLE
Fix order of enabling FIPS in try

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -112,6 +112,11 @@ PHASE_ORDER_PREPARE_INSTALL_REQUIRES = 70
 PHASE_ORDER_PREPARE_INSTALL_RECOMMENDS = 75
 #: Verification of package source repositories after installation.
 PHASE_ORDER_PREPARE_VERIFY_INSTALLATION = 79
+#: Enabling FIPS mode.
+#:
+#: To prevent issues with installation of packages signed by non-FIPS-compliant algorithms
+#: FIPS should be enabled after package installation in 'try'
+TRY_PHASE_ORDER_PREPARE_FEATURE_FIPS = PHASE_ORDER_PREPARE_INSTALL_RECOMMENDS + 10
 
 # Supported steps and actions
 StepName = Literal['discover', 'provision', 'prepare', 'execute', 'report', 'finish', 'cleanup']

--- a/tmt/steps/prepare/feature/fips.py
+++ b/tmt/steps/prepare/feature/fips.py
@@ -25,6 +25,29 @@ class FipsStepData(PrepareFeatureData):
 
 @provides_feature('fips')
 class Fips(ToggleableFeature):
+    """
+    Enable FIPS mode on the guest.
+
+    Enable FIPS mode on RHEL 7, 8, 9 and 10 and CentOS Stream
+    8, 9 and 10 systems.
+
+    .. code-block:: yaml
+
+        prepare:
+            how: feature
+            fips: enabled
+
+    .. code-block:: shell
+
+        prepare --how feature --fips enabled
+
+    .. note::
+
+       In order to prevent issues with installation of packages signed by
+       non-FIPS-compliant algorithms we recommend enabling FIPS mode after
+       package installation prepare steps. Use ``order:`` to enforce that.
+    """
+
     _data_class = FipsStepData
 
     PLAYBOOKS = {'fips-enable.yaml'}

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -786,6 +786,7 @@ class Try(tmt.utils.Common):
         data = prepare_data_class(
             name="tmt-try-fips",
             how='feature',
+            order=tmt.steps.TRY_PHASE_ORDER_PREPARE_FEATURE_FIPS,
             fips="enabled",  # type: ignore[reportCallIssue,call-arg,unused-ignore]
         )
 


### PR DESCRIPTION
It is recommended to run FIPS prepare feature after all test dependencies are installed to prevent issues with packages using FIPS-incompatible digests. This only applies to `tmt try` but a note into FIPS prepare feature is added too.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
