### PR TITLE
Resolve ArtifactInfo.location overloading for verify-installation

### DIFF
--- a/tests/prepare/artifact/nvr-priority/data/tc11.fmf
+++ b/tests/prepare/artifact/nvr-priority/data/tc11.fmf
@@ -14,7 +14,6 @@ summary: TC 1.1 - Repository priority overrides package version
           script: mkdir -p /tmp/nvr-test && cp -r tc11-high tc11-low /tmp/nvr-test/
         - name: Install repo files
           how: artifact
-          verify: false
           provide:
             - repository-file:file:tc11-high.repo
             - repository-file:file:tc11-low.repo

--- a/tests/unit/artifact/test_base.py
+++ b/tests/unit/artifact/test_base.py
@@ -6,7 +6,6 @@ import pytest
 import tmt.utils
 from tmt.steps.prepare.artifact import PrepareArtifact
 from tmt.steps.prepare.artifact.providers import (
-    SHARED_REPO_NAME,
     ArtifactInfo,
     ArtifactProvider,
     Version,
@@ -24,7 +23,6 @@ class MockProvider(ArtifactProvider):
                 version=Version(name="mock", version="1.0", release="1", arch="x86_64"),
                 location="http://example.com/mock-1.0-1.x86_64.rpm",
                 provider=self,
-                repo_ids=[SHARED_REPO_NAME],
             )
         ]
 
@@ -88,7 +86,7 @@ def test_persist_artifact_metadata(tmp_path, mock_provider):
         },
         "nvra": "mock-1.0-1.x86_64",
         "location": "http://example.com/mock-1.0-1.x86_64.rpm",
-        "repo_ids": ["tmt-artifact-shared"],
+        "repo_id": "tmt-artifact-shared",
     }
     assert artifact == expected
 

--- a/tests/unit/artifact/test_base.py
+++ b/tests/unit/artifact/test_base.py
@@ -5,7 +5,12 @@ import pytest
 
 import tmt.utils
 from tmt.steps.prepare.artifact import PrepareArtifact
-from tmt.steps.prepare.artifact.providers import ArtifactInfo, ArtifactProvider, Version
+from tmt.steps.prepare.artifact.providers import (
+    SHARED_REPO_NAME,
+    ArtifactInfo,
+    ArtifactProvider,
+    Version,
+)
 
 
 class MockProvider(ArtifactProvider):
@@ -19,6 +24,7 @@ class MockProvider(ArtifactProvider):
                 version=Version(name="mock", version="1.0", release="1", arch="x86_64"),
                 location="http://example.com/mock-1.0-1.x86_64.rpm",
                 provider=self,
+                repo_ids=[SHARED_REPO_NAME],
             )
         ]
 
@@ -82,6 +88,7 @@ def test_persist_artifact_metadata(tmp_path, mock_provider):
         },
         "nvra": "mock-1.0-1.x86_64",
         "location": "http://example.com/mock-1.0-1.x86_64.rpm",
+        "repo_ids": ["tmt-artifact-shared"],
     }
     assert artifact == expected
 

--- a/tests/unit/artifact/test_copr_repository.py
+++ b/tests/unit/artifact/test_copr_repository.py
@@ -58,8 +58,12 @@ def test_enumerate_artifacts(
     mock_guest.package_manager = mock_package_manager
 
     mock_package_manager.list_packages.return_value = [
-        RpmVersion.from_nevra('tmt-1.69.0-1.fc42.noarch'),
-        RpmVersion.from_nevra('tmt-all-0:1.69.0-1.fc42.noarch'),
+        RpmVersion.from_nevra(
+            'tmt-1.69.0-1.fc42.noarch', repo_id='group_teemtee-stable-fedora-42-x86_64'
+        ),
+        RpmVersion.from_nevra(
+            'tmt-all-0:1.69.0-1.fc42.noarch', repo_id='group_teemtee-stable-fedora-42-x86_64'
+        ),
     ]
 
     provider = artifact_provider("copr.repository:@teemtee/stable")

--- a/tests/unit/artifact/test_file.py
+++ b/tests/unit/artifact/test_file.py
@@ -74,6 +74,7 @@ def test_download_artifact(tmp_path, artifact_provider):
                 "version": "5.1.8",
                 "release": "6.el9",
                 "arch": "x86_64",
+                "repo_id": None,
             },
         ),
         (
@@ -84,6 +85,7 @@ def test_download_artifact(tmp_path, artifact_provider):
                 "version": "1.61.0.dev17+gf29b2e83e",
                 "release": "1.fc41",
                 "arch": "x86_64",
+                "repo_id": None,
             },
         ),
     ],

--- a/tmt/package_managers/_rpm.py
+++ b/tmt/package_managers/_rpm.py
@@ -3,7 +3,7 @@ RPM-specific version type shared across package managers and artifact providers.
 """
 
 import re
-from typing import Any
+from typing import Any, Optional
 
 from tmt._compat.typing import Self
 from tmt.container import container
@@ -19,6 +19,9 @@ class RpmVersion(Version):
     """
     Represents an RPM package version.
     """
+
+    #: The repository section ID this package was listed from, if known.
+    repo_id: Optional[str] = None
 
     @classmethod
     def from_rpm_meta(cls, rpm_meta: dict[str, Any]) -> Self:
@@ -69,7 +72,7 @@ class RpmVersion(Version):
         return cls(name=name, version=version, release=release, arch=arch, epoch=0)
 
     @classmethod
-    def from_nevra(cls, nevra: str) -> Self:
+    def from_nevra(cls, nevra: str, repo_id: Optional[str] = None) -> Self:
         """
         Version constructed from a NEVRA string as returned by ``dnf repoquery``.
 
@@ -90,4 +93,5 @@ class RpmVersion(Version):
             version=match.group('version'),
             release=match.group('release'),
             arch=match.group('arch'),
+            repo_id=repo_id,
         )

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -192,7 +192,7 @@ class DnfEngine(PackageManagerEngine):
                 '--disablerepo=*',
                 *[f'--enablerepo={repo_id}' for repo_id in repository.repo_ids],
                 '--queryformat',
-                r'%{repoid} %{name}-%{epoch}:%{version}-%{release}.%{arch}\n',
+                r'%{repoid}\t%{name}-%{epoch}:%{version}-%{release}.%{arch}\n',
             )
         ).to_script()
 
@@ -262,7 +262,7 @@ class Dnf(PackageManager[DnfEngine]):
             line = line.strip()
             if not line:
                 continue
-            repo_id, _, nevra = line.partition(' ')
+            repo_id, nevra = line.split('\t', maxsplit=1)
             result.append(RpmVersion.from_nevra(nevra, repo_id=repo_id))
         return result
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -192,7 +192,7 @@ class DnfEngine(PackageManagerEngine):
                 '--disablerepo=*',
                 *[f'--enablerepo={repo_id}' for repo_id in repository.repo_ids],
                 '--queryformat',
-                r'%{repoid}\t%{name}-%{epoch}:%{version}-%{release}.%{arch}\n',
+                r'%{repoid};%{name}-%{epoch}:%{version}-%{release}.%{arch}\n',
             )
         ).to_script()
 
@@ -262,7 +262,7 @@ class Dnf(PackageManager[DnfEngine]):
             line = line.strip()
             if not line:
                 continue
-            repo_id, nevra = line.split('\t', maxsplit=1)
+            repo_id, nevra = line.split(';', maxsplit=1)
             result.append(RpmVersion.from_nevra(nevra, repo_id=repo_id))
         return result
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -185,12 +185,16 @@ class DnfEngine(PackageManagerEngine):
         )
 
     def list_packages(self, repository: Repository) -> ShellScript:
-        repo_ids = " ".join(f"--enablerepo={repo_id}" for repo_id in repository.repo_ids)
-        return ShellScript(
-            f"""
-            {self.command.to_script()} repoquery --disablerepo='*' {repo_ids}
-            """
-        )
+        return (
+            self.command
+            + Command(
+                'repoquery',
+                '--disablerepo=*',
+                *[f'--enablerepo={repo_id}' for repo_id in repository.repo_ids],
+                '--queryformat',
+                r'%{repoid} %{name}-%{epoch}:%{version}-%{release}.%{arch}\n',
+            )
+        ).to_script()
 
     def get_package_origin(self, packages: Iterable[str]) -> ShellScript:
         return (
@@ -253,8 +257,14 @@ class Dnf(PackageManager[DnfEngine]):
         if stdout is None:
             raise GeneralError("Repository query provided no output")
 
-        stripped_lines = (line.strip() for line in stdout.strip().splitlines())
-        return [RpmVersion.from_nevra(line) for line in stripped_lines if line]
+        result: list[Version] = []
+        for line in stdout.strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            repo_id, _, nevra = line.partition(' ')
+            result.append(RpmVersion.from_nevra(nevra, repo_id=repo_id))
+        return result
 
     def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
         try:

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -199,7 +199,6 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
 
     # Shared repository configuration
     SHARED_REPO_DIR_NAME: ClassVar[str] = 'artifact-shared-repo'
-    SHARED_REPO_NAME: ClassVar[str] = SHARED_REPO_NAME
     ARTIFACTS_METADATA_FILENAME: ClassVar[str] = 'artifacts.yaml'
 
     #: Name of the auto-injected verify-installation phase.
@@ -229,7 +228,7 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
             artifact_dir=shared_repo_dir,
             guest=guest,
             logger=logger,
-            repo_name=self.SHARED_REPO_NAME,
+            repo_name=SHARED_REPO_NAME,
             priority=self.data.default_repository_priority,
         )
 
@@ -356,18 +355,15 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
             for pkg in install_phase.data.package:  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
                 pkg_names.add(str(pkg))  # pyright: ignore[reportUnknownArgumentType]
 
-        # Build package → list of valid repo_ids mapping from all providers.
-        pkg_to_repos: dict[str, list[str]] = {}
+        # Build package → set of valid repo_ids mapping from all providers.
+        pkg_to_repos: dict[str, set[str]] = {}
         for provider in providers:
             for artifact in provider.artifacts:
-                existing = pkg_to_repos.setdefault(artifact.version.name, [])
-                existing.extend(
-                    repo_id for repo_id in artifact.repo_ids if repo_id not in existing
-                )
+                pkg_to_repos.setdefault(artifact.version.name, set()).update(artifact.repo_ids)
 
         # Only verify packages that are both required and from a known artifact.
         pkgs_to_verify = {
-            pkg: repo_ids for pkg, repo_ids in pkg_to_repos.items() if pkg in pkg_names
+            pkg: sorted(repo_ids) for pkg, repo_ids in pkg_to_repos.items() if pkg in pkg_names
         }
 
         if not pkgs_to_verify:

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -355,11 +355,11 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
             for pkg in install_phase.data.package:  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
                 pkg_names.add(str(pkg))  # pyright: ignore[reportUnknownArgumentType]
 
-        # Build package → set of valid repo_ids mapping from all providers.
+        # Build package → set of valid repo_id mapping from all providers.
         pkg_to_repos: dict[str, set[str]] = {}
         for provider in providers:
             for artifact in provider.artifacts:
-                pkg_to_repos.setdefault(artifact.version.name, set()).update(artifact.repo_ids)
+                pkg_to_repos.setdefault(artifact.version.name, set()).add(artifact.repo_id)
 
         # Only verify packages that are both required and from a known artifact.
         pkgs_to_verify = {

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -360,13 +360,15 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
         pkg_to_repos: dict[str, list[str]] = {}
         for provider in providers:
             for artifact in provider.artifacts:
-                repo_ids = artifact.repo_ids
-                pkg_name = artifact.version.name
-                existing = pkg_to_repos.setdefault(pkg_name, [])
-                existing.extend(rid for rid in repo_ids if rid not in existing)
+                existing = pkg_to_repos.setdefault(artifact.version.name, [])
+                existing.extend(
+                    repo_id for repo_id in artifact.repo_ids if repo_id not in existing
+                )
 
         # Only verify packages that are both required and from a known artifact.
-        pkgs_to_verify = {pkg: repos for pkg, repos in pkg_to_repos.items() if pkg in pkg_names}
+        pkgs_to_verify = {
+            pkg: repo_ids for pkg, repo_ids in pkg_to_repos.items() if pkg in pkg_names
+        }
 
         if not pkgs_to_verify:
             self.verbose('No packages to be installed were found in the provided artifacts.')
@@ -389,7 +391,7 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
             # Merge into existing verify phase, extending repo lists rather than replacing them.
             for verify_pkg, verify_repos in pkgs_to_verify.items():
                 existing = existing_verify.data.verify.setdefault(verify_pkg, [])  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-                existing.extend(r for r in verify_repos if r not in existing)  # pyright: ignore[reportUnknownMemberType]
+                existing.extend(repo_id for repo_id in verify_repos if repo_id not in existing)  # pyright: ignore[reportUnknownMemberType]
         else:
             # Create and add a new verify phase.
             verify_data = PrepareVerifyInstallationData(

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -355,16 +355,12 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
             for pkg in install_phase.data.package:  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
                 pkg_names.add(str(pkg))  # pyright: ignore[reportUnknownArgumentType]
 
-        # Build package → set of valid repo_id mapping from all providers.
-        pkg_to_repos: dict[str, set[str]] = {}
+        # Build package → set of valid repo_ids, filtering to only required packages.
+        pkgs_to_verify: dict[str, set[str]] = {}
         for provider in providers:
             for artifact in provider.artifacts:
-                pkg_to_repos.setdefault(artifact.version.name, set()).add(artifact.repo_id)
-
-        # Only verify packages that are both required and from a known artifact.
-        pkgs_to_verify = {
-            pkg: sorted(repo_ids) for pkg, repo_ids in pkg_to_repos.items() if pkg in pkg_names
-        }
+                if artifact.version.name in pkg_names:
+                    pkgs_to_verify.setdefault(artifact.version.name, set()).add(artifact.repo_id)
 
         if not pkgs_to_verify:
             self.verbose('No packages to be installed were found in the provided artifacts.')
@@ -396,7 +392,7 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
                 summary=self.VERIFY_PHASE_SUMMARY,
                 order=tmt.steps.PHASE_ORDER_PREPARE_VERIFY_INSTALLATION,
                 where=list(self.data.where),
-                verify=pkgs_to_verify,
+                verify={pkg: sorted(repo_ids) for pkg, repo_ids in pkgs_to_verify.items()},
             )
             verify_phase = PreparePlugin.delegate(self.step, data=verify_data)  # pyright: ignore[reportUnknownVariableType]
             self.step.add_phase(verify_phase)  # pyright: ignore[reportUnknownArgumentType]

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -12,6 +12,7 @@ from tmt.steps import PluginOutcome
 from tmt.steps.prepare import PreparePlugin, PrepareStepData
 from tmt.steps.prepare.artifact.providers import (
     _PROVIDER_REGISTRY,
+    SHARED_REPO_NAME,
     ArtifactProvider,
     Repository,
 )
@@ -198,7 +199,7 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
 
     # Shared repository configuration
     SHARED_REPO_DIR_NAME: ClassVar[str] = 'artifact-shared-repo'
-    SHARED_REPO_NAME: ClassVar[str] = 'tmt-artifact-shared'
+    SHARED_REPO_NAME: ClassVar[str] = SHARED_REPO_NAME
     ARTIFACTS_METADATA_FILENAME: ClassVar[str] = 'artifacts.yaml'
 
     #: Name of the auto-injected verify-installation phase.
@@ -355,29 +356,17 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
             for pkg in install_phase.data.package:  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
                 pkg_names.add(str(pkg))  # pyright: ignore[reportUnknownArgumentType]
 
-        # Build package → origin repo mapping from all providers.
-        # TODO: ``artifact.location`` is overloaded: a download URL for download
-        # providers and a repo name for repository providers. We use
-        # ``provider.get_repositories()`` as a proxy until ``ArtifactInfo`` gains
-        # a dedicated ``repo`` field. See https://github.com/teemtee/tmt/issues/4714.
-        pkg_to_repo: dict[str, str] = {}
+        # Build package → list of valid repo_ids mapping from all providers.
+        pkg_to_repos: dict[str, list[str]] = {}
         for provider in providers:
-            repositories = provider.get_repositories()
-            if repositories:
-                # Repository provider: collect all repo_ids from all repositories.
-                # A .repo file may declare multiple sections; any of them is a valid origin.
-                all_repo_ids = ','.join(
-                    repo_id for repo in repositories for repo_id in repo.repo_ids
-                )
-                for artifact in provider.artifacts:
-                    pkg_to_repo[artifact.version.name] = all_repo_ids
-            else:
-                # Download provider: packages land in the shared repo.
-                for artifact in provider.artifacts:
-                    pkg_to_repo[artifact.version.name] = self.SHARED_REPO_NAME
+            for artifact in provider.artifacts:
+                repo_ids = artifact.repo_ids
+                pkg_name = artifact.version.name
+                existing = pkg_to_repos.setdefault(pkg_name, [])
+                existing.extend(rid for rid in repo_ids if rid not in existing)
 
         # Only verify packages that are both required and from a known artifact.
-        pkgs_to_verify = {pkg: repo for pkg, repo in pkg_to_repo.items() if pkg in pkg_names}
+        pkgs_to_verify = {pkg: repos for pkg, repos in pkg_to_repos.items() if pkg in pkg_names}
 
         if not pkgs_to_verify:
             self.verbose('No packages to be installed were found in the provided artifacts.')
@@ -397,8 +386,10 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
         )
 
         if existing_verify is not None:
-            # Merge into existing verify phase.
-            existing_verify.data.verify.update(pkgs_to_verify)  # pyright: ignore[reportUnknownMemberType]
+            # Merge into existing verify phase, extending repo lists rather than replacing them.
+            for verify_pkg, verify_repos in pkgs_to_verify.items():
+                existing = existing_verify.data.verify.setdefault(verify_pkg, [])  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+                existing.extend(r for r in verify_repos if r not in existing)  # pyright: ignore[reportUnknownMemberType]
         else:
             # Create and add a new verify phase.
             verify_data = PrepareVerifyInstallationData(

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -23,7 +23,7 @@ NEVRA_PATTERN = re.compile(
     r'^(?P<name>.+)-(?:(?P<epoch>\d+):)?(?P<version>.+)-(?P<release>.+)\.(?P<arch>.+)$'
 )
 
-#: Name of the shared DNF repository that download providers contribute RPMs into.
+#: Name of the shared repository that download providers contribute RPMs into.
 SHARED_REPO_NAME: str = 'tmt-artifact-shared'
 
 
@@ -48,11 +48,9 @@ class ArtifactInfo:
     version: Version
     location: str
     provider: "ArtifactProvider"
-    #: DNF repo section IDs this artifact is available from.
-    #: Download providers set this to ``[ArtifactProvider.SHARED_REPO_NAME]``
-    #: since their RPMs land in the shared repo after being downloaded.
-    #: Repository providers set this to the section IDs from their ``.repo`` file.
-    repo_ids: list[str]
+    #: Repository IDs this artifact is available from. Used during verification
+    #: to confirm the artifact was installed from an expected repository.
+    repo_ids: list[str] = simple_field(default_factory=lambda: [SHARED_REPO_NAME])
 
     @property
     def id(self) -> str:

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -23,6 +23,9 @@ NEVRA_PATTERN = re.compile(
     r'^(?P<name>.+)-(?:(?P<epoch>\d+):)?(?P<version>.+)-(?P<release>.+)\.(?P<arch>.+)$'
 )
 
+#: Name of the shared DNF repository that download providers contribute RPMs into.
+SHARED_REPO_NAME: str = 'tmt-artifact-shared'
+
 
 class DownloadError(tmt.utils.GeneralError):
     """
@@ -45,6 +48,11 @@ class ArtifactInfo:
     version: Version
     location: str
     provider: "ArtifactProvider"
+    #: DNF repo section IDs this artifact is available from.
+    #: Download providers set this to ``[ArtifactProvider.SHARED_REPO_NAME]``
+    #: since their RPMs land in the shared repo after being downloaded.
+    #: Repository providers set this to the section IDs from their ``.repo`` file.
+    repo_ids: list[str]
 
     @property
     def id(self) -> str:
@@ -259,6 +267,7 @@ class ArtifactProvider(ABC):
                         version=rpm_version,
                         provider=self,
                         location=repository.name,
+                        repo_ids=list(repository.repo_ids),
                     )
                 )
             self.logger.debug(
@@ -303,6 +312,7 @@ class ArtifactProvider(ABC):
                 'version': vars(artifact.version),
                 'nvra': artifact.version.nvra,
                 'location': artifact.location,
+                'repo_ids': artifact.repo_ids,
             }
             for artifact in self.artifacts
         ]

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -50,7 +50,7 @@ class ArtifactInfo:
     provider: "ArtifactProvider"
     #: Repository ID this artifact is available from. Used during verification
     #: to confirm the artifact was installed from the expected repository.
-    repo_id: str = simple_field(default=SHARED_REPO_NAME)
+    repo_id: str = SHARED_REPO_NAME
 
     @property
     def id(self) -> str:
@@ -262,8 +262,16 @@ class ArtifactProvider(ABC):
             for rpm_version in packages:
                 from tmt.package_managers._rpm import RpmVersion
 
-                if not isinstance(rpm_version, RpmVersion) or rpm_version.repo_id is None:
-                    continue
+                if not isinstance(rpm_version, RpmVersion):
+                    raise tmt.utils.GeneralError(
+                        f"Unexpected package type '{type(rpm_version).__name__}' "
+                        f"from repository '{repository.name}'."
+                    )
+                if rpm_version.repo_id is None:
+                    raise tmt.utils.GeneralError(
+                        f"Package '{rpm_version}' from repository '{repository.name}' "
+                        f"has no repo_id."
+                    )
                 self._artifacts.append(
                     ArtifactInfo(
                         version=rpm_version,

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -48,9 +48,9 @@ class ArtifactInfo:
     version: Version
     location: str
     provider: "ArtifactProvider"
-    #: Repository IDs this artifact is available from. Used during verification
-    #: to confirm the artifact was installed from an expected repository.
-    repo_ids: list[str] = simple_field(default_factory=lambda: [SHARED_REPO_NAME])
+    #: Repository ID this artifact is available from. Used during verification
+    #: to confirm the artifact was installed from the expected repository.
+    repo_id: str = simple_field(default=SHARED_REPO_NAME)
 
     @property
     def id(self) -> str:
@@ -260,12 +260,16 @@ class ArtifactProvider(ABC):
                 )
                 continue
             for rpm_version in packages:
+                from tmt.package_managers._rpm import RpmVersion
+
+                if not isinstance(rpm_version, RpmVersion) or rpm_version.repo_id is None:
+                    continue
                 self._artifacts.append(
                     ArtifactInfo(
                         version=rpm_version,
                         provider=self,
                         location=repository.name,
-                        repo_ids=list(repository.repo_ids),
+                        repo_id=rpm_version.repo_id,
                     )
                 )
             self.logger.debug(
@@ -310,7 +314,7 @@ class ArtifactProvider(ABC):
                 'version': vars(artifact.version),
                 'nvra': artifact.version.nvra,
                 'location': artifact.location,
-                'repo_ids': artifact.repo_ids,
+                'repo_id': artifact.repo_id,
             }
             for artifact in self.artifacts
         ]

--- a/tmt/steps/prepare/artifact/providers/copr_build.py
+++ b/tmt/steps/prepare/artifact/providers/copr_build.py
@@ -16,7 +16,6 @@ from tmt.container import container, simple_field
 from tmt.guest import Guest
 from tmt.package_managers._rpm import RpmVersion
 from tmt.steps.prepare.artifact.providers import (
-    SHARED_REPO_NAME,
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
@@ -224,7 +223,6 @@ class CoprBuildArtifactProvider(ArtifactProvider):
             version=version_info,
             location=urljoin(base_url + "/", filename),
             provider=self,
-            repo_ids=[SHARED_REPO_NAME],
         )
 
     @cached_property

--- a/tmt/steps/prepare/artifact/providers/copr_build.py
+++ b/tmt/steps/prepare/artifact/providers/copr_build.py
@@ -16,6 +16,7 @@ from tmt.container import container, simple_field
 from tmt.guest import Guest
 from tmt.package_managers._rpm import RpmVersion
 from tmt.steps.prepare.artifact.providers import (
+    SHARED_REPO_NAME,
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
@@ -220,7 +221,10 @@ class CoprBuildArtifactProvider(ArtifactProvider):
             base_url = self.result_url.rstrip("/")
 
         return ArtifactInfo(
-            version=version_info, location=urljoin(base_url + "/", filename), provider=self
+            version=version_info,
+            location=urljoin(base_url + "/", filename),
+            provider=self,
+            repo_ids=[SHARED_REPO_NAME],
         )
 
     @cached_property

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -10,7 +10,6 @@ from tmt.container import container, simple_field
 from tmt.guest import Guest, TransferOptions
 from tmt.package_managers._rpm import RpmVersion
 from tmt.steps.prepare.artifact.providers import (
-    SHARED_REPO_NAME,
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
@@ -70,7 +69,6 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
             version=RpmVersion.from_filename(tmt.utils.Path(path).name),
             location=path,
             provider=self,
-            repo_ids=[SHARED_REPO_NAME],
         )
 
     @cached_property

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -10,6 +10,7 @@ from tmt.container import container, simple_field
 from tmt.guest import Guest, TransferOptions
 from tmt.package_managers._rpm import RpmVersion
 from tmt.steps.prepare.artifact.providers import (
+    SHARED_REPO_NAME,
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
@@ -69,6 +70,7 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
             version=RpmVersion.from_filename(tmt.utils.Path(path).name),
             location=path,
             provider=self,
+            repo_ids=[SHARED_REPO_NAME],
         )
 
     @cached_property

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -17,6 +17,7 @@ from tmt.container import container, simple_field
 from tmt.guest import Guest
 from tmt.package_managers._rpm import RpmVersion
 from tmt.steps.prepare.artifact.providers import (
+    SHARED_REPO_NAME,
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
@@ -227,7 +228,10 @@ class KojiArtifactProvider(ArtifactProvider):
         )
 
         return ArtifactInfo(
-            version=version_info, location=urljoin(self._top_url, path), provider=self
+            version=version_info,
+            location=urljoin(self._top_url, path),
+            provider=self,
+            repo_ids=[SHARED_REPO_NAME],
         )
 
 
@@ -269,7 +273,10 @@ class KojiTask(KojiArtifactProvider):
         url = f"{work_path}/{task_path}/{filename}"
 
         return ArtifactInfo(
-            version=RpmVersion.from_filename(filename), location=url, provider=self
+            version=RpmVersion.from_filename(filename),
+            location=url,
+            provider=self,
+            repo_ids=[SHARED_REPO_NAME],
         )
 
     @cached_property

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -17,7 +17,6 @@ from tmt.container import container, simple_field
 from tmt.guest import Guest
 from tmt.package_managers._rpm import RpmVersion
 from tmt.steps.prepare.artifact.providers import (
-    SHARED_REPO_NAME,
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
@@ -231,7 +230,6 @@ class KojiArtifactProvider(ArtifactProvider):
             version=version_info,
             location=urljoin(self._top_url, path),
             provider=self,
-            repo_ids=[SHARED_REPO_NAME],
         )
 
 
@@ -276,7 +274,6 @@ class KojiTask(KojiArtifactProvider):
             version=RpmVersion.from_filename(filename),
             location=url,
             provider=self,
-            repo_ids=[SHARED_REPO_NAME],
         )
 
     @cached_property

--- a/tmt/steps/prepare/verify_installation.py
+++ b/tmt/steps/prepare/verify_installation.py
@@ -137,7 +137,7 @@ class PrepareVerifyInstallation(PreparePlugin[PrepareVerifyInstallationData]):
                 continue
 
             failed_packages.append(package)
-            expected_repos_formatted = ' or '.join(f"'{repo_id}'" for repo_id in expected_repos)
+            expected_repos_formatted = fmf.utils.listed(expected_repos, quote="'", join='or')
             if actual_origin is SpecialPackageOrigin.NOT_INSTALLED:
                 note = (
                     f"Package '{package}': expected repo {expected_repos_formatted},"

--- a/tmt/steps/prepare/verify_installation.py
+++ b/tmt/steps/prepare/verify_installation.py
@@ -24,9 +24,9 @@ class PrepareVerifyInstallationData(PrepareStepData):
         default_factory=dict,
         help="""
             Mapping of package names to expected source repository names.
-            A package passes verification if its actual source repo matches
-            any of the listed repos (OR semantics). A single string value is
-            accepted and treated as a one-element list.
+            A package passes verification if it is installed and it was
+            installed from one of the listed repositories. A single string
+            value is accepted and treated as a one-element list.
             """,
         normalize=tmt.utils.normalize_string_list_dict,
     )
@@ -137,15 +137,16 @@ class PrepareVerifyInstallation(PreparePlugin[PrepareVerifyInstallationData]):
                 continue
 
             failed_packages.append(package)
-            expected_str = ' or '.join(f"'{r}'" for r in expected_repos)
+            expected_repos_formatted = ' or '.join(f"'{repo_id}'" for repo_id in expected_repos)
             if actual_origin is SpecialPackageOrigin.NOT_INSTALLED:
                 note = (
-                    f"Package '{package}': expected repo {expected_str},"
+                    f"Package '{package}': expected repo {expected_repos_formatted},"
                     f" but the package is not installed."
                 )
             else:
                 note = (
-                    f"Package '{package}': expected repo {expected_str}, actual '{actual_origin}'."
+                    f"Package '{package}': expected repo {expected_repos_formatted},"
+                    f" actual '{actual_origin}'."
                 )
 
             outcome.results.append(

--- a/tmt/steps/prepare/verify_installation.py
+++ b/tmt/steps/prepare/verify_installation.py
@@ -20,17 +20,15 @@ class PrepareVerifyInstallationData(PrepareStepData):
         help='Order in which the phase should be handled.',
     )
 
-    # TODO: The value type should be ``list[str]`` to allow specifying multiple
-    # acceptable source repositories for a single package (e.g. the same NVR
-    # can exist in both ``tmt-artifact-shared`` and added ``repository`` without clashing.
-    # When that change is made the comparison in ``go()`` must be updated from
-    # ``actual_origin == expected_repo`` to ``actual_origin in expected_repos``,
-    # and the semantics must be documented: a package passes verification if its
-    # actual source repo matches ANY of the listed repos (OR semantics).
-    verify: dict[str, str] = field(
+    verify: dict[str, list[str]] = field(
         default_factory=dict,
-        help="Mapping of package names to expected source repository names.",
-        normalize=tmt.utils.normalize_string_dict,
+        help="""
+            Mapping of package names to expected source repository names.
+            A package passes verification if its actual source repo matches
+            any of the listed repos (OR semantics). A single string value is
+            accepted and treated as a one-element list.
+            """,
+        normalize=tmt.utils.normalize_string_list_dict,
     )
 
 
@@ -45,12 +43,16 @@ class PrepareVerifyInstallation(PreparePlugin[PrepareVerifyInstallationData]):
 
     Packages pre-installed in a container image (or otherwise not installed
     via a repository) report an unknown source. Such packages are attributed
-    to ``<unknown>`` and can be matched with ``expected-repo: '<unknown>'``
-    in the verification mapping.
+    to ``<unknown>`` and can be matched by specifying ``'<unknown>'`` as the
+    expected repository in the verification mapping.
 
     Verification failures are recorded as ``FAIL`` results in the
     prepare phase output and cause the prepare step to fail, preventing
     test execution.
+
+    Each package may specify a single expected repository (string) or a list
+    of acceptable repositories. A package passes if its actual source matches
+    any of the listed repos.
 
     Example usage:
 
@@ -61,6 +63,9 @@ class PrepareVerifyInstallation(PreparePlugin[PrepareVerifyInstallationData]):
             verify:
                 make: tmt-artifact-shared
                 gcc: fedora
+                curl:
+                  - tmt-artifact-shared
+                  - updates
     """
 
     _data_class = PrepareVerifyInstallationData
@@ -115,10 +120,10 @@ class PrepareVerifyInstallation(PreparePlugin[PrepareVerifyInstallationData]):
             return outcome
 
         failed_packages: list[str] = []
-        for package, expected_repo in self.data.verify.items():
+        for package, expected_repos in self.data.verify.items():
             actual_origin = package_origins[package]
 
-            if actual_origin in expected_repo:
+            if actual_origin in expected_repos:
                 outcome.results.append(
                     PhaseResult(
                         name=f'{self.name} / {package}',
@@ -132,15 +137,15 @@ class PrepareVerifyInstallation(PreparePlugin[PrepareVerifyInstallationData]):
                 continue
 
             failed_packages.append(package)
+            expected_str = ' or '.join(f"'{r}'" for r in expected_repos)
             if actual_origin is SpecialPackageOrigin.NOT_INSTALLED:
                 note = (
-                    f"Package '{package}': expected repo"
-                    f" '{expected_repo}', but the package is not installed."
+                    f"Package '{package}': expected repo {expected_str},"
+                    f" but the package is not installed."
                 )
             else:
                 note = (
-                    f"Package '{package}': expected repo"
-                    f" '{expected_repo}', actual '{actual_origin}'."
+                    f"Package '{package}': expected repo {expected_str}, actual '{actual_origin}'."
                 )
 
             outcome.results.append(

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -5904,6 +5904,42 @@ def normalize_string_dict(
     )
 
 
+def normalize_string_list_dict(
+    key_address: str,
+    raw_value: Any,
+    logger: tmt.log.Logger,
+) -> dict[str, list[str]]:
+    """
+    Normalize a key/value dictionary where values are lists of strings.
+
+    Each value may be specified as a single string (coerced to a one-element
+    list) or as a list of strings.
+
+    For example, the following are acceptable inputs:
+
+    .. code-block:: python
+
+       {'foo': 'bar'}               # becomes {'foo': ['bar']}
+       {'foo': ['bar', 'baz']}      # stays as-is
+
+    :param raw_value: input value from key source.
+    """
+
+    if not isinstance(raw_value, dict):
+        raise tmt.utils.NormalizationError(
+            key_address,
+            raw_value,
+            'a dictionary mapping string keys to string values or lists of strings',
+        )
+
+    return {
+        str(k).strip(): (
+            [str(v).strip() for v in val] if isinstance(val, list) else [str(val).strip()]
+        )
+        for k, val in raw_value.items()
+    }
+
+
 def normalize_data_amount(
     key_address: str,
     raw_value: Any,

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -5933,10 +5933,10 @@ def normalize_string_list_dict(
         )
 
     return {
-        str(k).strip(): (
-            [str(v).strip() for v in val] if isinstance(val, list) else [str(val).strip()]
+        str(key).strip(): (
+            [str(v).strip() for v in value] if isinstance(value, list) else [str(value).strip()]
         )
-        for k, val in raw_value.items()
+        for key, value in raw_value.items()
     }
 
 


### PR DESCRIPTION
Add a dedicated ``repo`` field to ``ArtifactInfo`` holding the DNF repo_ids for repository providers (``None`` for download providers whose artifacts land in the shared repo). This replaces the workaround in ``_inject_verify_phase()`` that used ``provider.get_repositories()`` as a proxy and stored a comma-joined string of repo_ids, fixing the last-writer-wins bug where the same package in multiple providers would silently drop all but one valid source repo.

The ``verify`` field in ``PrepareVerifyInstallationData`` is changed from ``dict[str, str]`` to ``dict[str, list[str]]`` so that a package can be expected from any of multiple repos (OR semantics). A new ``normalize_string_list_dict`` normalizer coerces single string values to one-element lists, keeping existing fmf plans working without changes.

The ``verify: false`` workaround in the nvr-priority TC 1.1 test is removed as it is no longer needed.

Closes: https://github.com/teemtee/tmt/issues/4714

Assisted-by: Claude
