### PR TITLE
Implement the `sprint-sync` script

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -855,6 +855,38 @@ prioritized issues.
 .. _backlog: https://github.com/orgs/teemtee/projects/1/views/1
 
 
+Sync
+------------------------------------------------------------------
+
+The ``scripts/sprint-overview`` script lists all issues and pull
+requests in a GitHub Project sprint together with their story
+points. It can also output the data in YAML format for further
+processing:
+
+  .. code-block:: bash
+
+     ./scripts/sprint-overview --sprint 'Sprint 11'
+     ./scripts/sprint-overview --sprint 'Sprint 11' --yaml
+
+The ``scripts/sprint-sync`` script synchronizes a Jira sprint
+with GitHub sprint items. It reads the YAML output from
+``sprint-overview``, removes Jira items not present in the
+GitHub sprint and adds missing items into the Jira sprint:
+
+  .. code-block:: bash
+
+     ./scripts/sprint-overview --sprint 'Sprint 11' --yaml \
+         | ./scripts/sprint-sync --sprint 'Sprint 11'
+
+Use ``--dry`` to preview changes without modifying the Jira
+sprint:
+
+  .. code-block:: bash
+
+     ./scripts/sprint-overview --sprint 'Sprint 11' --yaml \
+         | ./scripts/sprint-sync --sprint 'Sprint 11' --dry
+
+
 Release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,0 +1,26 @@
+"""
+Common data structures shared between sprint scripts.
+"""
+
+import dataclasses
+from typing import Optional
+
+
+@dataclasses.dataclass
+class Item:
+    """
+    A sprint item (issue or pull request).
+    """
+
+    id: int
+    type: str
+    repo: str
+    status: str
+    size: Optional[int]
+    url: str
+    title: str
+
+    def __str__(self) -> str:
+        size_str = f"[{self.size}]" if self.size is not None else "[-]"
+        identifier = f"{self.repo}#{self.id}"
+        return f"{identifier:<10} {size_str:>4}  {self.title}"

--- a/scripts/sprint-overview
+++ b/scripts/sprint-overview
@@ -24,6 +24,7 @@ from typing import Any, Optional
 import click
 import jinja2
 import requests
+from common import Item
 from ruamel.yaml import YAML
 
 # https://docs.github.com/en/rest/about-the-rest-api/breaking-changes
@@ -73,26 +74,6 @@ DISPLAY_TEMPLATE = jinja2.Template(
 ================================================================================
 """,
 )
-
-
-@dataclasses.dataclass
-class Item:
-    """
-    A sprint item (issue or pull request).
-    """
-
-    id: int
-    type: str
-    repo: str
-    status: str
-    size: Optional[int]
-    url: str
-    title: str
-
-    def __str__(self) -> str:
-        size_str = f"[{self.size}]" if self.size is not None else "[-]"
-        identifier = f"{self.repo}#{self.id}"
-        return f"{identifier:<10} {size_str:>4}  {self.title}"
 
 
 def github_api_get(

--- a/scripts/sprint-overview
+++ b/scripts/sprint-overview
@@ -235,14 +235,14 @@ def main(sprint: str, output_yaml: bool) -> None:
     """
     items = fetch_sprint_items(sprint)
 
-    if not items:
-        click.echo(f"No items found in sprint '{sprint}'.")
-        return
-
     if output_yaml:
         YAML().dump([dataclasses.asdict(item) for item in items], sys.stdout)
-    else:
+        return
+
+    if items:
         display_items(sprint, items)
+    else:
+        click.echo(f"No items found in sprint '{sprint}'.", err=True)
 
 
 if __name__ == "__main__":

--- a/scripts/sprint-overview
+++ b/scripts/sprint-overview
@@ -24,8 +24,9 @@ from typing import Any, Optional
 import click
 import jinja2
 import requests
-from common import Item
 from ruamel.yaml import YAML
+
+from common import Item  # isort: skip
 
 # https://docs.github.com/en/rest/about-the-rest-api/breaking-changes
 GITHUB_API_URL = "https://api.github.com"

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -1,0 +1,309 @@
+#!/usr/bin/python3
+#
+# /// script
+# dependencies = [
+#   "click",
+#   "jinja2",
+#   "jira",
+#   "ruamel.yaml",
+# ]
+# ///
+
+"""
+Sync a Jira sprint with GitHub sprint items.
+"""
+
+import os
+import re
+import sys
+from typing import Optional, cast
+
+import click
+import jinja2
+from common import Item
+from jira import JIRA
+from jira.resources import Issue
+from ruamel.yaml import YAML
+
+ITEM_TEMPLATE = jinja2.Template(
+    source="""\
+  {{ key      }}   {{ summary }}
+  {{ decision }}   {{ url }}
+{% if duplicates %}\
+             duplicates found: {{ duplicates }}
+{% endif %}"""
+)
+
+DECISION_COLORS = {
+    "keep": "blue",
+    "add ": "green",
+    "drop": "red",
+    "miss": "yellow",
+}
+
+JIRA_SERVER = "https://redhat.atlassian.net/"
+JIRA_PROJECT = "TMT"
+JIRA_BOARD_ID = 1411
+
+
+def connect_to_jira() -> JIRA:
+    """
+    Connect to Jira using environment variables for authentication.
+
+    :returns: an authenticated :py:class:`JIRA` client.
+    """
+
+    server = os.environ.get("JIRA_SERVER", JIRA_SERVER)
+    email = os.environ.get("JIRA_EMAIL")
+    token = os.environ.get("JIRA_TOKEN")
+
+    if not email:
+        click.echo("Error: JIRA_EMAIL environment variable is not set.")
+        sys.exit(1)
+
+    if not token:
+        click.echo("Error: JIRA_TOKEN environment variable is not set.")
+        sys.exit(1)
+
+    return JIRA(server=server, basic_auth=(email, token))
+
+
+def fetch_jira_items(jira: JIRA, sprint_name: str) -> list[Issue]:
+    """
+    Fetch all items from the given sprint.
+
+    :param jira: authenticated Jira client.
+    :param sprint_name: name of the sprint.
+    :returns: list of Jira items
+    """
+
+    query = f'sprint = "{sprint_name}" ORDER BY key ASC'
+    items = cast(list[Issue], jira.search_issues(query, maxResults=False))
+    click.echo(f"Fetched {len(items)} items.\n")
+
+    return items
+
+
+def load_github_items(path: Optional[str] = None) -> list[Item]:
+    """
+    Load GitHub sprint items in sprint-overview --yaml format.
+
+    :param path: path to the YAML file, or ``None`` to read from stdin.
+    :returns: a list of :py:class:`Item` instances.
+    """
+
+    if path:
+        with open(path) as f:
+            data = YAML().load(f)
+    else:
+        data = YAML().load(sys.stdin)
+
+    if not data:
+        return []
+
+    return [Item(**item) for item in data]
+
+
+def get_upstream_url(jira: JIRA, issue: Issue) -> Optional[str]:
+    """
+    Get the "Upstream issue" remote link URL for a Jira issue.
+
+    :param jira: authenticated Jira client.
+    :param issue: a Jira issue object.
+    :returns: the upstream URL, or ``None`` if not found.
+    """
+
+    for link in jira.remote_links(issue):
+        if link.object.title == "Upstream issue":
+            return link.object.url
+
+    return None
+
+
+def find_sprint_id(jira: JIRA, sprint_name: str) -> Optional[int]:
+    """
+    Find the sprint ID by name on the TMT board.
+
+    :param jira: authenticated Jira client.
+    :param sprint_name: name of the sprint.
+    :returns: the sprint ID, or ``None`` if not found.
+    """
+
+    for sprint in jira.sprints(JIRA_BOARD_ID):
+        if sprint.name == sprint_name:
+            return sprint.id
+
+    return None
+
+
+def find_jira_issue(
+    jira: JIRA,
+    github_item: Item,
+) -> tuple[Optional[Issue], Optional[str]]:
+    """
+    Find a Jira issue that has a remote link matching the given GitHub item.
+
+    First searches by remote link URL, then falls back to title search.
+
+    :param jira: authenticated Jira client.
+    :param github_item: the GitHub :py:class:`Item` to search for.
+    :returns: a tuple of the matching Jira issue (or ``None``) and
+        a comma-separated string of duplicate keys (or ``None``).
+    """
+
+    def pick_item(results: list[Issue]) -> tuple[Optional[Issue], Optional[str]]:
+        """
+        Pick the oldest item, identify duplicates
+        """
+
+        if not results:
+            return None, None
+
+        duplicates = None
+        if len(results) > 1:
+            duplicates = ", ".join(result.key for result in results)
+
+        return min(results, key=lambda result: int(result.key.split("-")[-1])), duplicates
+
+    # Search by remote link URL (works only if already indexed)
+    query = f'project = "{JIRA_PROJECT}" AND remoteLinkUrl in ("{github_item.url}")'
+    results = cast(list[Issue], jira.search_issues(query, maxResults=False))
+    if results:
+        return pick_item(results)
+
+    # Fall back to title search and verify via remote links
+    title = github_item.title.replace('"', '')
+    query = f'project = "{JIRA_PROJECT}" AND summary ~ "{title}"'
+    candidates = cast(list[Issue], jira.search_issues(query, maxResults=False))
+
+    matched = [
+        candidate
+        for candidate in candidates
+        if get_upstream_url(jira, candidate) == github_item.url
+    ]
+    return pick_item(matched)
+
+
+def sync_sprint(
+    jira: JIRA,
+    sprint_id: int,
+    jira_items: list[Issue],
+    github_items: list[Item],
+    dry: bool = False,
+) -> None:
+    """
+    Sync Jira sprint with GitHub sprint items.
+
+    Removes Jira issues not present in the GitHub sprint and adds
+    missing GitHub items into the Jira sprint.
+
+    :param jira: authenticated Jira client.
+    :param sprint_id: ID of the sprint.
+    :param jira_items: list of Jira issues currently in the sprint.
+    :param github_items: list of GitHub :py:class:`Item` instances.
+    :param dry: if ``True``, only show what would be done without
+        making any changes.
+    """
+
+    github_items_by_url = {item.url: item for item in github_items}
+    github_urls = set(github_items_by_url.keys())
+    matched_urls: set[str] = set()
+
+    def show_item(
+        key: str,
+        decision: str,
+        summary: str,
+        url: Optional[str] = None,
+        duplicates: Optional[str] = None,
+    ) -> None:
+        """
+        Render a single item, color decisions, remove prefix
+        """
+
+        click.echo(
+            ITEM_TEMPLATE.render(
+                key=f"{key:<8}",
+                decision=click.style(f"{decision:<8}", fg=DECISION_COLORS.get(decision)),
+                summary=re.sub(r'^\[teemtee/[^\]]*\]\s*', '', summary),
+                url=url,
+                duplicates=duplicates,
+            )
+        )
+
+    # Step 1: Check existing Jira items — keep or remove
+    for jira_item in jira_items:
+        url = get_upstream_url(jira, jira_item)
+
+        if url and url in github_urls:
+            matched_urls.add(url)
+            show_item(jira_item.key, "keep", jira_item.fields.summary, url)
+        else:
+            show_item(jira_item.key, "drop", jira_item.fields.summary, url)
+            if not dry:
+                jira.move_to_backlog([jira_item.key])
+
+    # Step 2: Add missing GitHub items
+    missing_urls = github_urls - matched_urls
+    if not missing_urls:
+        return
+
+    for url in missing_urls:
+        github_item = github_items_by_url[url]
+        jira_item, duplicates = find_jira_issue(jira, github_item)
+
+        if jira_item:
+            show_item(jira_item.key, "add ", jira_item.fields.summary, url, duplicates)
+            if not dry:
+                jira.add_issues_to_sprint(sprint_id, [jira_item.key])
+        else:
+            show_item("???", "miss", github_item.title, url)
+
+
+@click.command()
+@click.option(
+    "--sprint",
+    metavar="NAME",
+    required=True,
+    help="Name of the sprint, e.g. 'TMT Sprint 11'.",
+)
+@click.option(
+    "--dry",
+    is_flag=True,
+    default=False,
+    help="Only show what would be done without making any changes.",
+)
+@click.argument("yaml_file", required=False, default=None)
+def main(sprint: str, dry: bool, yaml_file: Optional[str]) -> None:
+    """
+    Sync a Jira sprint with GitHub sprint items.
+
+    Reads GitHub sprint items in YAML format (from sprint-overview --yaml)
+    from YAML_FILE or stdin. Example usage:
+
+    \b
+        ./sprint-overview --sprint 'Sprint 11' --yaml | ./sprint-sync --sprint 'TMT Sprint 11'
+
+    Authentication is configured via environment variables:
+
+    \b
+        JIRA_SERVER ... Jira server URL, https://redhat.atlassian.net/ by default
+        JIRA_EMAIL .... User email for authentication
+        JIRA_TOKEN .... Personal access token
+    """
+
+    click.echo(f"\nSyncing sprint: {sprint}{' (dry mode)' if dry else ''}")
+
+    jira = connect_to_jira()
+
+    sprint_id = find_sprint_id(jira, sprint)
+    if not sprint_id:
+        click.echo(f"Error: sprint '{sprint}' not found.")
+        sys.exit(1)
+
+    github_items = load_github_items(yaml_file)
+    jira_items = fetch_jira_items(jira, sprint)
+    sync_sprint(jira, sprint_id, jira_items, github_items, dry=dry)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -117,7 +117,7 @@ def get_upstream_url(jira: JIRA, issue: Issue) -> Optional[str]:
     return None
 
 
-def find_sprint_id(jira: JIRA, sprint_name: str) -> Optional[int]:
+def find_sprint_id(jira: JIRA, sprint_name: str) -> int:
     """
     Find the sprint ID by name on the TMT board.
 
@@ -130,7 +130,8 @@ def find_sprint_id(jira: JIRA, sprint_name: str) -> Optional[int]:
         if sprint.name == sprint_name:
             return sprint.id
 
-    return None
+    click.echo(f"Sprint '{sprint_name}' not found.")
+    sys.exit(1)
 
 
 def find_jira_issue(
@@ -299,10 +300,6 @@ def main(sprint: str, dry: bool, yaml_file: IO[str]) -> None:
     jira = connect_to_jira()
 
     sprint_id = find_sprint_id(jira, sprint)
-    if not sprint_id:
-        click.echo(f"Error: sprint '{sprint}' not found.")
-        sys.exit(1)
-
     github_items = load_github_items(yaml_file)
     jira_items = fetch_jira_items(jira, sprint)
     sync_sprint(jira, sprint_id, jira_items, github_items, dry=dry)

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -275,7 +275,7 @@ def main(sprint: str, dry: bool, yaml_file: IO[str]) -> None:
     from YAML_FILE or stdin. Example usage:
 
     \b
-        ./sprint-overview --sprint 'Sprint 11' --yaml | ./sprint-sync --sprint 'TMT Sprint 11'
+        ./sprint-overview --sprint 'Sprint 11' --yaml | ./sprint-sync --sprint 'Sprint 11'
 
     Authentication is configured via environment variables:
 
@@ -287,11 +287,14 @@ def main(sprint: str, dry: bool, yaml_file: IO[str]) -> None:
 
     click.echo(f"\nSyncing sprint: {sprint}{' (dry mode)' if dry else ''}")
 
+    # Sprint names in Jira are prefixed with 'TMT'
+    sprint_name = f"TMT {sprint}"
+
     jira = connect_to_jira()
 
-    sprint_id = find_sprint_id(jira, sprint)
+    sprint_id = find_sprint_id(jira, sprint_name)
     github_items = load_github_items(yaml_file)
-    jira_items = fetch_jira_items(jira, sprint)
+    jira_items = fetch_jira_items(jira, sprint_name)
     sync_sprint(jira, sprint_id, jira_items, github_items, dry=dry)
 
 

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -26,26 +26,61 @@ from ruamel.yaml import YAML
 
 from common import Item  # isort: skip
 
-ITEM_TEMPLATE = jinja2.Template(
-    source="""\
+JIRA_SERVER = "https://redhat.atlassian.net/"
+JIRA_PROJECT = "TMT"
+JIRA_BOARD_ID = 1411
+
+
+class SyncItem:
+    """
+    Represents a sync decision for a single item.
+    """
+
+    TEMPLATE = jinja2.Template(
+        source="""\
   {{ key      }}   {{ summary }}
   {{ decision }}   {{ url }}
 {% if duplicates %}\
              duplicates found: {{ duplicates | join(", ") }}
 {% endif %}"""
-)
+    )
 
-DECISION_COLORS = {
-    "keep": "blue",
-    "add ": "green",
-    "drop": "red",
-    "lost": "red",
-    "miss": "yellow",
-}
+    COLORS = {
+        "keep": "blue",
+        "add ": "green",
+        "drop": "red",
+        "lost": "red",
+        "miss": "yellow",
+    }
 
-JIRA_SERVER = "https://redhat.atlassian.net/"
-JIRA_PROJECT = "TMT"
-JIRA_BOARD_ID = 1411
+    def __init__(
+        self,
+        key: str,
+        decision: str,
+        summary: str,
+        url: Optional[str] = None,
+        duplicates: Optional[list[str]] = None,
+    ) -> None:
+        self.key = key
+        self.decision = decision
+        self.summary = re.sub(r'^\[teemtee/[^\]]*\]\s*', '', summary)
+        self.url = url
+        self.duplicates = duplicates
+
+    def show(self) -> None:
+        """
+        Render the item, color decisions
+        """
+
+        click.echo(
+            self.TEMPLATE.render(
+                key=f"{self.key:<8}",
+                decision=click.style(f"{self.decision:<8}", fg=self.COLORS.get(self.decision)),
+                summary=self.summary,
+                url=self.url or "Upstream issue not found.",
+                duplicates=self.duplicates,
+            )
+        )
 
 
 def connect_to_jira() -> JIRA:
@@ -200,27 +235,6 @@ def sync_sprint(
     github_items_by_url = {item.url: item for item in github_items}
     urls_to_process = set(github_items_by_url.keys())
 
-    def show_item(
-        key: str,
-        decision: str,
-        summary: str,
-        url: Optional[str] = None,
-        duplicates: Optional[list[str]] = None,
-    ) -> None:
-        """
-        Render a single item, color decisions, remove prefix
-        """
-
-        click.echo(
-            ITEM_TEMPLATE.render(
-                key=f"{key:<8}",
-                decision=click.style(f"{decision:<8}", fg=DECISION_COLORS.get(decision)),
-                summary=re.sub(r'^\[teemtee/[^\]]*\]\s*', '', summary),
-                url=url,
-                duplicates=duplicates,
-            )
-        )
-
     items_to_drop: list[str] = []
     items_to_add: list[str] = []
 
@@ -229,12 +243,12 @@ def sync_sprint(
         url = get_upstream_url(jira, jira_item)
 
         if not url:
-            show_item(jira_item.key, "lost", jira_item.fields.summary, "Upstream issue not found.")
+            SyncItem(jira_item.key, "lost", jira_item.fields.summary).show()
         elif url in urls_to_process:
             urls_to_process.remove(url)
-            show_item(jira_item.key, "keep", jira_item.fields.summary, url)
+            SyncItem(jira_item.key, "keep", jira_item.fields.summary, url).show()
         else:
-            show_item(jira_item.key, "drop", jira_item.fields.summary, url)
+            SyncItem(jira_item.key, "drop", jira_item.fields.summary, url).show()
             items_to_drop.append(jira_item.key)
 
     # Step 2: Find missing GitHub items
@@ -245,10 +259,10 @@ def sync_sprint(
         if jira_issues:
             jira_item = jira_issues[0]
             duplicates = [issue.key for issue in jira_issues[1:]] or None
-            show_item(jira_item.key, "add ", jira_item.fields.summary, url, duplicates)
+            SyncItem(jira_item.key, "add ", jira_item.fields.summary, url, duplicates).show()
             items_to_add.append(jira_item.key)
         else:
-            show_item("???", "miss", github_item.title, url)
+            SyncItem("???", "miss", github_item.title, url).show()
 
     # Step 3: Apply changes
     if not dry:

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -292,7 +292,7 @@ def main(sprint: str, dry: bool, yaml_file: IO[str]) -> None:
         JIRA_TOKEN .... Personal access token
     """
 
-    click.echo(f"\nSyncing sprint: {sprint}{' (dry mode)' if dry else ''}")
+    click.echo(f"Syncing sprint: {sprint}{' (dry mode)' if dry else ''}")
 
     # Sprint names in Jira are prefixed with 'TMT'
     sprint_name = f"TMT {sprint}"

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -172,7 +172,7 @@ def find_jira_issue(
         return pick_item(results)
 
     # Fall back to title search and verify via remote links
-    title = github_item.title.replace('"', '')
+    title = github_item.title.replace('\\', '\\\\').replace("'", "\\'").replace('"', '')
     query = f'project = "{JIRA_PROJECT}" AND summary ~ "{title}"'
     candidates = cast(list[Issue], jira.search_issues(query, maxResults=False))
 

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -39,6 +39,7 @@ DECISION_COLORS = {
     "keep": "blue",
     "add ": "green",
     "drop": "red",
+    "lost": "red",
     "miss": "yellow",
 }
 
@@ -225,7 +226,9 @@ def sync_sprint(
     for jira_item in jira_items:
         url = get_upstream_url(jira, jira_item)
 
-        if url and url in urls_to_process:
+        if not url:
+            show_item(jira_item.key, "lost", jira_item.fields.summary, "Upstream issue not found.")
+        elif url in urls_to_process:
             urls_to_process.remove(url)
             show_item(jira_item.key, "keep", jira_item.fields.summary, url)
         else:

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -154,7 +154,8 @@ def find_jira_issues(
     def sort_by_key(results: list[Issue]) -> list[Issue]:
         return sorted(results, key=lambda result: int(result.key.split("-")[-1]))
 
-    # Search by remote link URL (works only if already indexed)
+    # Search by remote link URL (this works only if already indexed, and
+    # rebuilding the index can take several days when restarted again)
     query = f'project = "{JIRA_PROJECT}" AND remoteLinkUrl in ("{github_item.url}")'
     results = jira.search_issues(query, maxResults=False, json_result=False)
     assert isinstance(results, list)

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -134,40 +134,28 @@ def find_sprint_id(jira: JIRA, sprint_name: str) -> int:
     sys.exit(1)
 
 
-def find_jira_issue(
+def find_jira_issues(
     jira: JIRA,
     github_item: Item,
-) -> tuple[Optional[Issue], Optional[list[str]]]:
+) -> list[Issue]:
     """
-    Find a Jira issue that has a remote link matching the given GitHub item.
+    Find Jira issues that have a remote link matching the given GitHub item.
 
     First searches by remote link URL, then falls back to title search.
 
     :param jira: authenticated Jira client.
     :param github_item: the GitHub :py:class:`Item` to search for.
-    :returns: a tuple of the matching Jira issue (or ``None``) and
-        a list of duplicate keys (or ``None``).
+    :returns: a list of matching Jira issues sorted by key (lowest first).
     """
 
-    def pick_item(results: list[Issue]) -> tuple[Optional[Issue], Optional[list[str]]]:
-        """
-        Pick the oldest item, identify duplicates
-        """
-
-        if not results:
-            return None, None
-
-        duplicates = None
-        if len(results) > 1:
-            duplicates = [result.key for result in results]
-
-        return min(results, key=lambda result: int(result.key.split("-")[-1])), duplicates
+    def sort_by_key(results: list[Issue]) -> list[Issue]:
+        return sorted(results, key=lambda result: int(result.key.split("-")[-1]))
 
     # Search by remote link URL (works only if already indexed)
     query = f'project = "{JIRA_PROJECT}" AND remoteLinkUrl in ("{github_item.url}")'
     results = cast(list[Issue], jira.search_issues(query, maxResults=False))
     if results:
-        return pick_item(results)
+        return sort_by_key(results)
 
     # Fall back to title search and verify via remote links
     title = github_item.title.replace('\\', '\\\\').replace("'", "\\'").replace('"', '')
@@ -179,7 +167,7 @@ def find_jira_issue(
         for candidate in candidates
         if get_upstream_url(jira, candidate) == github_item.url
     ]
-    return pick_item(matched)
+    return sort_by_key(matched)
 
 
 def sync_sprint(
@@ -247,9 +235,11 @@ def sync_sprint(
 
     for url in missing_urls:
         github_item = github_items_by_url[url]
-        jira_item, duplicates = find_jira_issue(jira, github_item)
+        jira_issues = find_jira_issues(jira, github_item)
 
-        if jira_item:
+        if jira_issues:
+            jira_item = jira_issues[0]
+            duplicates = [issue.key for issue in jira_issues[1:]] or None
             show_item(jira_item.key, "add ", jira_item.fields.summary, url, duplicates)
             items_to_add.append(jira_item.key)
         else:

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -272,10 +272,14 @@ def sync_sprint(
 @click.argument("yaml_file", default="-", type=click.File())
 def main(sprint: str, dry: bool, yaml_file: IO[str]) -> None:
     """
-    Sync a Jira sprint with GitHub sprint items.
+    Sync a Jira sprint items with GitHub sprint items.
 
     Reads GitHub sprint items in YAML format (from sprint-overview --yaml)
-    from YAML_FILE or stdin. Example usage:
+    from YAML_FILE or stdin and synchronizes them with the Jira sprint.
+    Removed items are dropped, new items are added, no status changes
+    are performed.
+
+    Example usage:
 
     \b
         ./sprint-overview --sprint 'Sprint 11' --yaml | ./sprint-sync --sprint 'Sprint 11'

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -16,7 +16,7 @@ Sync a Jira sprint with GitHub sprint items.
 import os
 import re
 import sys
-from typing import IO, Optional, cast
+from typing import IO, Optional
 
 import click
 import jinja2
@@ -79,7 +79,8 @@ def fetch_jira_items(jira: JIRA, sprint_name: str) -> list[Issue]:
     """
 
     query = f'sprint = "{sprint_name}" ORDER BY key ASC'
-    items = cast(list[Issue], jira.search_issues(query, maxResults=False))
+    items = jira.search_issues(query, maxResults=False, json_result=False)
+    assert isinstance(items, list)
     click.echo(f"Fetched {len(items)} items.\n")
 
     return items
@@ -153,14 +154,16 @@ def find_jira_issues(
 
     # Search by remote link URL (works only if already indexed)
     query = f'project = "{JIRA_PROJECT}" AND remoteLinkUrl in ("{github_item.url}")'
-    results = cast(list[Issue], jira.search_issues(query, maxResults=False))
+    results = jira.search_issues(query, maxResults=False, json_result=False)
+    assert isinstance(results, list)
     if results:
         return sort_by_key(results)
 
     # Fall back to title search and verify via remote links
     title = github_item.title.replace('\\', '\\\\').replace("'", "\\'").replace('"', '')
     query = f'project = "{JIRA_PROJECT}" AND summary ~ "{title}"'
-    candidates = cast(list[Issue], jira.search_issues(query, maxResults=False))
+    candidates = jira.search_issues(query, maxResults=False, json_result=False)
+    assert isinstance(candidates, list)
 
     matched = [
         candidate

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -230,6 +230,9 @@ def sync_sprint(
             )
         )
 
+    items_to_drop: list[str] = []
+    items_to_add: list[str] = []
+
     # Step 1: Check existing Jira items — keep or remove
     for jira_item in jira_items:
         url = get_upstream_url(jira, jira_item)
@@ -239,13 +242,10 @@ def sync_sprint(
             show_item(jira_item.key, "keep", jira_item.fields.summary, url)
         else:
             show_item(jira_item.key, "drop", jira_item.fields.summary, url)
-            if not dry:
-                jira.move_to_backlog([jira_item.key])
+            items_to_drop.append(jira_item.key)
 
-    # Step 2: Add missing GitHub items
+    # Step 2: Find missing GitHub items
     missing_urls = github_urls - matched_urls
-    if not missing_urls:
-        return
 
     for url in missing_urls:
         github_item = github_items_by_url[url]
@@ -253,10 +253,16 @@ def sync_sprint(
 
         if jira_item:
             show_item(jira_item.key, "add ", jira_item.fields.summary, url, duplicates)
-            if not dry:
-                jira.add_issues_to_sprint(sprint_id, [jira_item.key])
+            items_to_add.append(jira_item.key)
         else:
             show_item("???", "miss", github_item.title, url)
+
+    # Step 3: Apply changes
+    if not dry:
+        if items_to_drop:
+            jira.move_to_backlog(items_to_drop)
+        if items_to_add:
+            jira.add_issues_to_sprint(sprint_id, items_to_add)
 
 
 @click.command()

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -90,7 +90,7 @@ def load_github_items(source: IO[str]) -> list[Item]:
     Load GitHub sprint items in sprint-overview --yaml format.
 
     :param source: a file-like object to read YAML from.
-    :returns: a list of :py:class:`Item` instances.
+    :returns: a list of sprint items
     """
 
     data = YAML().load(source)
@@ -198,7 +198,7 @@ def sync_sprint(
     :param jira: authenticated Jira client.
     :param sprint_id: ID of the sprint.
     :param jira_items: list of Jira issues currently in the sprint.
-    :param github_items: list of GitHub :py:class:`Item` instances.
+    :param github_items: list of GitHub project sprint items.
     :param dry: if ``True``, only show what would be done without
         making any changes.
     """

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -95,11 +95,11 @@ def connect_to_jira() -> JIRA:
     token = os.environ.get("JIRA_TOKEN")
 
     if not email:
-        click.echo("Error: JIRA_EMAIL environment variable is not set.")
+        click.echo("Error: JIRA_EMAIL environment variable is not set.", err=True)
         sys.exit(1)
 
     if not token:
-        click.echo("Error: JIRA_TOKEN environment variable is not set.")
+        click.echo("Error: JIRA_TOKEN environment variable is not set.", err=True)
         sys.exit(1)
 
     return JIRA(server=server, basic_auth=(email, token))
@@ -133,7 +133,7 @@ def load_github_items(source: IO[str]) -> list[Item]:
     data = YAML().load(source)
 
     if not isinstance(data, list):
-        click.echo(f"Invalid input data:\n{data}")
+        click.echo(f"Invalid input data:\n{data}", err=True)
         sys.exit(1)
 
     return [Item(**item) for item in cast(list[dict[str, Any]], data)]
@@ -161,14 +161,14 @@ def find_sprint_id(jira: JIRA, sprint_name: str) -> int:
 
     :param jira: authenticated Jira client.
     :param sprint_name: name of the sprint.
-    :returns: the sprint ID, or ``None`` if not found.
+    :returns: the sprint ID, or gives an error if not found.
     """
 
     for sprint in jira.sprints(JIRA_BOARD_ID):
         if sprint.name == sprint_name:
             return sprint.id
 
-    click.echo(f"Sprint '{sprint_name}' not found.")
+    click.echo(f"Sprint '{sprint_name}' not found.", err=True)
     sys.exit(1)
 
 
@@ -252,7 +252,7 @@ def sync_sprint(
             items_to_drop.append(jira_item.key)
 
     # Step 2: Find missing GitHub items
-    for url in urls_to_process:
+    for url in sorted(urls_to_process):
         github_item = github_items_by_url[url]
         jira_issues = find_jira_issues(jira, github_item)
 

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -20,10 +20,11 @@ from typing import IO, Optional, cast
 
 import click
 import jinja2
-from common import Item
 from jira import JIRA
 from jira.resources import Issue
 from ruamel.yaml import YAML
+
+from common import Item  # isort: skip
 
 ITEM_TEMPLATE = jinja2.Template(
     source="""\

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -16,7 +16,7 @@ Sync a Jira sprint with GitHub sprint items.
 import os
 import re
 import sys
-from typing import IO, Optional
+from typing import IO, Any, Optional, cast
 
 import click
 import jinja2
@@ -97,10 +97,11 @@ def load_github_items(source: IO[str]) -> list[Item]:
 
     data = YAML().load(source)
 
-    if not data:
-        return []
+    if not isinstance(data, list):
+        click.echo(f"Invalid input data:\n{data}")
+        sys.exit(1)
 
-    return [Item(**item) for item in data]
+    return [Item(**item) for item in cast(list[dict[str, Any]], data)]
 
 
 def get_upstream_url(jira: JIRA, issue: Issue) -> Optional[str]:

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -16,7 +16,7 @@ Sync a Jira sprint with GitHub sprint items.
 import os
 import re
 import sys
-from typing import Optional, cast
+from typing import IO, Optional, cast
 
 import click
 import jinja2
@@ -84,19 +84,15 @@ def fetch_jira_items(jira: JIRA, sprint_name: str) -> list[Issue]:
     return items
 
 
-def load_github_items(path: Optional[str] = None) -> list[Item]:
+def load_github_items(source: IO[str]) -> list[Item]:
     """
     Load GitHub sprint items in sprint-overview --yaml format.
 
-    :param path: path to the YAML file, or ``None`` to read from stdin.
+    :param source: a file-like object to read YAML from.
     :returns: a list of :py:class:`Item` instances.
     """
 
-    if path:
-        with open(path) as f:
-            data = YAML().load(f)
-    else:
-        data = YAML().load(sys.stdin)
+    data = YAML().load(source)
 
     if not data:
         return []
@@ -278,8 +274,8 @@ def sync_sprint(
     default=False,
     help="Only show what would be done without making any changes.",
 )
-@click.argument("yaml_file", required=False, default=None)
-def main(sprint: str, dry: bool, yaml_file: Optional[str]) -> None:
+@click.argument("yaml_file", default="-", type=click.File())
+def main(sprint: str, dry: bool, yaml_file: IO[str]) -> None:
     """
     Sync a Jira sprint with GitHub sprint items.
 

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -31,7 +31,7 @@ ITEM_TEMPLATE = jinja2.Template(
   {{ key      }}   {{ summary }}
   {{ decision }}   {{ url }}
 {% if duplicates %}\
-             duplicates found: {{ duplicates }}
+             duplicates found: {{ duplicates | join(", ") }}
 {% endif %}"""
 )
 
@@ -137,7 +137,7 @@ def find_sprint_id(jira: JIRA, sprint_name: str) -> int:
 def find_jira_issue(
     jira: JIRA,
     github_item: Item,
-) -> tuple[Optional[Issue], Optional[str]]:
+) -> tuple[Optional[Issue], Optional[list[str]]]:
     """
     Find a Jira issue that has a remote link matching the given GitHub item.
 
@@ -146,10 +146,10 @@ def find_jira_issue(
     :param jira: authenticated Jira client.
     :param github_item: the GitHub :py:class:`Item` to search for.
     :returns: a tuple of the matching Jira issue (or ``None``) and
-        a comma-separated string of duplicate keys (or ``None``).
+        a list of duplicate keys (or ``None``).
     """
 
-    def pick_item(results: list[Issue]) -> tuple[Optional[Issue], Optional[str]]:
+    def pick_item(results: list[Issue]) -> tuple[Optional[Issue], Optional[list[str]]]:
         """
         Pick the oldest item, identify duplicates
         """
@@ -159,7 +159,7 @@ def find_jira_issue(
 
         duplicates = None
         if len(results) > 1:
-            duplicates = ", ".join(result.key for result in results)
+            duplicates = [result.key for result in results]
 
         return min(results, key=lambda result: int(result.key.split("-")[-1])), duplicates
 
@@ -212,7 +212,7 @@ def sync_sprint(
         decision: str,
         summary: str,
         url: Optional[str] = None,
-        duplicates: Optional[str] = None,
+        duplicates: Optional[list[str]] = None,
     ) -> None:
         """
         Render a single item, color decisions, remove prefix

--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -192,8 +192,7 @@ def sync_sprint(
     """
 
     github_items_by_url = {item.url: item for item in github_items}
-    github_urls = set(github_items_by_url.keys())
-    matched_urls: set[str] = set()
+    urls_to_process = set(github_items_by_url.keys())
 
     def show_item(
         key: str,
@@ -223,17 +222,15 @@ def sync_sprint(
     for jira_item in jira_items:
         url = get_upstream_url(jira, jira_item)
 
-        if url and url in github_urls:
-            matched_urls.add(url)
+        if url and url in urls_to_process:
+            urls_to_process.remove(url)
             show_item(jira_item.key, "keep", jira_item.fields.summary, url)
         else:
             show_item(jira_item.key, "drop", jira_item.fields.summary, url)
             items_to_drop.append(jira_item.key)
 
     # Step 2: Find missing GitHub items
-    missing_urls = github_urls - matched_urls
-
-    for url in missing_urls:
+    for url in urls_to_process:
         github_item = github_items_by_url[url]
         jira_issues = find_jira_issues(jira, github_item)
 


### PR DESCRIPTION
Implement an easy way to sync github sprint items into the Jira sprint. Removed items are dropped, new items are added. Search for the right Jira issue is done using `remoteLinkUrl` but since it does not work always (e.g. when the index it outdated) fallback using the summary is included. Duplicate issues, when detected during the search, are reported as well.

Fix #4671.

Assisted-by: Claude

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation