### PR TITLE
Document the `podman` tag in the contribution docs

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -291,6 +291,12 @@ beakerlib
 integration
     Test using `requre`__ to mock connections to other servers.
 
+podman
+    Integration tests which are used as reverse dependency tests
+    for ``podman`` and related components. Test code should not
+    contain any distribution specific setup to work across Fedora,
+    CentOS Stream and RHEL.
+
 __ https://github.com/beakerlib/beakerlib
 __ https://requre.readthedocs.io/en/latest/
 

--- a/plans/friends/podman.fmf
+++ b/plans/friends/podman.fmf
@@ -14,10 +14,13 @@ discover:
       - check: avc
 
 prepare:
-    name: enable-epel
+  - name: enable-epel
     how: feature
     epel: enabled
     order: 20
+  - name: latest-packages
+    how: shell
+    script: dnf update -y
 
 link:
   - relates: https://github.com/containers/container-selinux

--- a/plans/friends/podman.fmf
+++ b/plans/friends/podman.fmf
@@ -14,13 +14,14 @@ discover:
       - check: avc
 
 prepare:
+  - name: latest-packages
+    how: shell
+    script: dnf update -y
+    order: 10
   - name: enable-epel
     how: feature
     epel: enabled
     order: 20
-  - name: latest-packages
-    how: shell
-    script: dnf update -y
 
 link:
   - relates: https://github.com/containers/container-selinux

--- a/plans/friends/podman.fmf
+++ b/plans/friends/podman.fmf
@@ -14,11 +14,7 @@ discover:
       - check: avc
 
 prepare:
-  - name: latest-packages
-    how: shell
-    script: dnf update -y
-    order: 10
-  - name: enable-epel
+    name: enable-epel
     how: feature
     epel: enabled
     order: 20


### PR DESCRIPTION
Tests marked with the `podman` tag are used for integration testing with `podman` and related components. Explicitly document the expectations for these tests.

* https://github.com/containers/podman/pull/28555