### PR TITLE
Fix recipe generation when execute script is provided

### DIFF
--- a/tests/recipe/data/minimal.yaml
+++ b/tests/recipe/data/minimal.yaml
@@ -1,0 +1,101 @@
+plans:
+- cleanup:
+    enabled: true
+    phases:
+    - how: tmt
+      name: default-0
+      order: 50
+  discover:
+    enabled: true
+    phases:
+    - dist-git-download-only: false
+      dist-git-install-builddeps: false
+      dist-git-source: false
+      how: shell
+      keep-git-metadata: false
+      name: default-0
+      order: 50
+      tests:
+      - duration: 1h
+        enabled: true
+        manual: false
+        name: script-00
+        order: 50
+        result: respect
+        test: echo "Execute script"
+        tty: false
+      url-content-type: git
+    tests:
+    - discover-phase: default-0
+      duration: 1h
+      enabled: true
+      framework: shell
+      manual: false
+      name: /script-00
+      order: 50
+      path: /default-0/tests
+      restart-max-count: 1
+      restart-with-reboot: false
+      result: respect
+      serial-number: 1
+      test: echo "Execute script"
+      tty: false
+  enabled: true
+  environment:
+    PLAN_ENV: plan_value
+  execute:
+    enabled: true
+    phases:
+    - duration: 1h
+      exit-first: false
+      how: tmt
+      ignore-duration: false
+      interactive: false
+      name: default-0
+      no-progress-bar: false
+      order: 50
+      restraint-compatible: false
+    results-path: plans/minimal/execute/results.yaml
+  finish:
+    enabled: true
+    phases:
+    - how: shell
+      name: default-0
+      order: 50
+  name: /plans/minimal
+  order: 50
+  prepare:
+    enabled: true
+    phases:
+    - how: shell
+      name: default-0
+      order: 50
+  provision:
+    enabled: true
+    phases:
+    - become: false
+      environment:
+        PROVISION_ENV: provision_value
+      force-pull: false
+      how: container
+      image: fedora
+      name: default-0
+      order: 50
+      pull-attempts: 5
+      pull-interval: 5
+      stop-time: 1
+      user: root
+  report:
+    enabled: true
+    phases:
+    - display-guest: auto
+      how: display
+      name: default-0
+      order: 50
+  summary: A minimal plan
+run:
+  context: {}
+  environment:
+    RUN_ENV: run_value
+  remove: false
+  root: /path/to/fmf_root

--- a/tests/recipe/data/plans.fmf
+++ b/tests/recipe/data/plans.fmf
@@ -51,3 +51,9 @@ environment:
         import:
             url: https://github.com/teemtee/tests
             name: /plans/remote
+
+/minimal:
+    summary: A minimal plan
+    execute:
+        how: tmt
+        script: echo "Execute script"

--- a/tests/recipe/generate.sh
+++ b/tests/recipe/generate.sh
@@ -14,7 +14,7 @@ rlJournalStart
         mv "$temp_recipe" "$recipe"
     }
 
-    for plan_name in 'local' 'remote'; do
+    for plan_name in 'local' 'remote' 'minimal'; do
         rlPhaseStartTest "Test recipe generation of a $plan_name plan"
             rlRun -s "tmt -vv run --scratch --id $run -e RUN_ENV=run_value plan -n /plans/$plan_name"
             rlAssertExists "$recipe" "Recipe file exists"

--- a/tests/recipe/load.sh
+++ b/tests/recipe/load.sh
@@ -46,6 +46,14 @@ rlJournalStart
         rlAssertGrep "summary: 2 tests selected" $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest "Test recipe loading of minimal plan"
+        replace_fmf_root "minimal.yaml"
+        rlRun -s "tmt run -vvv --scratch --id $run --recipe minimal.yaml"
+        rlAssertGrep "summary: 1 test selected" $rlRun_LOG
+        rlAssertGrep "total: 1 test passed" $rlRun_LOG
+        rlAssertGrep "Execute script" $rlRun_LOG
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $run" 0 "Remove run directory"

--- a/tmt/recipe.py
+++ b/tmt/recipe.py
@@ -365,9 +365,23 @@ class _RecipeExecuteStep(_RecipeStep):
     @classmethod
     def from_step(cls, step: 'Step') -> '_RecipeExecuteStep':
         enabled = bool(step.enabled)
+
+        # The 'script' field is consumed by _discover_from_execute() to create
+        # tests in the discover step. Keeping it in the recipe would cause
+        # a conflict during recipe loading.
+        phases = cast(
+            list[_RawStepData],
+            [
+                {key: value for key, value in phase.to_minimal_spec().items() if key != 'script'}
+                for phase in step.data
+            ]
+            if enabled
+            else [],
+        )
+
         return _RecipeExecuteStep(
             enabled=enabled,
-            phases=[phase.to_minimal_spec() for phase in step.data] if enabled else [],
+            phases=phases,
             results_path=(step.step_workdir / 'results.yaml').relative_to(step.run_workdir),
         )
 


### PR DESCRIPTION
When the execute phase had a `script` defined, the generated recipe included both the execute script and a newly created discover phase with the same script. This caused a loading error because the recipe defined both a discover phase and a script in the execute phase.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
